### PR TITLE
Cloud CLI Supabase Support

### DIFF
--- a/packages/dbos-cloud/applications/types.ts
+++ b/packages/dbos-cloud/applications/types.ts
@@ -38,4 +38,6 @@ export interface UserDBInstance {
   readonly HostName: string;
   readonly Port: number;
   readonly DatabaseUsername: string;
+  readonly IsLinked: boolean;
+  readonly SupabaseReference: string | null;
 }

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -260,9 +260,6 @@ databaseCommands
   .argument("[name]", "database instance name")
   .option("-W, --password <string>", "Specify the database user password")
   .action(async (dbName: string | undefined, options: { password: string }) => {
-    if (!options.password) {
-      options.password = prompt("Database Password (must contain at least 8 characters): ", { echo: "*" });
-    }
     const exitCode = await resetDBCredentials(DBOSCloudHost, dbName, options.password);
     process.exit(exitCode);
   });

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -319,9 +319,6 @@ databaseCommands
   .argument("[name]", "database instance name")
   .option("-W, --password <string>", "Specify the database user password")
   .action(async (dbname: string | undefined, options: { password: string | undefined }) => {
-    if (!options.password) {
-      options.password = prompt("Database Password (must contain at least 8 characters): ", { echo: "*" });
-    }
     const exitCode = await connect(DBOSCloudHost, dbname, options.password, false);
     process.exit(exitCode);
   });
@@ -332,9 +329,6 @@ databaseCommands
   .argument("[name]", "database instance name")
   .option("-W, --password <string>", "Specify the database user password")
   .action(async (dbname: string | undefined, options: { password: string | undefined }) => {
-    if (!options.password) {
-      options.password = prompt("Database Password (must contain at least 8 characters): ", { echo: "*" });
-    }
     const exitCode = await connect(DBOSCloudHost, dbname, options.password, true);
     process.exit(exitCode);
   });

--- a/packages/dbos-cloud/databases/databases.ts
+++ b/packages/dbos-cloud/databases/databases.ts
@@ -359,17 +359,20 @@ export async function connect(host: string, dbName: string | undefined, password
 
     logger.info("Retrieving cloud database info...");
     const userDBInfo = await getUserDBInfo(host, dbName, userCredentials);
+
+    const databaseUsername = userDBInfo.SupabaseReference === null ? userDBInfo.DatabaseUsername : `postgres.${userDBInfo.SupabaseReference}`
+
     console.log(`Postgres Instance Name: ${userDBInfo.PostgresInstanceName}`);
     console.log(`Host Name: ${userDBInfo.HostName}`);
     console.log(`Port: ${userDBInfo.Port}`);
-    console.log(`Database Username: ${userDBInfo.DatabaseUsername}`);
+    console.log(`Database Username: ${databaseUsername}`);
     console.log(`Status: ${userDBInfo.Status}`);
 
     logger.info(`Loading cloud database connection information into ${dbosConfigFilePath}...`)
     const config: ConfigFile = loadConfigFile(dbosConfigFilePath);
     config.database.hostname = userDBInfo.HostName;
     config.database.port = userDBInfo.Port;
-    config.database.username = userDBInfo.DatabaseUsername;
+    config.database.username = databaseUsername;
     config.database.password = password;
     config.database.local_suffix = local_suffix;
     writeConfigFile(config, dbosConfigFilePath);


### PR DESCRIPTION
- Attempting to reset the password of a linked database gives clearer error messages.
- `db local` works for Supabase.