### PR TITLE
Allow use of "Step" instead of "Communicator"

### DIFF
--- a/packages/communicator-bcrypt/README.md
+++ b/packages/communicator-bcrypt/README.md
@@ -1,8 +1,8 @@
-# DBOS `bcrypt` Communicator
+# DBOS `bcrypt` Step
 
-This is a [DBOS](https://docs.dbos.dev/) [communicator](https://docs.dbos.dev/tutorials/communicator-tutorial) for generating bcrypt hashes.
+This is a [DBOS](https://docs.dbos.dev/) [step](https://docs.dbos.dev/tutorials/communicator-tutorial) for generating bcrypt hashes.
 
-The reason that some `bcrypt` operations should be wrapped in a communicator is that they generate random numbers.  By using a communicator, replayed or restarted workflows will get the recorded value and therefore have the same behavior as the original.
+The reason that some `bcrypt` operations should be wrapped in a `@Step` is that they generate random numbers.  By using a step, replayed or restarted workflows will get the recorded value and therefore have the same behavior as the original.
 
 ## Available Functions
 

--- a/packages/communicator-bcrypt/index.ts
+++ b/packages/communicator-bcrypt/index.ts
@@ -1,19 +1,19 @@
 
-import {Step, StepContext} from '@dbos-inc/dbos-sdk';
+import {Communicator, CommunicatorContext} from '@dbos-inc/dbos-sdk';
 
 import bcryptjs from 'bcryptjs';
 
 
 class BcryptCommunicator
 {
-    @Step()
-    static async bcryptGenSalt(_ctx: StepContext, saltRounds: number = 10) : Promise<string>
+    @Communicator()
+    static async bcryptGenSalt(_ctx: CommunicatorContext, saltRounds: number = 10) : Promise<string>
     {
         return await bcryptjs.genSalt(saltRounds);
     }
 
-    @Step()
-    static async bcryptHash(_ctx: StepContext, txt: string, saltRounds: number = 10) : Promise<string> {
+    @Communicator()
+    static async bcryptHash(_ctx: CommunicatorContext, txt: string, saltRounds: number = 10) : Promise<string> {
         return await bcryptjs.hash(txt, saltRounds);
     }
 

--- a/packages/communicator-bcrypt/index.ts
+++ b/packages/communicator-bcrypt/index.ts
@@ -25,5 +25,6 @@ class BcryptCommunicator
 
 export
 {
-    BcryptCommunicator
+    BcryptCommunicator,
+    BcryptCommunicator as BcryptStep,
 }

--- a/packages/communicator-bcrypt/index.ts
+++ b/packages/communicator-bcrypt/index.ts
@@ -1,19 +1,19 @@
 
-import {Communicator, CommunicatorContext} from '@dbos-inc/dbos-sdk';
+import {Step, StepContext} from '@dbos-inc/dbos-sdk';
 
 import bcryptjs from 'bcryptjs';
 
 
 class BcryptCommunicator
 {
-    @Communicator()
-    static async bcryptGenSalt(_ctx: CommunicatorContext, saltRounds: number = 10) : Promise<string>
+    @Step()
+    static async bcryptGenSalt(_ctx: StepContext, saltRounds: number = 10) : Promise<string>
     {
         return await bcryptjs.genSalt(saltRounds);
     }
 
-    @Communicator()
-    static async bcryptHash(_ctx: CommunicatorContext, txt: string, saltRounds: number = 10) : Promise<string> {
+    @Step()
+    static async bcryptHash(_ctx: StepContext, txt: string, saltRounds: number = 10) : Promise<string> {
         return await bcryptjs.hash(txt, saltRounds);
     }
 

--- a/packages/communicator-datetime/README.md
+++ b/packages/communicator-datetime/README.md
@@ -1,8 +1,8 @@
-# DBOS Date/Time Communicator
+# DBOS Date/Time Step
 
-This is a [DBOS](https://docs.dbos.dev/) [communicator](https://docs.dbos.dev/tutorials/communicator-tutorial) for getting the current date / time.
+This is a [DBOS](https://docs.dbos.dev/) [step](https://docs.dbos.dev/tutorials/communicator-tutorial) for getting the current date / time.
 
-The reason that date retrieval should be wrapped in a communicator is so that replayed workflows get the recorded value and therefore have the same behavior as the original.
+The reason that date retrieval should be wrapped in a `@Step` is so that replayed workflows get the recorded value and therefore have the same behavior as the original.
 
 ## Available Functions
 

--- a/packages/communicator-datetime/index.ts
+++ b/packages/communicator-datetime/index.ts
@@ -16,5 +16,6 @@ class CurrentTimeCommunicator
 
 export
 {
-    CurrentTimeCommunicator
+    CurrentTimeCommunicator,
+    CurrentTimeCommunicator as CurrentTimeStep,
 }

--- a/packages/communicator-email-ses/index.ts
+++ b/packages/communicator-email-ses/index.ts
@@ -163,5 +163,6 @@ class SendEmailCommunicator extends ConfiguredInstance
 }
 
 export {
-    SendEmailCommunicator
+    SendEmailCommunicator,
+    SendEmailCommunicator as SendEmailStep,
 }

--- a/packages/communicator-random/README.md
+++ b/packages/communicator-random/README.md
@@ -1,8 +1,8 @@
 # DBOS Random Communicator
 
-This is a [DBOS](https://docs.dbos.dev/) [communicator](https://docs.dbos.dev/tutorials/communicator-tutorial) for generating random numbers.
+This is a [DBOS](https://docs.dbos.dev/) [step](https://docs.dbos.dev/tutorials/communicator-tutorial) for generating random numbers.
 
-The reason that random number generation should be wrapped in a communicator is so that replayed workflows get the recorded value and therefore have the same behavior as the original.
+The reason that random number generation should be wrapped in a `@Step` is so that replayed workflows get the recorded value and therefore have the same behavior as the original.
 
 ## Available Functions
 

--- a/packages/communicator-random/index.ts
+++ b/packages/communicator-random/index.ts
@@ -11,5 +11,6 @@ class RandomCommunicator
 
 export
 {
-    RandomCommunicator
+    RandomCommunicator,
+    RandomCommunicator as RandomStep,
 }

--- a/packages/dbos-compiler/compiler.ts
+++ b/packages/dbos-compiler/compiler.ts
@@ -298,7 +298,7 @@ function treeShake(project: tsm.Project) {
 
   removeUnusedFiles(project);
 
-  // delete all workflow/communicator/init/handler methods
+  // delete all workflow/step/init/handler methods
   for (const file of project.getSourceFiles()) {
     shakeFile(file);
   }
@@ -425,7 +425,7 @@ function getDbosDecoratorKind(node: tsm.Decorator | DecoratorInfo): DbosDecorato
 export function getDbosMethodKind(node: tsm.MethodDeclaration): DbosDecoratorKind | undefined {
   // Note, other DBOS method decorators (Scheduled, KafkaConsume, RequiredRole) modify runtime behavior
   //       of DBOS methods, but are not their own unique kind.
-  //       Get/PostApi decorators are atypical in that they can be used on @Communicator/@Transaction/@Workflow
+  //       Get/PostApi decorators are atypical in that they can be used on @Step/@Transaction/@Workflow
   //       methods as well as on their own.
   let isHandler = false;
   for (const decorator of node.getDecorators()) {

--- a/packages/dbos-sqs/index.ts
+++ b/packages/dbos-sqs/index.ts
@@ -275,6 +275,7 @@ function SQSMessageConsumer(config?: SQSConfig) {
 export {
     SQSConfig,
     SQSCommunicator,
+    SQSCommunicator as SQSStep,
     SQSConfigure,
     SQSMessageConsumer,
     SQSReceiver,

--- a/src/communicator.ts
+++ b/src/communicator.ts
@@ -4,8 +4,7 @@ import { WorkflowContextImpl } from "./workflow";
 import { DBOSContext, DBOSContextImpl } from "./context";
 import { WorkflowContextDebug } from "./debugger/debug_workflow";
 
-export type Communicator<T extends unknown[], R> = (ctxt: CommunicatorContext, ...args: T) => Promise<R>;
-export type CommunicatorFunction<T extends unknown[], R> = Communicator<T, R>;
+export type CommunicatorFunction<T extends unknown[], R> = (ctxt: CommunicatorContext, ...args: T) => Promise<R>;
 
 export interface CommunicatorConfig {
   retriesAllowed?: boolean; // Should failures be retried? (default true)

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -80,8 +80,8 @@ interface TransactionInfo {
   config: TransactionConfig;
 }
 
-interface CommunicatorInfo {
-  communicator: StepFunction<unknown[], unknown>;
+interface StepInfo {
+  step: StepFunction<unknown[], unknown>;
   config: StepConfig;
 }
 
@@ -136,7 +136,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
     ],
   ]);
   readonly transactionInfoMap: Map<string, TransactionInfo> = new Map();
-  readonly communicatorInfoMap: Map<string, CommunicatorInfo> = new Map();
+  readonly stepInfoMap: Map<string, StepInfo> = new Map();
   readonly procedureInfoMap: Map<string, ProcedureInfo> = new Map();
   readonly registeredOperations: Array<MethodRegistrationBase> = [];
   readonly pendingWorkflowMap: Map<string, Promise<unknown>> = new Map(); // Map from workflowUUID to workflow promise
@@ -301,7 +301,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
       } else if (ro.txnConfig) {
         this.#registerTransaction(ro);
       } else if (ro.commConfig) {
-        this.#registerCommunicator(ro);
+        this.#registerStep(ro);
       } else if (ro.procConfig) {
         this.#registerProcedure(ro);
       }
@@ -508,18 +508,18 @@ export class DBOSExecutor implements DBOSExecutorContext {
     this.logger.debug(`Registered transaction ${tfn}`);
   }
 
-  #registerCommunicator(ro: MethodRegistrationBase) {
+  #registerStep(ro: MethodRegistrationBase) {
     const comm = ro.registeredFunction as StepFunction<unknown[], unknown>;
     const cfn = ro.className + '.' + ro.name;
-    if (this.communicatorInfoMap.has(cfn)) {
+    if (this.stepInfoMap.has(cfn)) {
       throw new DBOSError(`Repeated Commmunicator name: ${cfn}`);
     }
-    const commInfo: CommunicatorInfo = {
-      communicator: comm,
+    const commInfo: StepInfo = {
+      step: comm,
       config: {...ro.commConfig},
     };
-    this.communicatorInfoMap.set(cfn, commInfo);
-    this.logger.debug(`Registered communicator ${cfn}`);
+    this.stepInfoMap.set(cfn, commInfo);
+    this.logger.debug(`Registered step ${cfn}`);
   }
 
   #registerProcedure(ro: MethodRegistrationBase) {
@@ -586,19 +586,19 @@ export class DBOSExecutor implements DBOSExecutorContext {
     return {txnInfo, clsInst: getConfiguredInstance(className, cfgName)};
   }
 
-  getCommunicatorInfo(cf: StepFunction<unknown[], unknown>) {
+  getStepInfo(cf: StepFunction<unknown[], unknown>) {
     const cfname = getRegisteredMethodClassName(cf) + '.' + cf.name;
-    return this.communicatorInfoMap.get(cfname);
+    return this.stepInfoMap.get(cfname);
   }
-  getCommunicatorInfoByNames(className: string, functionName: string, cfgName: string) {
+  getStepInfoByNames(className: string, functionName: string, cfgName: string) {
     const cfname = className + '.' + functionName;
-    let commInfo: CommunicatorInfo | undefined = this.communicatorInfoMap.get(cfname);
+    let commInfo: StepInfo | undefined = this.stepInfoMap.get(cfname);
 
     if (!commInfo && !className) {
-      for (const [_wfn, cfr] of this.communicatorInfoMap) {
-        if (functionName === cfr.communicator.name) {
+      for (const [_wfn, cfr] of this.stepInfoMap) {
+        if (functionName === cfr.step.name) {
           if (commInfo) {
-            throw new DBOSError(`Recovered communicator function name '${functionName}' is ambiguous.  The ambiguous name was recently added; remove it and recover pending workflows before re-adding the new function.`);
+            throw new DBOSError(`Recovered step function name '${functionName}' is ambiguous.  The ambiguous name was recently added; remove it and recover pending workflows before re-adding the new function.`);
           }
           else {
             commInfo = cfr;
@@ -947,17 +947,17 @@ export class DBOSExecutor implements DBOSExecutorContext {
       };
       clsinst = clsInst;
     } else if (nameArr[1] === TempWorkflowType.external) {
-      const {commInfo, clsInst} = this.getCommunicatorInfoByNames(wfStatus.workflowClassName, nameArr[2], wfStatus.workflowConfigName);
+      const {commInfo, clsInst} = this.getStepInfoByNames(wfStatus.workflowClassName, nameArr[2], wfStatus.workflowConfigName);
       if (!commInfo) {
-        this.logger.error(`Cannot find communicator info for UUID ${workflowUUID}, name ${nameArr[2]}`);
+        this.logger.error(`Cannot find step info for UUID ${workflowUUID}, name ${nameArr[2]}`);
         throw new DBOSNotRegisteredError(nameArr[2]);
       }
       tempWfType = TempWorkflowType.external;
-      tempWfName = getRegisteredMethodName(commInfo.communicator);
-      tempWfClass = getRegisteredMethodClassName(commInfo.communicator);
+      tempWfName = getRegisteredMethodName(commInfo.step);
+      tempWfClass = getRegisteredMethodClassName(commInfo.step);
       temp_workflow = async (ctxt: WorkflowContext, ...args: unknown[]) => {
         const ctxtImpl = ctxt as WorkflowContextImpl;
-        return await ctxtImpl.external(commInfo.communicator, clsInst, ...args);
+        return await ctxtImpl.external(commInfo.step, clsInst, ...args);
       };
       clsinst = clsInst;
     } else if (nameArr[1] === TempWorkflowType.send) {

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -831,17 +831,17 @@ export class DBOSExecutor implements DBOSExecutorContext {
     }
   }
 
-  async external<T extends unknown[], R>(commFn: StepFunction<T, R>, params: WorkflowParams, ...args: T): Promise<R> {
+  async external<T extends unknown[], R>(stepFn: StepFunction<T, R>, params: WorkflowParams, ...args: T): Promise<R> {
     // Create a workflow and call external.
     const temp_workflow = async (ctxt: WorkflowContext, ...args: T) => {
       const ctxtImpl = ctxt as WorkflowContextImpl;
-      return await ctxtImpl.external(commFn, params.configuredInstance ?? null, ...args);
+      return await ctxtImpl.external(stepFn, params.configuredInstance ?? null, ...args);
     };
     return (await this.workflow(temp_workflow, {
       ...params,
       tempWfType: TempWorkflowType.external,
-      tempWfName: getRegisteredMethodName(commFn),
-      tempWfClass: getRegisteredMethodClassName(commFn),
+      tempWfName: getRegisteredMethodName(stepFn),
+      tempWfClass: getRegisteredMethodClassName(stepFn),
     }, ...args)).getResult();
   }
 

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -15,7 +15,7 @@ import {
 } from './workflow';
 
 import { IsolationLevel, Transaction, TransactionConfig } from './transaction';
-import { CommunicatorConfig, Communicator } from './communicator';
+import { CommunicatorConfig, CommunicatorFunction } from './communicator';
 import { TelemetryCollector } from './telemetry/collector';
 import { Tracer } from './telemetry/traces';
 import { GlobalLogger as Logger } from './telemetry/logs';
@@ -81,7 +81,7 @@ interface TransactionInfo {
 }
 
 interface CommunicatorInfo {
-  communicator: Communicator<unknown[], unknown>;
+  communicator: CommunicatorFunction<unknown[], unknown>;
   config: CommunicatorConfig;
 }
 
@@ -510,7 +510,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
   }
 
   #registerCommunicator(ro: MethodRegistrationBase) {
-    const comm = ro.registeredFunction as Communicator<unknown[], unknown>;
+    const comm = ro.registeredFunction as CommunicatorFunction<unknown[], unknown>;
     const cfn = ro.className + '.' + ro.name;
     if (this.communicatorInfoMap.has(cfn)) {
       throw new DBOSError(`Repeated Commmunicator name: ${cfn}`);
@@ -587,7 +587,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
     return {txnInfo, clsInst: getConfiguredInstance(className, cfgName)};
   }
 
-  getCommunicatorInfo(cf: Communicator<unknown[], unknown>) {
+  getCommunicatorInfo(cf: CommunicatorFunction<unknown[], unknown>) {
     const cfname = getRegisteredMethodClassName(cf) + '.' + cf.name;
     return this.communicatorInfoMap.get(cfname);
   }
@@ -832,7 +832,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
     }
   }
 
-  async external<T extends unknown[], R>(commFn: Communicator<T, R>, params: WorkflowParams, ...args: T): Promise<R> {
+  async external<T extends unknown[], R>(commFn: CommunicatorFunction<T, R>, params: WorkflowParams, ...args: T): Promise<R> {
     // Create a workflow and call external.
     const temp_workflow = async (ctxt: WorkflowContext, ...args: T) => {
       const ctxtImpl = ctxt as WorkflowContextImpl;

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -15,7 +15,7 @@ import {
 } from './workflow';
 
 import { IsolationLevel, Transaction, TransactionConfig } from './transaction';
-import { CommunicatorConfig, CommunicatorFunction } from './communicator';
+import { StepConfig, StepFunction } from './step';
 import { TelemetryCollector } from './telemetry/collector';
 import { Tracer } from './telemetry/traces';
 import { GlobalLogger as Logger } from './telemetry/logs';
@@ -81,8 +81,8 @@ interface TransactionInfo {
 }
 
 interface CommunicatorInfo {
-  communicator: CommunicatorFunction<unknown[], unknown>;
-  config: CommunicatorConfig;
+  communicator: StepFunction<unknown[], unknown>;
+  config: StepConfig;
 }
 
 interface ProcedureInfo {
@@ -510,7 +510,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
   }
 
   #registerCommunicator(ro: MethodRegistrationBase) {
-    const comm = ro.registeredFunction as CommunicatorFunction<unknown[], unknown>;
+    const comm = ro.registeredFunction as StepFunction<unknown[], unknown>;
     const cfn = ro.className + '.' + ro.name;
     if (this.communicatorInfoMap.has(cfn)) {
       throw new DBOSError(`Repeated Commmunicator name: ${cfn}`);
@@ -587,7 +587,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
     return {txnInfo, clsInst: getConfiguredInstance(className, cfgName)};
   }
 
-  getCommunicatorInfo(cf: CommunicatorFunction<unknown[], unknown>) {
+  getCommunicatorInfo(cf: StepFunction<unknown[], unknown>) {
     const cfname = getRegisteredMethodClassName(cf) + '.' + cf.name;
     return this.communicatorInfoMap.get(cfname);
   }
@@ -832,7 +832,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
     }
   }
 
-  async external<T extends unknown[], R>(commFn: CommunicatorFunction<T, R>, params: WorkflowParams, ...args: T): Promise<R> {
+  async external<T extends unknown[], R>(commFn: StepFunction<T, R>, params: WorkflowParams, ...args: T): Promise<R> {
     // Create a workflow and call external.
     const temp_workflow = async (ctxt: WorkflowContext, ...args: T) => {
       const ctxtImpl = ctxt as WorkflowContextImpl;

--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -269,10 +269,10 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
     return check.output; // Always return the recorded result.
   }
 
-  async external<T extends unknown[], R>(commFn: StepFunction<T, R>, _clsinst: ConfiguredInstance | null, ..._args: T): Promise<R> {
-    const commConfig = this.#dbosExec.getStepInfo(commFn as StepFunction<unknown[], unknown>);
+  async external<T extends unknown[], R>(stepFn: StepFunction<T, R>, _clsinst: ConfiguredInstance | null, ..._args: T): Promise<R> {
+    const commConfig = this.#dbosExec.getStepInfo(stepFn as StepFunction<unknown[], unknown>);
     if (commConfig === undefined) {
-      throw new DBOSDebuggerError(`Step ${commFn.name} not registered!`);
+      throw new DBOSDebuggerError(`Step ${stepFn.name} not registered!`);
     }
     const funcID = this.functionIDGetIncrement();
 
@@ -281,7 +281,7 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
     // Original result must exist during replay.
     const check: R | DBOSNull = await this.#dbosExec.systemDatabase.checkOperationOutput<R>(this.workflowUUID, funcID);
     if (check === dbosNull) {
-      throw new DBOSDebuggerError(`Cannot find recorded step output for ${commFn.name}. Shouldn't happen in debug mode!`);
+      throw new DBOSDebuggerError(`Cannot find recorded step output for ${stepFn.name}. Shouldn't happen in debug mode!`);
     }
     this.logger.debug("Use recorded step output.");
     return check as R;

--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -2,7 +2,7 @@
 import { DBOSExecutor, DBOSNull, OperationType, dbosNull } from "../dbos-executor";
 import { transaction_outputs } from "../../schemas/user_db_schema";
 import { IsolationLevel, Transaction, TransactionContextImpl } from "../transaction";
-import { Communicator } from "../communicator";
+import { CommunicatorFunction } from "../communicator";
 import { DBOSDebuggerError } from "../error";
 import { deserializeError } from "serialize-error";
 import { SystemDatabase } from "../system_database";
@@ -67,7 +67,7 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
         proxy[op.name] = op.txnConfig
           ? (...args: unknown[]) => this.transaction(op.registeredFunction as Transaction<unknown[], unknown>, null, ...args)
           : op.commConfig
-            ? (...args: unknown[]) => this.external(op.registeredFunction as Communicator<unknown[], unknown>, null, ...args)
+            ? (...args: unknown[]) => this.external(op.registeredFunction as CommunicatorFunction<unknown[], unknown>, null, ...args)
             : op.procConfig
               ? (...args: unknown[]) => this.procedure(op.registeredFunction as StoredProcedure<unknown>, ...args)
               : undefined;
@@ -83,7 +83,7 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
         proxy[op.name] = op.txnConfig
           ?          (...args: unknown[]) => this.transaction(op.registeredFunction as Transaction<unknown[], unknown>, targetInst, ...args)
           : op.commConfig
-            ?            (...args: unknown[]) => this.external(op.registeredFunction as Communicator<unknown[], unknown>, targetInst, ...args)
+            ?            (...args: unknown[]) => this.external(op.registeredFunction as CommunicatorFunction<unknown[], unknown>, targetInst, ...args)
             : undefined;
       }
       return proxy as InvokeFuncsInst<T>;
@@ -269,8 +269,8 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
     return check.output; // Always return the recorded result.
   }
 
-  async external<T extends unknown[], R>(commFn: Communicator<T, R>, _clsinst: ConfiguredInstance | null, ..._args: T): Promise<R> {
-    const commConfig = this.#dbosExec.getCommunicatorInfo(commFn as Communicator<unknown[], unknown>);
+  async external<T extends unknown[], R>(commFn: CommunicatorFunction<T, R>, _clsinst: ConfiguredInstance | null, ..._args: T): Promise<R> {
+    const commConfig = this.#dbosExec.getCommunicatorInfo(commFn as CommunicatorFunction<unknown[], unknown>);
     if (commConfig === undefined) {
       throw new DBOSDebuggerError(`Communicator ${commFn.name} not registered!`);
     }

--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -270,20 +270,20 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
   }
 
   async external<T extends unknown[], R>(commFn: StepFunction<T, R>, _clsinst: ConfiguredInstance | null, ..._args: T): Promise<R> {
-    const commConfig = this.#dbosExec.getCommunicatorInfo(commFn as StepFunction<unknown[], unknown>);
+    const commConfig = this.#dbosExec.getStepInfo(commFn as StepFunction<unknown[], unknown>);
     if (commConfig === undefined) {
-      throw new DBOSDebuggerError(`Communicator ${commFn.name} not registered!`);
+      throw new DBOSDebuggerError(`Step ${commFn.name} not registered!`);
     }
     const funcID = this.functionIDGetIncrement();
 
-    // FIXME: we do not create a span for the replay communicator. Do we want to?
+    // FIXME: we do not create a span for the replay step. Do we want to?
 
     // Original result must exist during replay.
     const check: R | DBOSNull = await this.#dbosExec.systemDatabase.checkOperationOutput<R>(this.workflowUUID, funcID);
     if (check === dbosNull) {
-      throw new DBOSDebuggerError(`Cannot find recorded communicator output for ${commFn.name}. Shouldn't happen in debug mode!`);
+      throw new DBOSDebuggerError(`Cannot find recorded step output for ${commFn.name}. Shouldn't happen in debug mode!`);
     }
-    this.logger.debug("Use recorded communicator output.");
+    this.logger.debug("Use recorded step output.");
     return check as R;
   }
 

--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -2,7 +2,7 @@
 import { DBOSExecutor, DBOSNull, OperationType, dbosNull } from "../dbos-executor";
 import { transaction_outputs } from "../../schemas/user_db_schema";
 import { IsolationLevel, Transaction, TransactionContextImpl } from "../transaction";
-import { CommunicatorFunction } from "../communicator";
+import { StepFunction } from "../step";
 import { DBOSDebuggerError } from "../error";
 import { deserializeError } from "serialize-error";
 import { SystemDatabase } from "../system_database";
@@ -67,7 +67,7 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
         proxy[op.name] = op.txnConfig
           ? (...args: unknown[]) => this.transaction(op.registeredFunction as Transaction<unknown[], unknown>, null, ...args)
           : op.commConfig
-            ? (...args: unknown[]) => this.external(op.registeredFunction as CommunicatorFunction<unknown[], unknown>, null, ...args)
+            ? (...args: unknown[]) => this.external(op.registeredFunction as StepFunction<unknown[], unknown>, null, ...args)
             : op.procConfig
               ? (...args: unknown[]) => this.procedure(op.registeredFunction as StoredProcedure<unknown>, ...args)
               : undefined;
@@ -83,7 +83,7 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
         proxy[op.name] = op.txnConfig
           ?          (...args: unknown[]) => this.transaction(op.registeredFunction as Transaction<unknown[], unknown>, targetInst, ...args)
           : op.commConfig
-            ?            (...args: unknown[]) => this.external(op.registeredFunction as CommunicatorFunction<unknown[], unknown>, targetInst, ...args)
+            ?            (...args: unknown[]) => this.external(op.registeredFunction as StepFunction<unknown[], unknown>, targetInst, ...args)
             : undefined;
       }
       return proxy as InvokeFuncsInst<T>;
@@ -269,8 +269,8 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
     return check.output; // Always return the recorded result.
   }
 
-  async external<T extends unknown[], R>(commFn: CommunicatorFunction<T, R>, _clsinst: ConfiguredInstance | null, ..._args: T): Promise<R> {
-    const commConfig = this.#dbosExec.getCommunicatorInfo(commFn as CommunicatorFunction<unknown[], unknown>);
+  async external<T extends unknown[], R>(commFn: StepFunction<T, R>, _clsinst: ConfiguredInstance | null, ..._args: T): Promise<R> {
+    const commConfig = this.#dbosExec.getCommunicatorInfo(commFn as StepFunction<unknown[], unknown>);
     if (commConfig === undefined) {
       throw new DBOSDebuggerError(`Communicator ${commFn.name} not registered!`);
     }

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -4,7 +4,7 @@ import * as crypto from "crypto";
 import { TransactionConfig, TransactionContext } from "./transaction";
 import { WorkflowConfig, WorkflowContext } from "./workflow";
 import { DBOSContext, DBOSContextImpl, InitContext } from "./context";
-import { CommunicatorConfig, CommunicatorContext } from "./communicator";
+import { StepConfig, StepContext } from "./step";
 import { DBOSError, DBOSNotAuthorizedError } from "./error";
 import { validateMethodArgs } from "./data_validation";
 import { StoredProcedureConfig, StoredProcedureContext } from "./procedure";
@@ -147,7 +147,7 @@ export interface MethodRegistrationBase {
 
   workflowConfig?: WorkflowConfig;
   txnConfig?: TransactionConfig;
-  commConfig?: CommunicatorConfig;
+  commConfig?: StepConfig;
   procConfig?: TransactionConfig;
   isInstance: boolean;
 
@@ -182,7 +182,7 @@ implements MethodRegistrationBase
   registeredFunction: ((this: This, ...args: Args) => Promise<Return>) | undefined;
   workflowConfig?: WorkflowConfig;
   txnConfig?: TransactionConfig;
-  commConfig?: CommunicatorConfig;
+  commConfig?: StepConfig;
   procConfig?: TransactionConfig;
   eventReceiverInfo: Map<DBOSEventReceiver, unknown> = new Map();
 
@@ -637,11 +637,11 @@ export function StoredProcedure(config: StoredProcedureConfig={}) {
   return decorator;
 }
 
-export function Communicator(config: CommunicatorConfig={}) {
+export function Communicator(config: StepConfig={}) {
   function decorator<This, Args extends unknown[], Return>(
     target: object,
     propertyKey: string,
-    inDescriptor: TypedPropertyDescriptor<(this: This, ctx: CommunicatorContext, ...args: Args) => Promise<Return>>)
+    inDescriptor: TypedPropertyDescriptor<(this: This, ctx: StepContext, ...args: Args) => Promise<Return>>)
   {
     const { descriptor, registration } = registerAndWrapFunction(target, propertyKey, inDescriptor);
     registration.commConfig = config;

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -637,7 +637,7 @@ export function StoredProcedure(config: StoredProcedureConfig={}) {
   return decorator;
 }
 
-export function Communicator(config: StepConfig={}) {
+export function Step(config: StepConfig={}) {
   function decorator<This, Args extends unknown[], Return>(
     target: object,
     propertyKey: string,

--- a/src/eventreceiver.ts
+++ b/src/eventreceiver.ts
@@ -3,7 +3,7 @@ import { GlobalLogger as Logger } from './telemetry/logs';
 import { WorkflowFunction, WorkflowHandle, WorkflowParams } from './workflow';
 import { TransactionFunction } from './transaction';
 import { MethodRegistrationBase } from './decorators';
-import { CommunicatorFunction } from './communicator';
+import { StepFunction } from './step';
 
 /*
  * Info provided to an event receiver at initialization,
@@ -30,7 +30,7 @@ export interface DBOSExecutorContext
 
   transaction<T extends unknown[], R>(txn: TransactionFunction<T, R>, params: WorkflowParams, ...args: T): Promise<R>;
   workflow<T extends unknown[], R>(wf: WorkflowFunction<T, R>, params: WorkflowParams, ...args: T): Promise<WorkflowHandle<R>>;
-  external<T extends unknown[], R>(commFn: CommunicatorFunction<T, R>, params: WorkflowParams, ...args: T): Promise<R>;
+  external<T extends unknown[], R>(commFn: StepFunction<T, R>, params: WorkflowParams, ...args: T): Promise<R>;
 
   send<T>(destinationUUID: string, message: T, topic?: string, idempotencyKey?: string): Promise<void>;
   getEvent<T>(workflowUUID: string, key: string, timeoutSeconds: number): Promise<T | null>;

--- a/src/eventreceiver.ts
+++ b/src/eventreceiver.ts
@@ -30,7 +30,7 @@ export interface DBOSExecutorContext
 
   transaction<T extends unknown[], R>(txn: TransactionFunction<T, R>, params: WorkflowParams, ...args: T): Promise<R>;
   workflow<T extends unknown[], R>(wf: WorkflowFunction<T, R>, params: WorkflowParams, ...args: T): Promise<WorkflowHandle<R>>;
-  external<T extends unknown[], R>(commFn: StepFunction<T, R>, params: WorkflowParams, ...args: T): Promise<R>;
+  external<T extends unknown[], R>(stepFn: StepFunction<T, R>, params: WorkflowParams, ...args: T): Promise<R>;
 
   send<T>(destinationUUID: string, message: T, topic?: string, idempotencyKey?: string): Promise<void>;
   getEvent<T>(workflowUUID: string, key: string, timeoutSeconds: number): Promise<T | null>;

--- a/src/httpServer/handler.ts
+++ b/src/httpServer/handler.ts
@@ -8,7 +8,7 @@ import { W3CTraceContextPropagator } from "@opentelemetry/core";
 import { trace, defaultTextMapGetter, ROOT_CONTEXT } from '@opentelemetry/api';
 import { Span } from "@opentelemetry/sdk-trace-base";
 import { v4 as uuidv4 } from 'uuid';
-import { CommunicatorFunction } from "../communicator";
+import { StepFunction } from "../step";
 import { APITypes, ArgSources } from "./handlerTypes";
 import { StoredProcedure } from "../procedure";
 
@@ -159,7 +159,7 @@ export class HandlerContextImpl extends DBOSContextImpl implements HandlerContex
           ? (...args: unknown[]) => this.#workflow(op.registeredFunction as Workflow<unknown[], unknown>, params, ...args)
           : op.commConfig
 
-          ? (...args: unknown[]) => this.#external(op.registeredFunction as CommunicatorFunction<unknown[], unknown>, params, ...args)
+          ? (...args: unknown[]) => this.#external(op.registeredFunction as StepFunction<unknown[], unknown>, params, ...args)
           : op.procConfig
 
           ? (...args: unknown[]) => this.#procedure(op.registeredFunction as StoredProcedure<unknown>, params, ...args)
@@ -221,7 +221,7 @@ export class HandlerContextImpl extends DBOSContextImpl implements HandlerContex
     return this.#dbosExec.transaction(txn, params, ...args);
   }
 
-  async #external<T extends unknown[], R>(commFn: CommunicatorFunction<T, R>, params: WorkflowParams, ...args: T): Promise<R> {
+  async #external<T extends unknown[], R>(commFn: StepFunction<T, R>, params: WorkflowParams, ...args: T): Promise<R> {
     return this.#dbosExec.external(commFn, params, ...args);
   }
 

--- a/src/httpServer/handler.ts
+++ b/src/httpServer/handler.ts
@@ -221,8 +221,8 @@ export class HandlerContextImpl extends DBOSContextImpl implements HandlerContex
     return this.#dbosExec.transaction(txn, params, ...args);
   }
 
-  async #external<T extends unknown[], R>(commFn: StepFunction<T, R>, params: WorkflowParams, ...args: T): Promise<R> {
-    return this.#dbosExec.external(commFn, params, ...args);
+  async #external<T extends unknown[], R>(stepFn: StepFunction<T, R>, params: WorkflowParams, ...args: T): Promise<R> {
+    return this.#dbosExec.external(stepFn, params, ...args);
   }
 
   async #procedure<R>(proc: StoredProcedure<R>, params: WorkflowParams, ...args: unknown[]): Promise<R> {

--- a/src/httpServer/handler.ts
+++ b/src/httpServer/handler.ts
@@ -8,7 +8,7 @@ import { W3CTraceContextPropagator } from "@opentelemetry/core";
 import { trace, defaultTextMapGetter, ROOT_CONTEXT } from '@opentelemetry/api';
 import { Span } from "@opentelemetry/sdk-trace-base";
 import { v4 as uuidv4 } from 'uuid';
-import { Communicator } from "../communicator";
+import { CommunicatorFunction } from "../communicator";
 import { APITypes, ArgSources } from "./handlerTypes";
 import { StoredProcedure } from "../procedure";
 
@@ -159,7 +159,7 @@ export class HandlerContextImpl extends DBOSContextImpl implements HandlerContex
           ? (...args: unknown[]) => this.#workflow(op.registeredFunction as Workflow<unknown[], unknown>, params, ...args)
           : op.commConfig
 
-          ? (...args: unknown[]) => this.#external(op.registeredFunction as Communicator<unknown[], unknown>, params, ...args)
+          ? (...args: unknown[]) => this.#external(op.registeredFunction as CommunicatorFunction<unknown[], unknown>, params, ...args)
           : op.procConfig
 
           ? (...args: unknown[]) => this.#procedure(op.registeredFunction as StoredProcedure<unknown>, params, ...args)
@@ -221,7 +221,7 @@ export class HandlerContextImpl extends DBOSContextImpl implements HandlerContex
     return this.#dbosExec.transaction(txn, params, ...args);
   }
 
-  async #external<T extends unknown[], R>(commFn: Communicator<T, R>, params: WorkflowParams, ...args: T): Promise<R> {
+  async #external<T extends unknown[], R>(commFn: CommunicatorFunction<T, R>, params: WorkflowParams, ...args: T): Promise<R> {
     return this.#dbosExec.external(commFn, params, ...args);
   }
 

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -20,7 +20,7 @@ import { DBOSExecutor } from "../dbos-executor";
 import { GlobalLogger as Logger } from "../telemetry/logs";
 import { MiddlewareDefaults } from './middleware';
 import { SpanStatusCode, trace, ROOT_CONTEXT } from '@opentelemetry/api';
-import { CommunicatorFunction } from '../communicator';
+import { StepFunction } from '../step';
 import * as net from 'net';
 import { performance } from 'perf_hooks';
 import { DBOSJSON, exhaustiveCheckGuard } from '../utils';
@@ -309,7 +309,7 @@ async checkPortAvailability(port: number, host: string): Promise<void> {
             } else if (ro.workflowConfig) {
               koaCtxt.body = await (await dbosExec.workflow(ro.registeredFunction as Workflow<unknown[], unknown>, wfParams, ...args)).getResult();
             } else if (ro.commConfig) {
-              koaCtxt.body = await dbosExec.external(ro.registeredFunction as CommunicatorFunction<unknown[], unknown>, wfParams, ...args);
+              koaCtxt.body = await dbosExec.external(ro.registeredFunction as StepFunction<unknown[], unknown>, wfParams, ...args);
             } else {
               // Directly invoke the handler code.
               const retValue = await ro.invoke(undefined, [oc, ...args]);

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -20,7 +20,7 @@ import { DBOSExecutor } from "../dbos-executor";
 import { GlobalLogger as Logger } from "../telemetry/logs";
 import { MiddlewareDefaults } from './middleware';
 import { SpanStatusCode, trace, ROOT_CONTEXT } from '@opentelemetry/api';
-import { Communicator } from '../communicator';
+import { CommunicatorFunction } from '../communicator';
 import * as net from 'net';
 import { performance } from 'perf_hooks';
 import { DBOSJSON, exhaustiveCheckGuard } from '../utils';
@@ -309,7 +309,7 @@ async checkPortAvailability(port: number, host: string): Promise<void> {
             } else if (ro.workflowConfig) {
               koaCtxt.body = await (await dbosExec.workflow(ro.registeredFunction as Workflow<unknown[], unknown>, wfParams, ...args)).getResult();
             } else if (ro.commConfig) {
-              koaCtxt.body = await dbosExec.external(ro.registeredFunction as Communicator<unknown[], unknown>, wfParams, ...args);
+              koaCtxt.body = await dbosExec.external(ro.registeredFunction as CommunicatorFunction<unknown[], unknown>, wfParams, ...args);
             } else {
               // Directly invoke the handler code.
               const retValue = await ro.invoke(undefined, [oc, ...args]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,8 @@ export {
   // Method Decorators
   Transaction,
   Workflow,
-  Communicator,
+  Step,
+  Step as Communicator,
   StoredProcedure,
   RequiredRole,
   DBOSInitializer,

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,10 +30,13 @@ export {
 } from './workflow';
 
 export {
-  CommunicatorContext,
-  CommunicatorConfig,
-  CommunicatorFunction,
-} from './communicator';
+  StepContext as CommunicatorContext,
+  StepConfig as CommunicatorConfig,
+  StepFunction as CommunicatorFunction,
+  StepContext,
+  StepConfig,
+  StepFunction,
+} from './step';
 
 export * as Error from './error';
 

--- a/src/step.ts
+++ b/src/step.ts
@@ -4,22 +4,22 @@ import { WorkflowContextImpl } from "./workflow";
 import { DBOSContext, DBOSContextImpl } from "./context";
 import { WorkflowContextDebug } from "./debugger/debug_workflow";
 
-export type CommunicatorFunction<T extends unknown[], R> = (ctxt: CommunicatorContext, ...args: T) => Promise<R>;
+export type StepFunction<T extends unknown[], R> = (ctxt: StepContext, ...args: T) => Promise<R>;
 
-export interface CommunicatorConfig {
+export interface StepConfig {
   retriesAllowed?: boolean; // Should failures be retried? (default true)
   intervalSeconds?: number; // Seconds to wait before the first retry attempt (default 1).
   maxAttempts?: number; // Maximum number of retry attempts (default 3). If errors occur more times than this, throw an exception.
   backoffRate?: number; // The multiplier by which the retry interval increases after every retry attempt (default 2).
 }
 
-export interface CommunicatorContext extends DBOSContext {
+export interface StepContext extends DBOSContext {
   // These fields reflect the communictor's configuration.
   readonly retriesAllowed: boolean;
   readonly maxAttempts: number;
 }
 
-export class CommunicatorContextImpl extends DBOSContextImpl implements CommunicatorContext {
+export class StepContextImpl extends DBOSContextImpl implements StepContext {
   readonly functionID: number;
   readonly retriesAllowed: boolean;
   readonly intervalSeconds: number;
@@ -28,7 +28,7 @@ export class CommunicatorContextImpl extends DBOSContextImpl implements Communic
 
   // TODO: Validate the parameters.
   constructor(workflowContext: WorkflowContextImpl | WorkflowContextDebug, functionID: number, span: Span, logger: Logger,
-     params: CommunicatorConfig, commName: string)
+     params: StepConfig, commName: string)
   {
     super(commName, span, logger, workflowContext);
     this.functionID = functionID;

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { IncomingMessage } from "http";
-import { CommunicatorFunction } from "../communicator";
+import { StepFunction } from "../step";
 import { HTTPRequest, DBOSContextImpl } from "../context";
 import { ConfiguredInstance, getRegisteredOperations } from "../decorators";
 import { DBOSConfigKeyTypeError, DBOSError } from "../error";
@@ -170,7 +170,7 @@ export class TestingRuntimeImpl implements TestingRuntime {
           : op.workflowConfig
             ? (...args: unknown[]) => dbosExec.workflow(op.registeredFunction as Workflow<unknown[], unknown>, wfParams, ...args)
             : op.commConfig
-              ? (...args: unknown[]) => dbosExec.external(op.registeredFunction as CommunicatorFunction<unknown[], unknown>, wfParams, ...args)
+              ? (...args: unknown[]) => dbosExec.external(op.registeredFunction as StepFunction<unknown[], unknown>, wfParams, ...args)
               : op.procConfig
                 ? (...args: unknown[]) => dbosExec.procedure(op.registeredFunction as StoredProcedure<unknown>, wfParams, ...args)
                 : undefined;

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { IncomingMessage } from "http";
-import { Communicator } from "../communicator";
+import { CommunicatorFunction } from "../communicator";
 import { HTTPRequest, DBOSContextImpl } from "../context";
 import { ConfiguredInstance, getRegisteredOperations } from "../decorators";
 import { DBOSConfigKeyTypeError, DBOSError } from "../error";
@@ -170,7 +170,7 @@ export class TestingRuntimeImpl implements TestingRuntime {
           : op.workflowConfig
             ? (...args: unknown[]) => dbosExec.workflow(op.registeredFunction as Workflow<unknown[], unknown>, wfParams, ...args)
             : op.commConfig
-              ? (...args: unknown[]) => dbosExec.external(op.registeredFunction as Communicator<unknown[], unknown>, wfParams, ...args)
+              ? (...args: unknown[]) => dbosExec.external(op.registeredFunction as CommunicatorFunction<unknown[], unknown>, wfParams, ...args)
               : op.procConfig
                 ? (...args: unknown[]) => dbosExec.procedure(op.registeredFunction as StoredProcedure<unknown>, wfParams, ...args)
                 : undefined;

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -147,7 +147,7 @@ export class TestingRuntimeImpl implements TestingRuntime {
 
   /**
    * Generate a proxy object for the provided class that wraps direct calls (i.e. OpClass.someMethod(param))
-   * to invoke workflows, transactions, and communicators;
+   * to invoke workflows, transactions, and steps;
    */
   mainInvoke<T extends object>(object: T, workflowUUID: string | undefined, params: WorkflowInvokeParams | undefined, asyncWf: boolean,
     clsinst: ConfiguredInstance | null): InvokeFuncs<T>

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -1,4 +1,4 @@
-import { CommunicatorContext, Communicator, TestingRuntime, Transaction, Workflow, TransactionContext, WorkflowContext } from "../src";
+import { StepContext, Step, TestingRuntime, Transaction, Workflow, TransactionContext, WorkflowContext } from "../src";
 import { v1 as uuidv1 } from "uuid";
 import { sleepms } from "../src/utils";
 import { generateDBOSTestConfig, setUpDBOSTestDb } from "./helpers";
@@ -63,13 +63,13 @@ describe("concurrency-tests", () => {
     expect(ConcurrTestClass.wfCnt).toBe(2);
   });
 
-  test("duplicate-communicator", async () => {
-    // Run two communicators concurrently with the same UUID; both should succeed.
+  test("duplicate-step", async () => {
+    // Run two steps concurrently with the same UUID; both should succeed.
     // Since we only record the output after the function, it may cause more than once executions.
     const workflowUUID = uuidv1();
     const results = await Promise.allSettled([
-      testRuntime.invoke(ConcurrTestClass, workflowUUID).testCommunicator(11),
-      testRuntime.invoke(ConcurrTestClass, workflowUUID).testCommunicator(11),
+      testRuntime.invoke(ConcurrTestClass, workflowUUID).testStep(11),
+      testRuntime.invoke(ConcurrTestClass, workflowUUID).testStep(11),
     ]);
     expect((results[0] as PromiseFulfilledResult<number>).value).toBe(11);
     expect((results[1] as PromiseFulfilledResult<number>).value).toBe(11);
@@ -129,8 +129,8 @@ class ConcurrTestClass {
     await ctxt.invoke(ConcurrTestClass).testReadWriteFunction(1);
   }
 
-  @Communicator()
-  static async testCommunicator(_ctxt: CommunicatorContext, id: number) {
+  @Step()
+  static async testStep(_ctxt: StepContext, id: number) {
     ConcurrTestClass.cnt++;
     return Promise.resolve(id);
   }

--- a/tests/configuredinstances.test.ts
+++ b/tests/configuredinstances.test.ts
@@ -1,6 +1,6 @@
 import {
-  Communicator,
-  CommunicatorContext,
+  Step,
+  StepContext,
   ConfiguredInstance,
   GetApi,
   HandlerContext,
@@ -65,8 +65,8 @@ class DBOSTestConfiguredClass extends ConfiguredInstance {
     return Promise.resolve();
   }
 
-  @Communicator()
-  testCommunicator(_ctxt: CommunicatorContext) {
+  @Step()
+  testStep(_ctxt: StepContext) {
     const arg = this.tracker;
     expect(DBOSTestConfiguredClass.configs.has(this.name)).toBeTruthy();
     expect(arg).toBe(DBOSTestConfiguredClass.configs.get(this.name));
@@ -84,8 +84,8 @@ class DBOSTestConfiguredClass extends ConfiguredInstance {
     ++arg.nWF;
     ++arg.nByName;
 
-    // Invoke a transaction and a communicator
-    await ctxt.invoke(this).testCommunicator();
+    // Invoke a transaction and a step
+    await ctxt.invoke(this).testStep();
     await ctxt.invoke(this).testTransaction1();
   }
 
@@ -97,7 +97,7 @@ class DBOSTestConfiguredClass extends ConfiguredInstance {
     ++arg.nWF;
     ++arg.nByName;
 
-    // Invoke a workflow that invokes a transaction and a communicator
+    // Invoke a workflow that invokes a transaction and a step
     await ctxt.invokeWorkflow(this).testBasicWorkflow('please');
     const wfh = await ctxt.startWorkflow(this).testBasicWorkflow('please');
     await wfh.getResult();
@@ -163,12 +163,12 @@ describe("dbos-configclass-tests", () => {
 
   test("simple-functions", async () => {
     try {
-      await testRuntime.invoke(config1).testCommunicator();
+      await testRuntime.invoke(config1).testStep();
     } catch (e) {
       console.log(e);
       throw e;
     }
-    await testRuntime.invoke(configA).testCommunicator();
+    await testRuntime.invoke(configA).testStep();
     const wfUUID1 = uuidv1();
     const wfUUID2 = uuidv1();
     await testRuntime.invoke(config1, wfUUID1).testTransaction1();

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -1,4 +1,4 @@
-import { WorkflowContext, TransactionContext, CommunicatorContext, WorkflowHandle, Transaction, Workflow, Communicator, DBOSInitializer, InitContext } from "../src/";
+import { WorkflowContext, TransactionContext, StepContext, WorkflowHandle, Transaction, Workflow, Step, DBOSInitializer, InitContext } from "../src/";
 import { generateDBOSTestConfig, setUpDBOSTestDb, TestKvTable } from "./helpers";
 import { v1 as uuidv1 } from "uuid";
 import { StatusString } from "../src/workflow";
@@ -58,10 +58,10 @@ describe("dbos-tests", () => {
     await expect(testRuntime.invokeWorkflow(DBOSTestClass).testFailWorkflow("fail")).rejects.toThrow("fail");
   });
 
-  test("simple-communicator", async () => {
+  test("simple-step", async () => {
     const workflowUUID: string = uuidv1();
-    await expect(testRuntime.invoke(DBOSTestClass, workflowUUID).testCommunicator()).resolves.toBe(0);
-    await expect(testRuntime.invoke(DBOSTestClass).testCommunicator()).resolves.toBe(1);
+    await expect(testRuntime.invoke(DBOSTestClass, workflowUUID).testStep()).resolves.toBe(0);
+    await expect(testRuntime.invoke(DBOSTestClass).testStep()).resolves.toBe(1);
   });
 
   test("simple-workflow-notifications", async () => {
@@ -304,8 +304,8 @@ class DBOSTestClass {
     return checkResult;
   }
 
-  @Communicator()
-  static async testCommunicator(ctxt: CommunicatorContext) {
+  @Step()
+  static async testStep(ctxt: StepContext) {
     expect(ctxt.getConfig<number>("counter")).toBe(3);
     return Promise.resolve(DBOSTestClass.cnt++);
   }

--- a/tests/failures.test.ts
+++ b/tests/failures.test.ts
@@ -1,4 +1,4 @@
-import { WorkflowContext, TransactionContext, CommunicatorContext, Communicator, Workflow, Transaction, ArgOptional, TestingRuntime } from "../src/";
+import { WorkflowContext, TransactionContext, StepContext, Step, Workflow, Transaction, ArgOptional, TestingRuntime } from "../src/";
 import { generateDBOSTestConfig, setUpDBOSTestDb, TestKvTable } from "./helpers";
 import { DatabaseError, PoolClient } from "pg";
 import { v1 as uuidv1 } from "uuid";
@@ -33,7 +33,7 @@ describe("failures-tests", () => {
 
   test("dbos-error", async () => {
     const wfUUID1 = uuidv1();
-    await expect(testRuntime.invoke(FailureTestClass, wfUUID1).testCommunicator(11)).rejects.toThrow(new DBOSError("test dbos error with code.", 11));
+    await expect(testRuntime.invoke(FailureTestClass, wfUUID1).testStep(11)).rejects.toThrow(new DBOSError("test dbos error with code.", 11));
 
     const retrievedHandle = testRuntime.retrieveWorkflow<string>(wfUUID1);
     expect(retrievedHandle).not.toBeNull();
@@ -44,7 +44,7 @@ describe("failures-tests", () => {
 
     // Test without code.
     const wfUUID = uuidv1();
-    await expect(testRuntime.invoke(FailureTestClass, wfUUID).testCommunicator()).rejects.toThrow(new DBOSError("test dbos error without code."));
+    await expect(testRuntime.invoke(FailureTestClass, wfUUID).testStep()).rejects.toThrow(new DBOSError("test dbos error without code."));
   });
 
   test("readonly-error", async () => {
@@ -101,17 +101,17 @@ describe("failures-tests", () => {
     expect(FailureTestClass.cnt).toBe(10);
   });
 
-  test("failing-communicator", async () => {
+  test("failing-step", async () => {
     let startTime = Date.now();
-    await expect(testRuntime.invoke(FailureTestClass).testFailCommunicator()).resolves.toBe(2);
+    await expect(testRuntime.invoke(FailureTestClass).testFailStep()).resolves.toBe(2);
     expect(Date.now() - startTime).toBeGreaterThanOrEqual(1000);
 
     startTime = Date.now();
-    await expect(testRuntime.invoke(FailureTestClass).testFailCommunicator()).rejects.toThrow(new DBOSError("Step reached maximum retries.", 1));
+    await expect(testRuntime.invoke(FailureTestClass).testFailStep()).rejects.toThrow(new DBOSError("Step reached maximum retries.", 1));
     expect(Date.now() - startTime).toBeGreaterThanOrEqual(1000);
   });
 
-  test("nonretry-communicator", async () => {
+  test("nonretry-step", async () => {
     const workflowUUID = uuidv1();
 
     // Should throw an error.
@@ -132,7 +132,7 @@ describe("failures-tests", () => {
     // Invoke an unregistered transaction.
     expect(() => testRuntime.invoke(FailureTestClass).noRegTransaction(10)).toThrow();
 
-    // Invoke an unregistered communicator in a workflow.
+    // Invoke an unregistered step in a workflow.
     await expect(testRuntime.invokeWorkflow(FailureTestClass).testCommWorkflow()).rejects.toThrow();
   });
 });
@@ -141,8 +141,8 @@ class FailureTestClass {
   static cnt = 0;
   static success: string = "";
 
-  @Communicator({ retriesAllowed: false })
-  static async testCommunicator(_ctxt: CommunicatorContext, @ArgOptional code?: number) {
+  @Step({ retriesAllowed: false })
+  static async testStep(_ctxt: StepContext, @ArgOptional code?: number) {
     const err = code
       ? new DBOSError("test dbos error with code.", code)
       : new DBOSError("test dbos error without code.")
@@ -179,8 +179,8 @@ class FailureTestClass {
     return await ctxt.invoke(FailureTestClass).testSerialError(maxRetry);
   }
 
-  @Communicator({ retriesAllowed: true, intervalSeconds: 1, maxAttempts: 2 })
-  static async testFailCommunicator(ctxt: CommunicatorContext) {
+  @Step({ retriesAllowed: true, intervalSeconds: 1, maxAttempts: 2 })
+  static async testFailStep(ctxt: StepContext) {
     FailureTestClass.cnt++;
     if (ctxt.retriesAllowed && FailureTestClass.cnt !== ctxt.maxAttempts) {
       throw new Error("bad number");
@@ -188,14 +188,14 @@ class FailureTestClass {
     return Promise.resolve(FailureTestClass.cnt);
   }
 
-  @Communicator({ retriesAllowed: false })
-  static async testNoRetry(_ctxt: CommunicatorContext) {
+  @Step({ retriesAllowed: false })
+  static async testNoRetry(_ctxt: StepContext) {
     FailureTestClass.cnt++;
     return Promise.reject(new Error("failed no retry"));
   }
 
   // Test decorator registration works.
-  static async noRegComm(_ctxt: CommunicatorContext, code: number) {
+  static async noRegComm(_ctxt: StepContext, code: number) {
     return Promise.resolve(code + 1);
   }
 

--- a/tests/failures.test.ts
+++ b/tests/failures.test.ts
@@ -107,7 +107,7 @@ describe("failures-tests", () => {
     expect(Date.now() - startTime).toBeGreaterThanOrEqual(1000);
 
     startTime = Date.now();
-    await expect(testRuntime.invoke(FailureTestClass).testFailCommunicator()).rejects.toThrow(new DBOSError("Communicator reached maximum retries.", 1));
+    await expect(testRuntime.invoke(FailureTestClass).testFailCommunicator()).rejects.toThrow(new DBOSError("Step reached maximum retries.", 1));
     expect(Date.now() - startTime).toBeGreaterThanOrEqual(1000);
   });
 

--- a/tests/foundationdb/foundationdb.test.ts
+++ b/tests/foundationdb/foundationdb.test.ts
@@ -57,8 +57,8 @@ describe("foundationdb-dbos", () => {
     await expect(testRuntime.invoke(FdbTestClass).testErrorCommunicator()).resolves.toBe("success");
 
     const workflowUUID: string = uuidv1();
-    await expect(testRuntime.invoke(FdbTestClass, workflowUUID).testErrorCommunicator()).rejects.toThrow(new DBOSError("Communicator reached maximum retries.", 1));
-    await expect(testRuntime.invoke(FdbTestClass, workflowUUID).testErrorCommunicator()).rejects.toThrow(new DBOSError("Communicator reached maximum retries.", 1));
+    await expect(testRuntime.invoke(FdbTestClass, workflowUUID).testErrorCommunicator()).rejects.toThrow(new DBOSError("Step reached maximum retries.", 1));
+    await expect(testRuntime.invoke(FdbTestClass, workflowUUID).testErrorCommunicator()).rejects.toThrow(new DBOSError("Step reached maximum retries.", 1));
   });
 
   test("fdb-workflow-status", async () => {

--- a/tests/foundationdb/foundationdb.test.ts
+++ b/tests/foundationdb/foundationdb.test.ts
@@ -1,4 +1,4 @@
-import { TransactionContext, CommunicatorContext, WorkflowContext, StatusString, WorkflowHandle, Transaction, Communicator, Workflow, TestingRuntime } from "../../src/";
+import { TransactionContext, StepContext, WorkflowContext, StatusString, WorkflowHandle, Transaction, Step, Workflow, TestingRuntime } from "../../src/";
 import { generateDBOSTestConfig, setUpDBOSTestDb } from "../helpers";
 import { v1 as uuidv1 } from "uuid";
 import { DBOSConfig } from "../../src/dbos-executor";
@@ -43,22 +43,22 @@ describe("foundationdb-dbos", () => {
     expect(FdbTestClass.cnt).toBe(1);
   });
 
-  test("fdb-communicator", async () => {
+  test("fdb-step", async () => {
     const workflowUUID: string = uuidv1();
 
-    await expect(testRuntime.invoke(FdbTestClass, workflowUUID).testCommunicator()).resolves.toBe(0);
+    await expect(testRuntime.invoke(FdbTestClass, workflowUUID).testStep()).resolves.toBe(0);
 
     // Test OAOO. Should return the original result.
-    await expect(testRuntime.invoke(FdbTestClass, workflowUUID).testCommunicator()).resolves.toBe(0);
+    await expect(testRuntime.invoke(FdbTestClass, workflowUUID).testStep()).resolves.toBe(0);
     expect(FdbTestClass.cnt).toBe(1);
   });
 
-  test("fdb-communicator-error", async () => {
-    await expect(testRuntime.invoke(FdbTestClass).testErrorCommunicator()).resolves.toBe("success");
+  test("fdb-step-error", async () => {
+    await expect(testRuntime.invoke(FdbTestClass).testErrorStep()).resolves.toBe("success");
 
     const workflowUUID: string = uuidv1();
-    await expect(testRuntime.invoke(FdbTestClass, workflowUUID).testErrorCommunicator()).rejects.toThrow(new DBOSError("Step reached maximum retries.", 1));
-    await expect(testRuntime.invoke(FdbTestClass, workflowUUID).testErrorCommunicator()).rejects.toThrow(new DBOSError("Step reached maximum retries.", 1));
+    await expect(testRuntime.invoke(FdbTestClass, workflowUUID).testErrorStep()).rejects.toThrow(new DBOSError("Step reached maximum retries.", 1));
+    await expect(testRuntime.invoke(FdbTestClass, workflowUUID).testErrorStep()).rejects.toThrow(new DBOSError("Step reached maximum retries.", 1));
   });
 
   test("fdb-workflow-status", async () => {
@@ -100,8 +100,8 @@ describe("foundationdb-dbos", () => {
     await expect(testRuntime.invokeWorkflow(FdbTestClass, workflowUUID).setEventWorkflow()).resolves.toBe(0);
   });
 
-  test("fdb-duplicate-communicator", async () => {
-    // Run two communicators concurrently with the same UUID; both should succeed.
+  test("fdb-duplicate-step", async () => {
+    // Run two steps concurrently with the same UUID; both should succeed.
     // Since we only record the output after the function, it may cause more than once executions.
     const workflowUUID = uuidv1();
     const results = await Promise.allSettled([
@@ -152,13 +152,13 @@ class FdbTestClass {
     }
   }
 
-  @Communicator()
-  static async testCommunicator(_commCtxt: CommunicatorContext) {
+  @Step()
+  static async testStep(_commCtxt: StepContext) {
     return Promise.resolve(FdbTestClass.cnt++);
   }
 
-  @Communicator({ intervalSeconds: 0, maxAttempts: 4 })
-  static async testErrorCommunicator(ctxt: CommunicatorContext) {
+  @Step({ intervalSeconds: 0, maxAttempts: 4 })
+  static async testErrorStep(ctxt: StepContext) {
     FdbTestClass.cnt++;
     if (FdbTestClass.cnt !== ctxt.maxAttempts) {
       throw new Error("bad number");
@@ -166,8 +166,8 @@ class FdbTestClass {
     return Promise.resolve("success");
   }
 
-  @Communicator({ retriesAllowed: false })
-  static async noRetryComm(_ctxt: CommunicatorContext, id: number) {
+  @Step({ retriesAllowed: false })
+  static async noRetryComm(_ctxt: StepContext, id: number) {
     FdbTestClass.cnt++;
     return Promise.resolve(id);
   }

--- a/tests/httpServer/server.test.ts
+++ b/tests/httpServer/server.test.ts
@@ -9,8 +9,8 @@ import {
   TransactionContext,
   WorkflowContext,
   StatusString,
-  Communicator,
-  CommunicatorContext,
+  Step,
+  StepContext,
 } from "../../src";
 import { RequestIDHeader } from "../../src/httpServer/handler";
 import { DeleteApi, PatchApi, PutApi } from "../../src";
@@ -144,8 +144,8 @@ describe("httpserver-tests", () => {
     expect(response.text).toBe("hello 1");
   });
 
-  test("endpoint-communicator", async () => {
-    const response = await request(testRuntime.getHandlersCallback()).get("/communicator/alice");
+  test("endpoint-step", async () => {
+    const response = await request(testRuntime.getHandlersCallback()).get("/step/alice");
     expect(response.statusCode).toBe(200);
     expect(response.text).toBe("alice");
   });
@@ -390,9 +390,9 @@ describe("httpserver-tests", () => {
       return `hello ${rows[0].id}`;
     }
 
-    @GetApi("/communicator/:input")
-    @Communicator()
-    static async testCommunicator(_ctxt: CommunicatorContext, input: string) {
+    @GetApi("/step/:input")
+    @Step()
+    static async testStep(_ctxt: StepContext, input: string) {
       return Promise.resolve(input);
     }
 
@@ -400,7 +400,7 @@ describe("httpserver-tests", () => {
     @Workflow()
     static async testWorkflow(wfCtxt: WorkflowContext, @ArgSource(ArgSources.QUERY) name: string) {
       const res = await wfCtxt.invoke(TestEndpoints).testTransaction(name);
-      return wfCtxt.invoke(TestEndpoints).testCommunicator(res);
+      return wfCtxt.invoke(TestEndpoints).testStep(res);
     }
 
     @PostApi("/error")

--- a/tests/testing/debugger_configuredinst.test.ts
+++ b/tests/testing/debugger_configuredinst.test.ts
@@ -1,6 +1,6 @@
 import {
-  Communicator,
-  CommunicatorContext,
+  Step,
+  StepContext,
   ConfiguredInstance,
   configureInstance,
   InitContext,
@@ -37,8 +37,8 @@ class DebuggerCCTest extends ConfiguredInstance {
     return `${name}${funcResult}`;
   }
 
-  @Communicator()
-  async testCommunicator(_ctxt: CommunicatorContext, inp: string) {
+  @Step()
+  async testStep(_ctxt: StepContext, inp: string) {
     expect(this.name).toBe('configA');
     return Promise.resolve(inp);
   }
@@ -49,7 +49,7 @@ class DebuggerCCTest extends ConfiguredInstance {
     expect(this.name).toBe('configA');
     await ctxt.sleep(1);
     const txResult = await ctxt.invoke(this).testReadOnlyFunction(num);
-    const cResult = await ctxt.invoke(this).testCommunicator("comm");
+    const cResult = await ctxt.invoke(this).testStep("comm");
     const wfResult = await ctxt.invokeWorkflow(this).testWorkflow('cwf');
     return `${this.name}${txResult}${cResult}${wfResult}-${num}`;
   }


### PR DESCRIPTION
This is a "step" in the journey of calling things "step" rather than "communicator" across TS and Python.

Allow @Step, StepContext, etc., while keeping @Communicator, CommunicatorContext, etc., working.

Also add aliases in some of the communicator libraries.

We would be able to do a lot of doc and demo work with this change, then wrestle down the rest.