### PR TITLE
Configurable admin server port

### DIFF
--- a/dbos-config.schema.json
+++ b/dbos-config.schema.json
@@ -136,11 +136,12 @@
           }
         },
         "port": {
-          "type": "number"
+          "type": "number",
+          "description": "The port number of the application server (Default: 3000)"
         },
         "admin_port": {
             "type": "number",
-            "description": "The port number of the admin server (Default: 3001)"
+            "description": "The port number of the admin server (Default: 3001 or the app server port + 1)"
         }
       }
     },

--- a/dbos-config.schema.json
+++ b/dbos-config.schema.json
@@ -137,6 +137,10 @@
         },
         "port": {
           "type": "number"
+        },
+        "admin_port": {
+            "type": "number",
+            "description": "The port number of the admin server (Default: 3001)"
         }
       }
     },

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -239,9 +239,11 @@ export function parseConfigFile(cliOptions?: ParseOptions, useProxy: boolean = f
     entrypoints.add(defaultEntryPoint);
   }
 
+  const appPort = Number(cliOptions?.port) || Number(configFile.runtimeConfig?.port) || 3000;
   const runtimeConfig: DBOSRuntimeConfig = {
     entrypoints: [...entrypoints],
-    port: Number(cliOptions?.port) || Number(configFile.runtimeConfig?.port) || 3000,
+    port: appPort,
+    admin_port: Number(configFile.runtimeConfig?.admin_port) || appPort + 1,
   };
 
   return [dbosConfig, runtimeConfig];

--- a/src/dbos-runtime/runtime.ts
+++ b/src/dbos-runtime/runtime.ts
@@ -18,6 +18,7 @@ interface ModuleExports {
 export interface DBOSRuntimeConfig {
   entrypoints: string[];
   port: number;
+  admin_port: number;
 }
 export const defaultEntryPoint = "dist/operations.js";
 
@@ -50,7 +51,7 @@ export class DBOSRuntime {
       await DBOSRuntime.loadClasses(this.runtimeConfig.entrypoints);
       await this.dbosExec.init();
       const server = new DBOSHttpServer(this.dbosExec);
-      this.servers = await server.listen(this.runtimeConfig.port);
+      this.servers = await server.listen(this.runtimeConfig.port, this.runtimeConfig.admin_port);
       this.dbosExec.logRegisteredHTTPUrls();
 
       this.scheduler = new DBOSScheduler(this.dbosExec);

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -64,7 +64,7 @@ export class DBOSHttpServer {
    * Register HTTP endpoints and attach to the app. Then start the server at the given port.
    * @param port
    */
-  async listen(port: number) {
+  async listen(port: number, adminPort: number) {
     try {
       await this.checkPortAvailability(port, "127.0.0.1");
     } catch (error) {
@@ -93,7 +93,6 @@ export class DBOSHttpServer {
       this.logger.info(`DBOS Server is running at http://localhost:${port}`);
     });
 
-    const adminPort = port + 1
     const adminServer = this.adminApp.listen(adminPort, () => {
       this.logger.info(`DBOS Admin Server is running at http://localhost:${adminPort}`);
     });

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -85,6 +85,7 @@ describe("dbos-config", () => {
           - a
           - b
           - b
+        admin_port: 2345
       `;
       jest.spyOn(utils, "readFileSync").mockReturnValue(mockDBOSConfigWithEntryPoints);
 
@@ -92,6 +93,7 @@ describe("dbos-config", () => {
 
       expect(runtimeConfig).toBeDefined();
       expect(runtimeConfig?.port).toBe(1234);
+      expect(runtimeConfig?.admin_port).toBe(2345);
       expect(runtimeConfig.entrypoints).toBeDefined();
       expect(runtimeConfig.entrypoints).toBeInstanceOf(Array);
       expect(runtimeConfig.entrypoints).toHaveLength(2);


### PR DESCRIPTION
Now you can specify the admin_port field under runtimeConfig in the dbos-config.yaml file.

Added a test to make sure we can specify a different port.