### PR TITLE
 Simplify Database Configuration

### DIFF
--- a/dbos-config.schema.json
+++ b/dbos-config.schema.json
@@ -87,8 +87,7 @@
         "hostname",
         "port",
         "username",
-        "password",
-        "app_db_name"
+        "password"
       ]
     },
     "telemetry": {

--- a/packages/create/init.ts
+++ b/packages/create/init.ts
@@ -4,14 +4,12 @@ import fs from 'fs'
 import { execSync } from 'child_process'
 import validator from 'validator';
 import { fileURLToPath } from 'url';
-import YAML from "yaml";
 
 interface CopyOption {
   rename?: (basename: string) => string;
 }
 
 const identity = (x: string) => x;
-const dbosConfigFilePath = "dbos-config.yaml";
 
 export const copy = async (
   src: string,
@@ -55,7 +53,7 @@ function isValidApplicationName(appName: string): boolean {
 }
 
 const filesAllowedInEmpty = ['.gitignore', 'readme.md'];
-const pathPrefixesAllowedInEmpty = ['.']; // Directories that start with 
+const pathPrefixesAllowedInEmpty = ['.']; // Directories that start with
 
 function dirHasStuffInIt(pathName: string): boolean {
   if (!fs.existsSync(pathName)) {
@@ -100,27 +98,6 @@ function mergeGitIgnore(existingGISet: Set<string>, templateGISet: Set<string>):
     return joined.replaceAll('\n#','\n\n#');
 }
 
-function updateAppConfig(configFilePath: string, appName: string): void {
-  try {
-    const content = fs.readFileSync(configFilePath, 'utf-8');
-    const configFile = YAML.parseDocument(content);
-
-    // Change the app_db_name field to the sanitized appName, replacing dashes with underscores
-    let appDBName = appName.toLowerCase().replaceAll('-', '_');
-    if (appDBName.match(/^\d/)) {
-      appDBName = "_" + appDBName; // Append an underscore if the name starts with a digit
-    }
-    configFile.setIn(['database', 'app_db_name'], appDBName);
-    fs.writeFileSync(configFilePath, configFile.toString());
-  } catch (e) {
-    if (e instanceof Error) {
-      throw new Error(`Failed to load config from ${configFilePath}: ${e.message}`);
-    } else {
-      throw e;
-    }
-  }
-}
-
 function mergeGitignoreFiles(existingFilePath: string, templateFilePath: string, outputFilePath: string): void {
     const existingSet = loadGitignoreFile(existingFilePath);
     const templateSet = loadGitignoreFile(templateFilePath);
@@ -157,6 +134,5 @@ export async function init(appName: string, templateName: string) {
   execSync("npm install --no-fund --save @dbos-inc/dbos-sdk@latest --loglevel=error", {cwd: appName, stdio: 'inherit'})
   execSync("npm i --no-fund --loglevel=error", {cwd: appName, stdio: 'inherit'})
   execSync("npm install --no-fund --save-dev @dbos-inc/dbos-cloud@latest", {cwd: appName, stdio: 'inherit'})
-  updateAppConfig(path.join(appName, dbosConfigFilePath), appName);
   console.log("Application initialized successfully!")
 }

--- a/packages/create/templates/hello-drizzle/dbos-config.yaml
+++ b/packages/create/templates/hello-drizzle/dbos-config.yaml
@@ -9,7 +9,6 @@ database:
   port: 5432
   username: postgres
   password: ${PGPASSWORD}
-  app_db_name: hello_drizzle
   connectionTimeoutMillis: 3000
   app_db_client: drizzle
   migrate:

--- a/packages/create/templates/hello-prisma/dbos-config.yaml
+++ b/packages/create/templates/hello-prisma/dbos-config.yaml
@@ -8,7 +8,6 @@ database:
   hostname: 'localhost'
   port: 5432
   username: 'postgres'
-  app_db_name: 'hello_prisma'
   password: ${PGPASSWORD}
   connectionTimeoutMillis: 3000
   app_db_client: prisma

--- a/packages/create/templates/hello-typeorm/dbos-config.yaml
+++ b/packages/create/templates/hello-typeorm/dbos-config.yaml
@@ -8,7 +8,6 @@ database:
   hostname: 'localhost'
   port: 5432
   username: 'postgres'
-  app_db_name: 'hello_typeorm'
   password: ${PGPASSWORD}
   connectionTimeoutMillis: 3000
   app_db_client: typeorm

--- a/packages/create/templates/hello/dbos-config.yaml
+++ b/packages/create/templates/hello/dbos-config.yaml
@@ -9,7 +9,6 @@ database:
   port: 5432
   username: postgres
   password: ${PGPASSWORD}
-  app_db_name: hello
   connectionTimeoutMillis: 3000
   app_db_client: knex
   migrate:

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -139,7 +139,6 @@ export async function deployAppCode(
     if (userDBName === "") {
       return 1;
     }
-    logger.info(`Loaded application database name from ${dbosConfigFilePath}: ${dbosConfig.database.app_db_name}`);
 
     // Register the app
     if (enableTimeTravel) {
@@ -158,7 +157,7 @@ export async function deployAppCode(
     }
 
     // Make sure the app database is the same.
-    if (appRegistered.ApplicationDatabaseName && (dbosConfig.database.app_db_name !== appRegistered.ApplicationDatabaseName)) {
+    if (appRegistered.ApplicationDatabaseName && dbosConfig.database.app_db_name && (dbosConfig.database.app_db_name !== appRegistered.ApplicationDatabaseName)) {
       logger.error(`Application ${chalk.bold(appName)} is deployed with app_db_name ${chalk.bold(appRegistered.ApplicationDatabaseName)}, but ${dbosConfigFilePath} specifies ${chalk.bold(dbosConfig.database.app_db_name)}. Please update the app_db_name field in ${dbosConfigFilePath} to match the database name.`);
       return 1;
     }

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -216,15 +216,15 @@ export function parseConfigFile(cliOptions?: ParseOptions, useProxy: boolean = f
     throw new DBOSInitializationError(`${configFilePath} specifies invalid language ${configFile.language}`)
   }
 
-  if (!isValidDBname(configFile.database.app_db_name)) {
-    throw new DBOSInitializationError(`${configFilePath} specifies invalid app_db_name ${configFile.database.app_db_name}. Must be between 3 and 31 characters long and contain only lowercase letters, underscores, and digits (cannot begin with a digit).`);
-  }
-
   /*******************************/
   /* Handle user database config */
   /*******************************/
 
   const poolConfig = constructPoolConfig(configFile);
+
+  if (!isValidDBname(poolConfig.database!)) {
+    throw new DBOSInitializationError(`${configFilePath} specifies invalid app_db_name ${configFile.database.app_db_name}. Must be between 3 and 31 characters long and contain only lowercase letters, underscores, and digits (cannot begin with a digit).`);
+  }
 
   /***************************/
   /* Handle telemetry config */

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -247,6 +247,22 @@ describe("dbos-config", () => {
       expect(dbosConfig.poolConfig.ssl).toEqual({ rejectUnauthorized: false });
     });
 
+    test("config works without app_db_name", async () => {
+      const localMockDBOSConfigYamlString = `
+        name: some-app
+        database:
+          hostname: 'localhost'
+          port: 1234
+          username: 'some user'
+          password: \${PGPASSWORD}
+      `;
+      jest.restoreAllMocks();
+      jest.spyOn(utils, "readFileSync").mockReturnValue(localMockDBOSConfigYamlString);
+      const [dbosConfig, _dbosRuntimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(mockCLIOptions);
+      const poolConfig = dbosConfig.poolConfig;
+      expect(poolConfig.database).toBe("some_app");
+    });
+
 
     test("local_suffix works", async () => {
       const localMockDBOSConfigYamlString = `
@@ -272,6 +288,22 @@ describe("dbos-config", () => {
       expect(dbosConfig.poolConfig.ssl).toBe(false);
     });
 
+    test("local_suffix works without app_db_name", async () => {
+      const localMockDBOSConfigYamlString = `
+        name: some-app
+        database:
+          hostname: 'localhost'
+          port: 1234
+          username: 'some user'
+          password: \${PGPASSWORD}
+          local_suffix: true
+      `;
+      jest.restoreAllMocks();
+      jest.spyOn(utils, "readFileSync").mockReturnValue(localMockDBOSConfigYamlString);
+      const [dbosConfig, _dbosRuntimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(mockCLIOptions);
+      const poolConfig = dbosConfig.poolConfig;
+      expect(poolConfig.database).toBe("some_app_local");
+    });
 
     test("ssl defaults off for localhost", async () => {
       const localMockDBOSConfigYamlString = `

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -129,10 +129,9 @@ describe("dbos-config", () => {
       process.env.PGPASSWORD = dbPassword;
     });
 
-    test("config file is missing app database name", () => {
+    test("config file is missing hostname", () => {
       const localMockDBOSConfigYamlString = `
         database:
-          hostname: 'some host'
           port: 1234
           username: 'some user'
           password: \${PGPASSWORD}

--- a/tests/dbos-runtime/runtime.test.ts
+++ b/tests/dbos-runtime/runtime.test.ts
@@ -102,7 +102,6 @@ database:
   port: 5432
   username: 'postgres'
   password: \${PGPASSWORD}
-  app_db_name: 'hello'
   connectionTimeoutMillis: 3000
   app_db_client: 'knex'
 runtimeConfig:
@@ -176,7 +175,6 @@ database:
   port: 5432
   username: 'postgres'
   password: \${PGPASSWORD}
-  app_db_name: 'hello'
   connectionTimeoutMillis: 3000
   app_db_client: 'knex'
 runtimeConfig:


### PR DESCRIPTION
Make `app_db_name` optional and remove it from the template. If it's not specified, use the app name (suitably transformed) as `app_db_name`.