### PR TITLE
DBOSFailedSqlTransactionError

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -174,3 +174,10 @@ export class DBOSDeadLetterQueueError extends DBOSError {
     super(`Workflow ${workflowUUID} has been moved to the dead-letter queue after exceeding the maximum of ${maxRetries} retries`, DeadLetterQueueError);
   }
 }
+
+const FailedSqlTransactionError = 19;
+export class DBOSFailedSqlTransactionError extends DBOSError {
+  constructor(workflowUUID: string, txnName: string) {
+    super(`Postgres aborted the transaction ${txnName} of Workflow ${workflowUUID}.`, FailedSqlTransactionError);
+  }
+}

--- a/src/error.ts
+++ b/src/error.ts
@@ -178,6 +178,6 @@ export class DBOSDeadLetterQueueError extends DBOSError {
 const FailedSqlTransactionError = 19;
 export class DBOSFailedSqlTransactionError extends DBOSError {
   constructor(workflowUUID: string, txnName: string) {
-    super(`Postgres aborted the transaction ${txnName} of Workflow ${workflowUUID}.`, FailedSqlTransactionError);
+    super(`Postgres aborted the ${txnName} transaction of Workflow ${workflowUUID}.`, FailedSqlTransactionError);
   }
 }

--- a/src/user_database.ts
+++ b/src/user_database.ts
@@ -23,6 +23,8 @@ export interface UserDatabase {
   isRetriableTransactionError(error: unknown): boolean;
   // Is a database error caused by a key conflict (key constraint violation or serialization error)?
   isKeyConflictError(error: unknown): boolean;
+  // Is the database error caused by a failed or aported transaciton?
+  isFailedSqlTransactionError(error: unknown): boolean;
 
   // Not all databases support this, TypeORM can.
   // Drop the user database tables (for testing)
@@ -164,6 +166,13 @@ export class PGNodeUserDatabase implements UserDatabase {
     return pge === "23505";
   }
 
+  isFailedSqlTransactionError(error: unknown): boolean {
+    if (!(error instanceof PGDatabaseError)) {
+      return false;
+    }
+    return this.getPostgresErrorCode(error) === "25P02";
+  }
+
   async createSchema(): Promise<void> {
     return Promise.reject(new Error("createSchema() is not supported in PG user database."));
   }
@@ -268,8 +277,11 @@ export class PrismaUserDatabase implements UserDatabase {
   }
 
   isKeyConflictError(error: unknown): boolean {
-    const pge = this.getPostgresErrorCode(error);
-    return pge === "23505";
+    return this.getPostgresErrorCode(error) === "23505";
+  }
+
+  isFailedSqlTransactionError(error: unknown): boolean {
+    return this.getPostgresErrorCode(error) === "25P02";
   }
 
   async createSchema(): Promise<void> {
@@ -385,8 +397,11 @@ export class TypeORMDatabase implements UserDatabase {
   }
 
   isKeyConflictError(error: unknown): boolean {
-    const pge = this.getPostgresErrorCode(error);
-    return pge === "23505";
+    return this.getPostgresErrorCode(error) === "23505";
+  }
+
+  isFailedSqlTransactionError(error: unknown): boolean {
+    return this.getPostgresErrorCode(error) === "25P02";
   }
 
   async createSchema(): Promise<void> {
@@ -482,8 +497,11 @@ export class KnexUserDatabase implements UserDatabase {
   }
 
   isKeyConflictError(error: unknown): boolean {
-    const pge = this.getPostgresErrorCode(error);
-    return pge === "23505";
+    return this.getPostgresErrorCode(error) === "23505";
+  }
+
+  isFailedSqlTransactionError(error: unknown): boolean {
+    return this.getPostgresErrorCode(error) === "25P02";
   }
 
   async createSchema(): Promise<void> {
@@ -590,8 +608,11 @@ export class DrizzleUserDatabase implements UserDatabase {
   }
 
   isKeyConflictError(error: unknown): boolean {
-    const pge = this.getPostgresErrorCode(error);
-    return pge === "23505";
+    return this.getPostgresErrorCode(error) === "23505";
+  }
+
+  isFailedSqlTransactionError(error: unknown): boolean {
+    return this.getPostgresErrorCode(error) === "25P02";
   }
 
   async createSchema(): Promise<void> {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -708,7 +708,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
             this.resultBuffer.clear();
           } catch (error) {
             if (this.#dbosExec.userDatabase.isFailedSqlTransactionError(error)) {
-              this.logger.error(`Postgres aborted the ${txn.name} @Transaction of Workflow ${workflowUUID}, but the function did not raise an exception. Please ensure that if a transaction aborts from an exception, that exception is allowed to escape the @Transaction method.`);
+              this.logger.error(`Postgres aborted the ${txn.name} @Transaction of Workflow ${workflowUUID}, but the function did not raise an exception.  Please ensure that the @Transaction method raises an exception if the database transaction is aborted.`);
               throw new DBOSFailedSqlTransactionError(workflowUUID, txn.name)
             } else {
               throw error;

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -708,7 +708,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
             this.resultBuffer.clear();
           } catch (error) {
             if (this.#dbosExec.userDatabase.isFailedSqlTransactionError(error)) {
-              this.logger.error(`Postgres aborted the ${txn.name} transaction of Workflow ${workflowUUID}. Something, such as a stored procedure, in the database caused the transaction to abort.`);
+              this.logger.error(`Postgres aborted the ${txn.name} @Transaction of Workflow ${workflowUUID}, but the function did not raise an exception. Please ensure that if a transaction aborts from an exception, that exception is allowed to escape the @Transaction method.`);
               throw new DBOSFailedSqlTransactionError(workflowUUID, txn.name)
             } else {
               throw error;

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -691,6 +691,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
             this.resultBuffer.clear();
           } catch (error) {
             if (this.#dbosExec.userDatabase.isFailedSqlTransactionError(error)) {
+              this.logger.error(`Postgres aborted the ${txn.name} transaction of Workflow ${workflowUUID}. Something, such as a stored procedure, in the database caused the transaction to abort.`);
               throw new DBOSFailedSqlTransactionError(workflowUUID, txn.name)
             } else {
               throw error;


### PR DESCRIPTION
If a `@Transaction` method invokes a user-authored stored procedure that raises an exception, the db transaction is aborted even if the exception is caught in the `@Transaction` method. If the exception is caught and handled in the `@transaction` method, DBOS will fail when it attempts to write the `@Transaction` method return value to the `transaction_outputs` table because the associated db transaction has been aborted. This PR creates a DBOS specific error to throw in this situation. 

Fixes #626