### PR TITLE
Import Secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ packages/create/templates/**/package-lock.json
 tests/**/package-lock.json
 packages/**/package-lock.json
 .DS_Store
+.env
 
 # Logs
 logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -6268,8 +6268,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.5",
-      "dev": true,
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -12602,6 +12603,7 @@
         "axios": "^1.7.4",
         "chalk": "4.1.2",
         "commander": "^12.0.0",
+        "dotenv": "^16.4.7",
         "fast-glob": "^3.3.2",
         "jsonwebtoken": "^9.0.2",
         "jszip": "^3.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6279,6 +6279,21 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.1.tgz",
+      "integrity": "sha512-LaKRbou8gt0RNID/9RoI+J2rvXsBRPMV7p+ElHlPhcSARbCPDYcYG2s1TIzAfWv4YSgyY5taidWzzs31lNV3yQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/drizzle-orm": {
       "version": "0.32.2",
       "dev": true,
@@ -12604,6 +12619,7 @@
         "chalk": "4.1.2",
         "commander": "^12.0.0",
         "dotenv": "^16.4.7",
+        "dotenv-expand": "^12.0.1",
         "fast-glob": "^3.3.2",
         "jsonwebtoken": "^9.0.2",
         "jszip": "^3.10.1",

--- a/packages/dbos-cloud/applications/secrets.ts
+++ b/packages/dbos-cloud/applications/secrets.ts
@@ -79,7 +79,8 @@ export async function importSecrets(host: string, appName: string | undefined, e
 
   const envConfig = readFileSync(envPath, 'utf-8');
 
-  // Parse the content using dotenv
+  // Parse the content using dotenv and expand it to support interpolation.
+  // Supported syntax guide: https://dotenvx.com/docs/env-file
   const parsed = dotenv.parse(envConfig);
   const expandedEnv = { ...process.env } as DotenvPopulateInput;
   const options = {

--- a/packages/dbos-cloud/applications/secrets.ts
+++ b/packages/dbos-cloud/applications/secrets.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosError } from "axios";
-import dotenv, { DotenvParseOutput, DotenvPopulateInput } from 'dotenv';
+import dotenv, { DotenvPopulateInput } from 'dotenv';
 import dotenvExpand from 'dotenv-expand'
 import { handleAPIErrors, getCloudCredentials, getLogger, isCloudAPIErrorResponse, retrieveApplicationName, DBOSCloudCredentials} from "../cloudutils.js";
 import { readFileSync } from "fs";

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -215,14 +215,14 @@ applicationCommands
     process.exit(exitCode);
   });
 
-  const secretsCommands = applicationCommands.command("secret").alias("secrets").alias("sec").description("manage secrets for your application");
+  const secretsCommands = applicationCommands.command("env").alias("secrets").alias("sec").alias("secret").description("Manage your application environment and secrets");
 
   secretsCommands
   .command("create")
-  .description("Create a secret for this application")
+  .description("Create an environment variable for this application")
   .argument("[string]", "application name (Default: name from package.json)")
-  .requiredOption("-s, --secretname <string>", "Specify the name of the secret to create")
-  .requiredOption("-v, --value <string>", "Specify the value of the secret to store with the name.")
+  .requiredOption("-s, --name <string>", "Specify the name of the environment variable to create")
+  .requiredOption("-v, --value <string>", "Specify the value of the variable.")
   .action(async (appName: string | undefined, options: { secretname: string; value: string }) => {
     const exitCode = await createSecret(DBOSCloudHost, appName, options.secretname , options.value);
     process.exit(exitCode);
@@ -230,7 +230,7 @@ applicationCommands
 
   secretsCommands
   .command("import")
-  .description("Import secrets from a dotenv file")
+  .description("Import environment variables from a dotenv file")
   .argument("[string]", "application name (Default: name from package.json)")
   .requiredOption("-d, --dotenv <string>", "Path to a dotenv file")
   .action(async (appName: string | undefined, options: { dotenv: string; }) => {
@@ -240,7 +240,7 @@ applicationCommands
 
   secretsCommands
   .command("list")
-  .description("List secrets for this application")
+  .description("List environment variables for this application")
   .argument("[string]", "application name (Default: name from package.json)")
   .option("--json", "Emit JSON output")
   .action(async (appName: string | undefined, options: { json: boolean }) => {

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -19,6 +19,7 @@ import { revokeRefreshToken } from "./users/authentication.js";
 import { listAppVersions } from "./applications/list-app-versions.js";
 import { orgInvite, orgListUsers, renameOrganization, joinOrganization } from "./organizations/organization.js";
 import { ListWorkflowsInput, listWorkflows } from "./applications/manage-workflows.js";
+import { importSecrets } from "./applications/secrets.js";
 
 // Read local package.json
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
@@ -224,6 +225,16 @@ applicationCommands
   .requiredOption("-v, --value <string>", "Specify the value of the secret to store with the name.")
   .action(async (appName: string | undefined, options: { secretname: string; value: string }) => {
     const exitCode = await createSecret(DBOSCloudHost, appName, options.secretname , options.value);
+    process.exit(exitCode);
+  });
+
+  secretsCommands
+  .command("import")
+  .description("Import secrets from a dotenv file")
+  .argument("[string]", "application name (Default: name from package.json)")
+  .requiredOption("-d, --dotenv <string>", "Path to a dotenv file")
+  .action(async (appName: string | undefined, options: { dotenv: string; }) => {
+    const exitCode = await importSecrets(DBOSCloudHost, appName, options.dotenv);
     process.exit(exitCode);
   });
 

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -215,14 +215,14 @@ applicationCommands
     process.exit(exitCode);
   });
 
-  const secretsCommands = applicationCommands.command("env").alias("secrets").alias("sec").alias("secret").description("Manage your application environment and secrets");
+  const secretsCommands = applicationCommands.command("secret").alias("secrets").alias("sec").alias("env").description("Manage your application environment and secrets");
 
   secretsCommands
   .command("create")
-  .description("Create an environment variable for this application")
+  .description("Create a secret for this application")
   .argument("[string]", "application name (Default: name from package.json)")
-  .requiredOption("-s, --name <string>", "Specify the name of the environment variable to create")
-  .requiredOption("-v, --value <string>", "Specify the value of the variable.")
+  .requiredOption("-s, --name <string>", "Specify the name of the secret to create")
+  .requiredOption("-v, --value <string>", "Specify the value of the secret.")
   .action(async (appName: string | undefined, options: { secretname: string; value: string }) => {
     const exitCode = await createSecret(DBOSCloudHost, appName, options.secretname , options.value);
     process.exit(exitCode);
@@ -230,7 +230,7 @@ applicationCommands
 
   secretsCommands
   .command("import")
-  .description("Import environment variables from a dotenv file")
+  .description("Import environment variables and secrets from a dotenv file")
   .argument("[string]", "application name (Default: name from package.json)")
   .requiredOption("-d, --dotenv <string>", "Path to a dotenv file")
   .action(async (appName: string | undefined, options: { dotenv: string; }) => {
@@ -240,7 +240,7 @@ applicationCommands
 
   secretsCommands
   .command("list")
-  .description("List environment variables for this application")
+  .description("List secrets for this application")
   .argument("[string]", "application name (Default: name from package.json)")
   .option("--json", "Emit JSON output")
   .action(async (appName: string | undefined, options: { json: boolean }) => {

--- a/packages/dbos-cloud/package.json
+++ b/packages/dbos-cloud/package.json
@@ -29,6 +29,7 @@
     "axios": "^1.7.4",
     "chalk": "4.1.2",
     "commander": "^12.0.0",
+    "dotenv": "^16.4.7",
     "fast-glob": "^3.3.2",
     "jsonwebtoken": "^9.0.2",
     "jszip": "^3.10.1",

--- a/packages/dbos-cloud/package.json
+++ b/packages/dbos-cloud/package.json
@@ -30,6 +30,7 @@
     "chalk": "4.1.2",
     "commander": "^12.0.0",
     "dotenv": "^16.4.7",
+    "dotenv-expand": "^12.0.1",
     "fast-glob": "^3.3.2",
     "jsonwebtoken": "^9.0.2",
     "jszip": "^3.10.1",


### PR DESCRIPTION
Support for importing secrets from a dotenv file. All environment variables in the file will be imported as DBOS Cloud secrets and made available as environment variables to the deployed application. Aim is to simplify environment management. Import a file with:

```shell
dbos-cloud app secrets import -d .env
```

Supported dotenv file syntax: https://dotenvx.com/docs/env-file