### PR TITLE
Make it easier to get the global logger

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -159,7 +159,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
   typeormEntities: Function[] = [];
   drizzleEntities: { [key: string]: object } = {};
 
-
   eventReceivers: DBOSEventReceiver[] = [];
 
   /* WORKFLOW EXECUTOR LIFE CYCLE MANAGEMENT */

--- a/src/dbos-runtime/runtime.ts
+++ b/src/dbos-runtime/runtime.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 import { Server } from 'http';
 import { pathToFileURL } from 'url';
 import { DBOSScheduler } from '../scheduler/scheduler';
+import { GlobalLogger } from '../telemetry/logs';
 
 interface ModuleExports {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -19,6 +20,11 @@ export interface DBOSRuntimeConfig {
 }
 export const defaultEntryPoint = "dist/operations.js";
 
+export class DBOS {
+  static globalLogger?: GlobalLogger;
+  static dbosConfig?: DBOSConfig;
+}
+
 export class DBOSRuntime {
   private dbosConfig: DBOSConfig;
   private dbosExec: DBOSExecutor | null = null;
@@ -28,6 +34,7 @@ export class DBOSRuntime {
   constructor(dbosConfig: DBOSConfig, private readonly runtimeConfig: DBOSRuntimeConfig) {
     // Initialize workflow executor.
     this.dbosConfig = dbosConfig;
+    DBOS.dbosConfig = dbosConfig;
   }
 
   /**
@@ -36,6 +43,7 @@ export class DBOSRuntime {
   async initAndStart() {
     try {
       this.dbosExec = new DBOSExecutor(this.dbosConfig);
+      DBOS.globalLogger = this.dbosExec.logger;
       this.dbosExec.logger.debug(`Loading classes from entrypoints ${JSON.stringify(this.runtimeConfig.entrypoints)}`);
       await DBOSRuntime.loadClasses(this.runtimeConfig.entrypoints);
       await this.dbosExec.init();

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,7 @@ export {
 
 export {
   DBOSRuntimeConfig,
+  DBOS,
 } from "./dbos-runtime/runtime";
 
 export {

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -17,6 +17,7 @@ import { get, set } from "lodash";
 import { Client } from "pg";
 import { DBOSScheduler } from "../scheduler/scheduler";
 import { StoredProcedure } from "../procedure";
+import { DBOS } from "../dbos-runtime/runtime";
 
 /**
  * Create a testing runtime. Warn: this function will drop the existing system DB and create a clean new one. Don't run tests against your production database!
@@ -98,7 +99,9 @@ export class TestingRuntimeImpl implements TestingRuntime {
    */
   async init(userClasses?: object[], testConfig?: DBOSConfig, systemDB?: SystemDatabase) {
     const dbosConfig = testConfig ? [testConfig] : parseConfigFile();
+    DBOS.dbosConfig = dbosConfig[0];
     const dbosExec = new DBOSExecutor(dbosConfig[0], systemDB);
+    DBOS.globalLogger = dbosExec.logger;
     await dbosExec.init(userClasses);
     this.#server = new DBOSHttpServer(dbosExec);
     for (const evtRcvr of dbosExec.eventReceivers) {

--- a/tests/httpServer/classdec.test.ts
+++ b/tests/httpServer/classdec.test.ts
@@ -8,6 +8,7 @@ import {
   TransactionContext,
   WorkflowContext,
   TestingRuntime,
+  DBOS,
 } from "../../src";
 import { TestKvTable, generateDBOSTestConfig, setUpDBOSTestDb } from "../helpers";
 import request from "supertest";
@@ -133,6 +134,7 @@ describe("httpserver-defsec-tests", () => {
   let middlewareCounterG = 0;
   const testMiddlewareG: Middleware = async (ctx, next) => {
     middlewareCounterG = middlewareCounterG + 1;
+    expect(DBOS.globalLogger).toBeDefined();
     await next();
   };
 


### PR DESCRIPTION
Export a global logger, so that your middleware can do something like this:

```
// Logging middleware
const logAllRequests = () => {
    return async (ctx: Koa.Context, next: Koa.Next) => {
        const start = Date.now();

        // Log the request method and URL
        DBOS.globalLogger?.info(`[Request] ${ctx.method} ${ctx.url}`);

        let ok = false;
        try {
            await next();
            ok = true;
        }
        finally {
            const ms = Date.now() - start;
            if (ok) {
                // Log the response status and time taken
                DBOS.globalLogger?.info(`[Response] ${ctx.method} ${ctx.url} - ${ctx.status} - ${ms}ms`);
            }
            else {
                // Log error response
                DBOS.globalLogger?.warn(`[Exception] ${ctx.method} ${ctx.url} - ${ctx.status} - ${ms}ms`);
            }
        }
        
    };
};

@KoaGlobalMiddleware(logAllRequests)
```