### PR TITLE
dbos compiler support for v2 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2133,55 +2133,8 @@
       "link": true
     },
     "node_modules/@dbos-inc/dbos-sdk": {
-      "version": "1.24.15",
-      "resolved": "https://registry.npmjs.org/@dbos-inc/dbos-sdk/-/dbos-sdk-1.24.15.tgz",
-      "integrity": "sha512-LRd90BwVb+P7qE0pxk326wgFwR7ey6UjiXy+5cLKitqirAo+GUKpMamedudjoxk5aPERhX+pQdbp6pcOiyCo3g==",
-      "peer": true,
-      "workspaces": [
-        "packages/*"
-      ],
-      "dependencies": {
-        "@inquirer/prompts": "^5.3.8",
-        "@koa/bodyparser": "5.0.0",
-        "@koa/cors": "5.0.0",
-        "@koa/router": "13.1.0",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/exporter-logs-otlp-proto": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-logs": "0.49.1",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
-        "ajv": "8.13.0",
-        "commander": "12.0.0",
-        "kafkajs": "^2.2.4",
-        "knex": "3.1.0",
-        "koa": "^2.15.0",
-        "lodash": "4.17.21",
-        "openapi-types": "12.1.3",
-        "pg": "8.11.3",
-        "pg-protocol": "^1.6.1",
-        "reflect-metadata": "^0.2.2",
-        "serialize-error": "8.1.0",
-        "uuid": "9.0.1",
-        "validator": "^13.12.0",
-        "winston": "3.12.0",
-        "winston-transport": "4.7.0",
-        "yaml": "2.4.1"
-      },
-      "bin": {
-        "dbos": "dist/src/dbos-runtime/cli.js",
-        "dbos-sdk": "dist/src/dbos-runtime/cli.js"
-      },
-      "optionalDependencies": {
-        "foundationdb": "^2.0.1"
-      },
-      "peerDependencies": {
-        "@types/koa": "^2.15.0",
-        "koa": "^2.15.0"
-      }
+      "resolved": ".",
+      "link": true
     },
     "node_modules/@dbos-inc/dbos-sqs": {
       "resolved": "packages/dbos-sqs",

--- a/packages/dbos-compiler/compiler.ts
+++ b/packages/dbos-compiler/compiler.ts
@@ -1,4 +1,3 @@
-import { UndefinedVariableError } from 'liquidjs';
 import tsm from 'ts-morph';
 
 export type CompileResult = {
@@ -330,7 +329,7 @@ function isValid<T>(value: T | null | undefined): value is T { return !!value; }
 
 type DbosDecoratorKind = "handler" | "storedProcedure" | "transaction" | "workflow" | "step" | "initializer";
 
-function getImportSpecifier(node: tsm.Identifier | undefined): tsm.ImportSpecifier | undefined {
+export function getImportSpecifier(node: tsm.Identifier | undefined): tsm.ImportSpecifier | undefined {
   const symbol = node?.getSymbol();
   if (symbol) {
     const importSpecifiers = symbol.getDeclarations()

--- a/packages/dbos-compiler/compiler.ts
+++ b/packages/dbos-compiler/compiler.ts
@@ -265,7 +265,7 @@ export function removeDecorators(file: tsm.SourceFile | tsm.Project) {
 }
 
 export function removeUnusedFiles(project: tsm.Project) {
-  // get the files w/ one or more @Transaction functions
+  // get the files w/ one or more @StoredProc functions
   const procFiles = new Set<tsm.SourceFile>();
   for (const file of project.getSourceFiles()) {
     const procMethods = getProcMethods(file);
@@ -274,7 +274,7 @@ export function removeUnusedFiles(project: tsm.Project) {
     }
   }
 
-  // get all the files that are imported by the txFiles
+  // get all the files that are imported by the procFiles
   const procImports = new Set<tsm.SourceFile>();
   for (const file of procFiles) {
     procImports.add(file);

--- a/packages/dbos-compiler/compiler.ts
+++ b/packages/dbos-compiler/compiler.ts
@@ -1,3 +1,4 @@
+import { UndefinedVariableError } from 'liquidjs';
 import tsm from 'ts-morph';
 
 export type CompileResult = {
@@ -150,7 +151,7 @@ export function removeDbosMethods(file: tsm.SourceFile) {
         const kind = getDbosMethodKind(method);
         switch (kind) {
           case 'workflow':
-          case 'communicator':
+          case 'step':
           case 'initializer':
           case 'transaction':
           case 'handler': {
@@ -327,42 +328,111 @@ function deAsync(project: tsm.Project) {
 // https://devblogs.microsoft.com/typescript/announcing-typescript-5-5-beta/#inferred-type-predicates
 function isValid<T>(value: T | null | undefined): value is T { return !!value; }
 
-export interface DecoratorInfo {
-  name: string;
-  alias?: string;
-  module?: string;
-  args: tsm.Node[] | undefined;
-}
+type DbosDecoratorKind = "handler" | "storedProcedure" | "transaction" | "workflow" | "step" | "initializer";
 
-// helper function to get the actual name (along with any alias) and module of a decorator
-// from its import declaration
-export function getDecoratorInfo(node: tsm.Decorator): DecoratorInfo {
-  const isFactory = node.isDecoratorFactory();
-
-  const identifier = isFactory
-    ? node.getCallExpression()?.getExpressionIfKind(tsm.SyntaxKind.Identifier)
-    : node.getExpressionIfKind(tsm.SyntaxKind.Identifier);
-
-  const args = isFactory
-    ? node.getCallExpression()?.getArguments()
-    : undefined;
-
-  const symbol = identifier?.getSymbol();
+function getImportSpecifier(node: tsm.Identifier | undefined): tsm.ImportSpecifier | undefined {
+  const symbol = node?.getSymbol();
   if (symbol) {
     const importSpecifiers = symbol.getDeclarations()
       .map(n => n.asKind(tsm.ts.SyntaxKind.ImportSpecifier))
       .filter(isValid);
 
-    if (importSpecifiers.length === 1) {
-      const { name, alias } = importSpecifiers[0].getStructure();
-      const modSpec = importSpecifiers[0].getImportDeclaration().getModuleSpecifier();
-      return { name, alias, module: modSpec.getLiteralText(), args };
-    }
-
+    if (importSpecifiers.length === 1) { return importSpecifiers[0]; }
     if (importSpecifiers.length > 1) { throw new Error("Too many import specifiers"); }
   }
 
-  return { name: node.getName(), args };
+  return undefined;
+}
+
+function isDbosImport(node: tsm.ImportSpecifier ): boolean {
+  const modSpec = node.getImportDeclaration().getModuleSpecifier();
+  return modSpec.getLiteralText() === "@dbos-inc/dbos-sdk";
+}
+
+function getDbosDecoratorKind(node: tsm.Decorator): DbosDecoratorKind | undefined {
+  if (!node.isDecoratorFactory()) { return undefined; }
+
+  const expr = node.getCallExpressionOrThrow().getExpression();
+
+  // v1 decorators single identifiers i.e. such as @Workflow()
+  if (tsm.Node.isIdentifier(expr)) {
+    const impSpec = getImportSpecifier(expr);
+    if (impSpec && isDbosImport(impSpec)) {
+      const { name } = impSpec.getStructure();
+      switch (name) {
+        case "GetApi":
+        case "PostApi":
+        case "PutApi":
+        case "PatchApi":
+        case "DeleteApi":
+          return "handler";
+        case "StoredProcedure": return "storedProcedure";
+        case "Transaction": return "transaction";
+        case "Workflow": return "workflow";
+        case "Communicator":
+        case "Step": 
+          return "step";
+        case "DBOSInitializer":
+        case "DBOSDeploy":
+          return "initializer";
+      }
+    }
+  }
+
+  // v2 decorators property access expressions i.e. such as @DBOS.workflow()
+  if (tsm.Node.isPropertyAccessExpression(expr)) {
+    const impSpec = getImportSpecifier(expr.getExpressionIfKind(tsm.SyntaxKind.Identifier));
+    if (impSpec && isDbosImport(impSpec)) {
+      const { name } = impSpec.getStructure();
+      if (name === "DBOS") { 
+        switch (expr.getName()) {
+          case "getApi":
+          case "postApi":
+          case "putApi":
+          case "patchApi":
+          case "deleteApi":
+            return "handler";
+          case "workflow": return "workflow";
+          case "transaction": return "transaction";
+          case "step": return "step";
+          case "storedProcedure": return "storedProcedure";
+        }
+      }
+    }
+  }
+
+  return undefined;
+}
+
+// helper function to determine the kind of DBOS method
+export function getDbosMethodKind(node: tsm.MethodDeclaration): DbosDecoratorKind | undefined {
+  // Note, other DBOS method decorators (Scheduled, KafkaConsume, RequiredRole) modify runtime behavior
+  //       of DBOS methods, but are not their own unique kind.
+  //       Get/PostApi decorators are atypical in that they can be used on @Step/@Transaction/@Workflow
+  //       methods as well as on their own.
+  let isHandler = false;
+  for (const decorator of node.getDecorators()) {
+    const kind = getDbosDecoratorKind(decorator);
+    switch (kind) {
+      case "storedProcedure":
+      case "transaction":
+      case "workflow":
+      case "step":
+      case "initializer":
+        return kind;
+      case "handler":
+        isHandler = true;
+        break;
+      case undefined:
+        break;
+      default: {
+        const _never: never = kind;
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        throw new Error(`Unexpected DBOS method kind: ${kind}`);
+      }
+    }
+  }
+  return isHandler ? "handler" : undefined;
 }
 
 export type DecoratorArgument = boolean | string | number | DecoratorArgument[] | Record<string, unknown>;
@@ -400,64 +470,12 @@ export function parseDecoratorArgument(node: tsm.Node): DecoratorArgument {
   }
 }
 
-type DbosDecoratorKind = "handler" | "storedProcedure" | "transaction" | "workflow" | "communicator" | "initializer";
-
-function getDbosDecoratorKind(node: tsm.Decorator | DecoratorInfo): DbosDecoratorKind | undefined {
-  const decoratorInfo = tsm.Node.isNode(node) ? getDecoratorInfo(node) : node;
-  if (!decoratorInfo) { return undefined; }
-  const { name, module } = decoratorInfo;
-  if (module !== "@dbos-inc/dbos-sdk") { return undefined; }
-  switch (name) {
-    case "GetApi":
-    case "PostApi":
-      return "handler";
-    case "StoredProcedure": return "storedProcedure";
-    case "Transaction": return "transaction";
-    case "Workflow": return "workflow";
-    case "Communicator": return "communicator";
-    case "DBOSInitializer":
-    case "DBOSDeploy":
-      return "initializer";
-  }
-}
-
-// helper function to determine the kind of DBOS method
-export function getDbosMethodKind(node: tsm.MethodDeclaration): DbosDecoratorKind | undefined {
-  // Note, other DBOS method decorators (Scheduled, KafkaConsume, RequiredRole) modify runtime behavior
-  //       of DBOS methods, but are not their own unique kind.
-  //       Get/PostApi decorators are atypical in that they can be used on @Step/@Transaction/@Workflow
-  //       methods as well as on their own.
-  let isHandler = false;
-  for (const decorator of node.getDecorators()) {
-    const kind = getDbosDecoratorKind(decorator);
-    switch (kind) {
-      case "storedProcedure":
-      case "transaction":
-      case "workflow":
-      case "communicator":
-      case "initializer":
-        return kind;
-      case "handler":
-        isHandler = true;
-        break;
-      case undefined:
-        break;
-      default: {
-        const _never: never = kind;
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-        throw new Error(`Unexpected DBOS method kind: ${kind}`);
-      }
-    }
-  }
-  return isHandler ? "handler" : undefined;
-}
-
 export function getStoredProcConfig(node: tsm.MethodDeclaration): StoredProcedureConfig {
-  const decorators = node.getDecorators().map(getDecoratorInfo);
+  const decorators = node.getDecorators();
   const procDecorator = decorators.find(d => getDbosDecoratorKind(d) === "storedProcedure");
   if (!procDecorator) { throw new Error("Missing StoredProcedure decorator"); }
 
-  const arg0 = procDecorator.args?.[0];
+  const arg0 = procDecorator.getCallExpression()?.getArguments()[0] ?? undefined;
   const configArg = arg0 ? parseDecoratorArgument(arg0) as Partial<StoredProcedureConfig> : undefined;
   const readOnly = configArg?.readOnly;
   const executeLocally = configArg?.executeLocally;

--- a/packages/dbos-compiler/tests/more-compiler.test.ts
+++ b/packages/dbos-compiler/tests/more-compiler.test.ts
@@ -1,5 +1,5 @@
 import * as tsm from "ts-morph";
-import { DecoratorArgument, DecoratorInfo, getDbosMethodKind, getDecoratorInfo, getStoredProcConfig, parseDecoratorArgument } from "../compiler.js";
+import { DecoratorArgument, getDbosMethodKind, getStoredProcConfig, parseDecoratorArgument } from "../compiler.js";
 import { sampleDbosClass, sampleDbosClassAliased } from "./test-code.js";
 import { makeTestProject } from "./test-utility.js";
 import { describe, it, expect } from 'vitest';
@@ -19,12 +19,15 @@ describe("more compiler", () => {
         const actual = Object.fromEntries(entries);
         const expected = {
             testGetHandler: "handler",
+            testPostHandler: "handler",
+            testDeleteHandler: "handler",
+            testPutHandler: "handler",
+            testPatchHandler: "handler",
             testGetHandlerWorkflow: "workflow",
             testGetHandlerTx: "transaction",
-            testGetHandlerComm: "communicator",
-            testPostHandler: "handler",
+            testGetHandlerComm: "step",
             testWorkflow: "workflow",
-            testCommunicator: "communicator",
+            testCommunicator: "step",
             testTransaction: "transaction",
             testProcedure: "storedProcedure",
             testReadOnlyProcedure: "storedProcedure",
@@ -35,77 +38,83 @@ describe("more compiler", () => {
             testLocalRepeatableReadProcedure: "storedProcedure",
             testLocalConfiguredProcedure: "storedProcedure",
             testDBOSInitializer: "initializer",
-            testDBOSDeploy: "initializer"
+            testDBOSDeploy: "initializer",
+
+            testGetHandler_v2: "handler",
+            testPostHandler_v2: "handler",
+            testDeleteHandler_v2: "handler",
+            testPutHandler_v2: "handler",
+            testPatchHandler_v2: "handler",
         };
         expect(actual).toEqual(expected);
     });
 
-    describe("aliased getDecoratorInfo", () => {
-        it("testGetHandler", () => {
-            const file = aliasProject.getSourceFileOrThrow("operations.ts");
-            const cls = file.getClassOrThrow("Test");
-            const method = cls.getStaticMethodOrThrow("testGetHandler");
-            const decoratorInfo = method.getDecorators().map(getDecoratorInfo);
+    // describe("aliased getDecoratorInfo", () => {
+    //     it("testGetHandler", () => {
+    //         const file = aliasProject.getSourceFileOrThrow("operations.ts");
+    //         const cls = file.getClassOrThrow("Test");
+    //         const method = cls.getStaticMethodOrThrow("testGetHandler");
+    //         const decoratorInfo = method.getDecorators().map(getDecoratorInfo);
 
-            const expected = <TestDecoratorInfo[]>[{
-                name: "GetApi",
-                alias: "TestGetApi",
-                module: "@dbos-inc/dbos-sdk",
-                args: ["/test"]
-            }];
+    //         const expected = <TestDecoratorInfo[]>[{
+    //             name: "GetApi",
+    //             alias: "TestGetApi",
+    //             module: "@dbos-inc/dbos-sdk",
+    //             args: ["/test"]
+    //         }];
 
-            testDecorators(expected, decoratorInfo);
-        });
-    });
+    //         testDecorators(expected, decoratorInfo);
+    //     });
+    // });
 
-    describe("getDecoratorInfo", () => {
-        it("testGetHandler", () => {
-            const method = cls.getStaticMethodOrThrow("testGetHandler");
-            const decoratorInfo = method.getDecorators().map(getDecoratorInfo);
+    // describe("getDecoratorInfo", () => {
+    //     it("testGetHandler", () => {
+    //         const method = cls.getStaticMethodOrThrow("testGetHandler");
+    //         const decoratorInfo = method.getDecorators().map(getDecoratorInfo);
 
-            const expected = <TestDecoratorInfo[]>[{
-                name: "GetApi",
-                alias: undefined,
-                module: "@dbos-inc/dbos-sdk",
-                args: ["/test"]
-            }];
+    //         const expected = <TestDecoratorInfo[]>[{
+    //             name: "GetApi",
+    //             alias: undefined,
+    //             module: "@dbos-inc/dbos-sdk",
+    //             args: ["/test"]
+    //         }];
 
-            testDecorators(expected, decoratorInfo);
-        });
+    //         testDecorators(expected, decoratorInfo);
+    //     });
 
-        it("testGetHandlerWorkflow", () => {
-            const method = cls.getStaticMethodOrThrow("testGetHandlerWorkflow");
-            const decoratorInfo = method.getDecorators().map(getDecoratorInfo);
+    //     it("testGetHandlerWorkflow", () => {
+    //         const method = cls.getStaticMethodOrThrow("testGetHandlerWorkflow");
+    //         const decoratorInfo = method.getDecorators().map(getDecoratorInfo);
 
-            const expected: TestDecoratorInfo[] = [{
-                name: "GetApi",
-                alias: undefined,
-                module: "@dbos-inc/dbos-sdk",
-                args: ["/test"]
-            }, {
-                name: "Workflow",
-                alias: undefined,
-                module: "@dbos-inc/dbos-sdk",
-                args: []
-            }];
+    //         const expected: TestDecoratorInfo[] = [{
+    //             name: "GetApi",
+    //             alias: undefined,
+    //             module: "@dbos-inc/dbos-sdk",
+    //             args: ["/test"]
+    //         }, {
+    //             name: "Workflow",
+    //             alias: undefined,
+    //             module: "@dbos-inc/dbos-sdk",
+    //             args: []
+    //         }];
 
-            testDecorators(expected, decoratorInfo);
-        });
+    //         testDecorators(expected, decoratorInfo);
+    //     });
 
-        it("testConfiguredProcedure", () => {
-            const method = cls.getStaticMethodOrThrow("testConfiguredProcedure");
-            const decoratorInfo = method.getDecorators().map(getDecoratorInfo);
+    //     it("testConfiguredProcedure", () => {
+    //         const method = cls.getStaticMethodOrThrow("testConfiguredProcedure");
+    //         const decoratorInfo = method.getDecorators().map(getDecoratorInfo);
 
-            const expected: TestDecoratorInfo[] = [{
-                name: "StoredProcedure",
-                alias: undefined,
-                module: "@dbos-inc/dbos-sdk",
-                args: [{ readOnly: true, isolationLevel: "READ COMMITTED" }]
-            }];
+    //         const expected: TestDecoratorInfo[] = [{
+    //             name: "StoredProcedure",
+    //             alias: undefined,
+    //             module: "@dbos-inc/dbos-sdk",
+    //             args: [{ readOnly: true, isolationLevel: "READ COMMITTED" }]
+    //         }];
 
-            testDecorators(expected, decoratorInfo);
-        });
-    })
+    //         testDecorators(expected, decoratorInfo);
+    //     });
+    // })
 
     describe("getStoredProcConfig", () => {
         it("testProcedure", () => {
@@ -158,21 +167,21 @@ describe("more compiler", () => {
     })
 });
 
-type TestDecoratorInfo = Omit<DecoratorInfo, 'args'> & {
-    args: DecoratorArgument[];
-};
+// type TestDecoratorInfo = Omit<DecoratorInfo, 'args'> & {
+//     args: DecoratorArgument[];
+// };
 
-function testDecorators(expected: TestDecoratorInfo[], actual: DecoratorInfo[]) {
-    expect(actual.length).toEqual(expected.length);
-    for (let i = 0; i < expected.length; i++) {
-        testDecorator(expected[i], actual[i]);
-    }
-}
-function testDecorator(expected: TestDecoratorInfo, actual: DecoratorInfo) {
-    expect(actual.name).toEqual(expected.name);
-    expect(actual.alias).toEqual(expected.alias);
-    expect(actual.module).toEqual(expected.module);
+// function testDecorators(expected: TestDecoratorInfo[], actual: DecoratorInfo[]) {
+//     expect(actual.length).toEqual(expected.length);
+//     for (let i = 0; i < expected.length; i++) {
+//         testDecorator(expected[i], actual[i]);
+//     }
+// }
+// function testDecorator(expected: TestDecoratorInfo, actual: DecoratorInfo) {
+//     expect(actual.name).toEqual(expected.name);
+//     expect(actual.alias).toEqual(expected.alias);
+//     expect(actual.module).toEqual(expected.module);
 
-    const args = actual.args?.map(parseDecoratorArgument);
-    expect(args).toEqual(expected.args);
-}
+//     const args = actual.args?.map(parseDecoratorArgument);
+//     expect(args).toEqual(expected.args);
+// }

--- a/packages/dbos-compiler/tests/more-compiler.test.ts
+++ b/packages/dbos-compiler/tests/more-compiler.test.ts
@@ -1,5 +1,5 @@
 import * as tsm from "ts-morph";
-import { DecoratorArgument, getDbosMethodKind, getStoredProcConfig, parseDecoratorArgument } from "../compiler.js";
+import { DecoratorArgument, getDbosMethodKind, getImportSpecifier, getStoredProcConfig, parseDecoratorArgument } from "../compiler.js";
 import { sampleDbosClass, sampleDbosClassAliased } from "./test-code.js";
 import { makeTestProject } from "./test-utility.js";
 import { describe, it, expect } from 'vitest';
@@ -58,72 +58,68 @@ describe("more compiler", () => {
         expect(actual).toEqual(expected);
     });
 
-    // describe("aliased getDecoratorInfo", () => {
-    //     it("testGetHandler", () => {
-    //         const file = aliasProject.getSourceFileOrThrow("operations.ts");
-    //         const cls = file.getClassOrThrow("Test");
-    //         const method = cls.getStaticMethodOrThrow("testGetHandler");
-    //         const decoratorInfo = method.getDecorators().map(getDecoratorInfo);
+    describe("aliased getDecoratorInfo", () => {
+        it("testGetHandler", () => {
+            const file = aliasProject.getSourceFileOrThrow("operations.ts");
+            const cls = file.getClassOrThrow("Test");
+            const method = cls.getStaticMethodOrThrow("testGetHandler");
 
-    //         const expected = <TestDecoratorInfo[]>[{
-    //             name: "GetApi",
-    //             alias: "TestGetApi",
-    //             module: "@dbos-inc/dbos-sdk",
-    //             args: ["/test"]
-    //         }];
+            const expected = <DecoratorInfo[]>[{
+                name: "GetApi",
+                alias: "TestGetApi",
+                module: "@dbos-inc/dbos-sdk",
+                args: ["/test"]
+            }];
 
-    //         testDecorators(expected, decoratorInfo);
-    //     });
-    // });
+            testDecorators(expected, method.getDecorators());
+        });
+    });
 
-    // describe("getDecoratorInfo", () => {
-    //     it("testGetHandler", () => {
-    //         const method = cls.getStaticMethodOrThrow("testGetHandler");
-    //         const decoratorInfo = method.getDecorators().map(getDecoratorInfo);
+    describe("getDecoratorInfo", () => {
+        it("testGetHandler", () => {
+            const method = cls.getStaticMethodOrThrow("testGetHandler");
 
-    //         const expected = <TestDecoratorInfo[]>[{
-    //             name: "GetApi",
-    //             alias: undefined,
-    //             module: "@dbos-inc/dbos-sdk",
-    //             args: ["/test"]
-    //         }];
+            const expected = <DecoratorInfo[]>[{
+                name: "GetApi",
+                alias: undefined,
+                module: "@dbos-inc/dbos-sdk",
+                args: ["/test"]
+            }];
 
-    //         testDecorators(expected, decoratorInfo);
-    //     });
+            testDecorators(expected, method.getDecorators());
+        });
 
-    //     it("testGetHandlerWorkflow", () => {
-    //         const method = cls.getStaticMethodOrThrow("testGetHandlerWorkflow");
-    //         const decoratorInfo = method.getDecorators().map(getDecoratorInfo);
+        it("testGetHandlerWorkflow", () => {
+            const method = cls.getStaticMethodOrThrow("testGetHandlerWorkflow");
 
-    //         const expected: TestDecoratorInfo[] = [{
-    //             name: "GetApi",
-    //             alias: undefined,
-    //             module: "@dbos-inc/dbos-sdk",
-    //             args: ["/test"]
-    //         }, {
-    //             name: "Workflow",
-    //             alias: undefined,
-    //             module: "@dbos-inc/dbos-sdk",
-    //             args: []
-    //         }];
+            const expected: DecoratorInfo[] = [{
+                name: "GetApi",
+                alias: undefined,
+                module: "@dbos-inc/dbos-sdk",
+                args: ["/test"]
+            }, {
+                name: "Workflow",
+                alias: undefined,
+                module: "@dbos-inc/dbos-sdk",
+                args: []
+            }];
 
-    //         testDecorators(expected, decoratorInfo);
-    //     });
+            testDecorators(expected, method.getDecorators());
+        });
 
-    //     it("testConfiguredProcedure", () => {
-    //         const method = cls.getStaticMethodOrThrow("testConfiguredProcedure");
-    //         const decoratorInfo = method.getDecorators().map(getDecoratorInfo);
+        it("testConfiguredProcedure", () => {
+            const method = cls.getStaticMethodOrThrow("testConfiguredProcedure");
 
-    //         const expected: TestDecoratorInfo[] = [{
-    //             name: "StoredProcedure",
-    //             alias: undefined,
-    //             module: "@dbos-inc/dbos-sdk",
-    //             args: [{ readOnly: true, isolationLevel: "READ COMMITTED" }]
-    //         }];
+            const expected: DecoratorInfo[] = [{
+                name: "StoredProcedure",
+                alias: undefined,
+                module: "@dbos-inc/dbos-sdk",
+                args: [{ readOnly: true, isolationLevel: "READ COMMITTED" }]
+            }];
 
-    //         testDecorators(expected, decoratorInfo);
-    //     });
-    // })
+            testDecorators(expected, method.getDecorators());
+        });
+    })
 
     describe("getStoredProcConfig", () => {
         it("testProcedure", () => {
@@ -176,21 +172,39 @@ describe("more compiler", () => {
     })
 });
 
-// type TestDecoratorInfo = Omit<DecoratorInfo, 'args'> & {
-//     args: DecoratorArgument[];
-// };
+interface DecoratorInfo {
+    name: string;
+    alias?: string;
+    module?: string;
+    args: DecoratorArgument[];
+  }
 
-// function testDecorators(expected: TestDecoratorInfo[], actual: DecoratorInfo[]) {
-//     expect(actual.length).toEqual(expected.length);
-//     for (let i = 0; i < expected.length; i++) {
-//         testDecorator(expected[i], actual[i]);
-//     }
-// }
-// function testDecorator(expected: TestDecoratorInfo, actual: DecoratorInfo) {
-//     expect(actual.name).toEqual(expected.name);
-//     expect(actual.alias).toEqual(expected.alias);
-//     expect(actual.module).toEqual(expected.module);
 
-//     const args = actual.args?.map(parseDecoratorArgument);
-//     expect(args).toEqual(expected.args);
-// }
+function testDecorators(expected: DecoratorInfo[], actual: tsm.Decorator[]) {
+    expect(actual.length).toEqual(expected.length);
+    for (let i = 0; i < expected.length; i++) {
+        testDecorator(expected[i], actual[i]);
+    }
+}
+function testDecorator(expected: DecoratorInfo, actual: tsm.Decorator) {
+
+    const callExpr = actual.getCallExpressionOrThrow();
+
+    const expr = callExpr.getExpression();
+    const idExpr = tsm.Node.isIdentifier(expr) 
+        ? expr
+        : expr.asKindOrThrow(tsm.SyntaxKind.PropertyAccessExpression).getExpressionIfKindOrThrow(tsm.SyntaxKind.Identifier);
+
+    const impSpec = getImportSpecifier(idExpr)
+    expect(impSpec).not.toBeNull();
+
+    const { name, alias } = impSpec!.getStructure();
+    const modSpec = impSpec!.getImportDeclaration().getModuleSpecifier();
+
+    expect(expected.name).toEqual(name);
+    expect(expected.alias).toEqual(alias);
+    expect(expected.module).toEqual(modSpec.getLiteralText());
+
+    const args = callExpr.getArguments().map(parseDecoratorArgument) ?? undefined;
+    expect(args).toEqual(expected.args);
+}

--- a/packages/dbos-compiler/tests/more-compiler.test.ts
+++ b/packages/dbos-compiler/tests/more-compiler.test.ts
@@ -26,8 +26,10 @@ describe("more compiler", () => {
             testGetHandlerWorkflow: "workflow",
             testGetHandlerTx: "transaction",
             testGetHandlerComm: "step",
+            testGetHandlerStep: "step",
             testWorkflow: "workflow",
             testCommunicator: "step",
+            testStep: "step",
             testTransaction: "transaction",
             testProcedure: "storedProcedure",
             testReadOnlyProcedure: "storedProcedure",
@@ -45,6 +47,13 @@ describe("more compiler", () => {
             testDeleteHandler_v2: "handler",
             testPutHandler_v2: "handler",
             testPatchHandler_v2: "handler",
+            testGetHandlerWorkflow_v2: "workflow",
+            testGetHandlerTx_v2: "transaction",
+            testGetHandlerStep_v2: "step",
+
+            testStep_v2: "step",
+            testTransaction_v2: "transaction",
+            testWorkflow_v2: "workflow",
         };
         expect(actual).toEqual(expected);
     });

--- a/packages/dbos-compiler/tests/test-code.ts
+++ b/packages/dbos-compiler/tests/test-code.ts
@@ -4,6 +4,7 @@ import {
   GetApi, PostApi, PutApi, PatchApi, DeleteApi, HandlerContext,
   Workflow, WorkflowContext,
   Communicator, CommunicatorContext,
+  Step, StepContext,
   Transaction, TransactionContext,
   StoredProcedure, StoredProcedureContext,
   DBOSInitializer, DBOSDeploy, InitContext,
@@ -27,31 +28,47 @@ export class Test {
   static async testDeleteHandler(ctxt: HandlerContext): Promise<void> {  }
 
   @DBOS.getApi('/test')
-  static async testGetHandler_v2(ctxt: HandlerContext): Promise<void> {  }
+  static async testGetHandler_v2(): Promise<void> {  }
 
   @DBOS.postApi('/test')
-  static async testPostHandler_v2(ctxt: HandlerContext): Promise<void> {  }
+  static async testPostHandler_v2(): Promise<void> {  }
 
   @DBOS.patchApi('/test')
-  static async testPatchHandler_v2(ctxt: HandlerContext): Promise<void> {  }
+  static async testPatchHandler_v2(): Promise<void> {  }
 
   @DBOS.putApi('/test')
-  static async testPutHandler_v2(ctxt: HandlerContext): Promise<void> {  }
+  static async testPutHandler_v2(): Promise<void> {  }
 
   @DBOS.deleteApi('/test')
-  static async testDeleteHandler_v2(ctxt: HandlerContext): Promise<void> {  }
+  static async testDeleteHandler_v2(): Promise<void> {  }
 
   @GetApi('/test')
   @Workflow()
-  static async testGetHandlerWorkflow(ctxt: HandlerContext): Promise<void> {  }
+  static async testGetHandlerWorkflow(ctxt: WorkflowContext): Promise<void> {  }
 
   @GetApi('/test')
   @Transaction()
-  static async testGetHandlerTx(ctxt: HandlerContext): Promise<void> {  }
+  static async testGetHandlerTx(ctxt: TransactionContext<Knex>): Promise<void> {  }
 
   @GetApi('/test')
   @Communicator()
-  static async testGetHandlerComm(ctxt: HandlerContext): Promise<void> {  }
+  static async testGetHandlerComm(ctxt: CommunicatorContext): Promise<void> {  }
+
+  @GetApi('/test')
+  @Step()
+  static async testGetHandlerStep(ctxt: StepContext): Promise<void> {  }
+
+  @DBOS.getApi('/test')
+  @DBOS.workflow()
+  static async testGetHandlerWorkflow_v2(): Promise<void> {  }
+
+  @DBOS.getApi('/test')
+  @DBOS.transaction()
+  static async testGetHandlerTx_v2(): Promise<void> {  }
+
+  @DBOS.getApi('/test')
+  @DBOS.step()
+  static async testGetHandlerStep_v2(): Promise<void> {  }
 
   @Workflow()
   static async testWorkflow(ctxt: WorkflowContext): Promise<void> {  }
@@ -59,8 +76,20 @@ export class Test {
   @Communicator()
   static async testCommunicator(ctxt: CommunicatorContext, message: string): Promise<void> {  }
 
+  @Step()
+  static async testStep(ctxt: StepContext, message: string): Promise<void> {  }
+
   @Transaction()
   static async testTransaction(ctxt: TransactionContext<Knex>, message: string): Promise<void> {  }
+
+  @DBOS.workflow()
+  static async testWorkflow_v2(): Promise<void> {  }
+
+  @DBOS.step()
+  static async testStep_v2(message: string): Promise<void> {  }
+
+  @DBOS.transaction()
+  static async testTransaction_v2(message: string): Promise<void> {  }
 
   @StoredProcedure()
   static async testProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {  }
@@ -102,6 +131,7 @@ import {
   DeleteApi as TestDeleteApi, HandlerContext,
   Workflow as TestWorkflow, WorkflowContext,
   Communicator as TestCommunicator, CommunicatorContext,
+  Step as TestStep, StepContext,
   Transaction as TestTransaction, TransactionContext,
   StoredProcedure as TestStoredProcedure, StoredProcedureContext,
   DBOSInitializer as TestInitializer, DBOSDeploy as TestDeploy, InitContext,
@@ -151,14 +181,42 @@ export class Test {
   @TestCommunicator()
   static async testGetHandlerComm(ctxt: HandlerContext): Promise<void> {  }
 
+  @TestGetApi('/test')
+  @TestStep()
+  static async testGetHandlerStep(ctxt: StepContext): Promise<void> {  }
+
+  @TestDBOS.getApi('/test')
+  @TestDBOS.workflow()
+  static async testGetHandlerWorkflow_v2(): Promise<void> {  }
+
+  @TestDBOS.getApi('/test')
+  @TestDBOS.transaction()
+  static async testGetHandlerTx_v2(): Promise<void> {  }
+
+  @TestDBOS.getApi('/test')
+  @TestDBOS.step()
+  static async testGetHandlerStep_v2(): Promise<void> {  }
+
   @TestWorkflow()
   static async testWorkflow(ctxt: WorkflowContext): Promise<void> {  }
 
   @TestCommunicator()
   static async testCommunicator(ctxt: CommunicatorContext, message: string): Promise<void> {  }
 
+  @TestStep()
+  static async testStep(ctxt: StepContext, message: string): Promise<void> {  }
+
   @TestTransaction()
   static async testTransaction(ctxt: TransactionContext<Knex>, message: string): Promise<void> {  }
+
+  @TestDBOS.workflow()
+  static async testWorkflow_v2(): Promise<void> {  }
+
+  @TestDBOS.step()
+  static async testStep_v2(message: string): Promise<void> {  }
+
+  @TestDBOS.transaction()
+  static async testTransaction_v2(message: string): Promise<void> {  }
 
   @TestStoredProcedure()
   static async testProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {  }

--- a/packages/dbos-compiler/tests/test-code.ts
+++ b/packages/dbos-compiler/tests/test-code.ts
@@ -1,6 +1,7 @@
 export const sampleDbosClass = /*ts*/`
 import {
-  GetApi, PostApi, HandlerContext,
+  DBOS,
+  GetApi, PostApi, PutApi, PatchApi, DeleteApi, HandlerContext,
   Workflow, WorkflowContext,
   Communicator, CommunicatorContext,
   Transaction, TransactionContext,
@@ -11,85 +12,94 @@ import { Knex } from 'knex';
 
 export class Test {
   @GetApi('/test')
-  static async testGetHandler(ctxt: HandlerContext): Promise<void> {
-  }
-
-  @GetApi('/test')
-  @Workflow()
-  static async testGetHandlerWorkflow(ctxt: HandlerContext): Promise<void> {
-  }
-
-  @GetApi('/test')
-  @Transaction()
-  static async testGetHandlerTx(ctxt: HandlerContext): Promise<void> {
-  }
-
-  @GetApi('/test')
-  @Communicator()
-  static async testGetHandlerComm(ctxt: HandlerContext): Promise<void> {
-  }
+  static async testGetHandler(ctxt: HandlerContext): Promise<void> {  }
 
   @PostApi('/test-post')
-  static async testPostHandler(ctxt: HandlerContext): Promise<void> {
-  }
+  static async testPostHandler(ctxt: HandlerContext): Promise<void> {  }
+
+  @PatchApi('/test-patch')
+  static async testPatchHandler(ctxt: HandlerContext): Promise<void> {  }
+
+  @PutApi('/test-put')
+  static async testPutHandler(ctxt: HandlerContext): Promise<void> {  }
+
+  @DeleteApi('/test-put')
+  static async testDeleteHandler(ctxt: HandlerContext): Promise<void> {  }
+
+  @DBOS.getApi('/test')
+  static async testGetHandler_v2(ctxt: HandlerContext): Promise<void> {  }
+
+  @DBOS.postApi('/test')
+  static async testPostHandler_v2(ctxt: HandlerContext): Promise<void> {  }
+
+  @DBOS.patchApi('/test')
+  static async testPatchHandler_v2(ctxt: HandlerContext): Promise<void> {  }
+
+  @DBOS.putApi('/test')
+  static async testPutHandler_v2(ctxt: HandlerContext): Promise<void> {  }
+
+  @DBOS.deleteApi('/test')
+  static async testDeleteHandler_v2(ctxt: HandlerContext): Promise<void> {  }
+
+  @GetApi('/test')
+  @Workflow()
+  static async testGetHandlerWorkflow(ctxt: HandlerContext): Promise<void> {  }
+
+  @GetApi('/test')
+  @Transaction()
+  static async testGetHandlerTx(ctxt: HandlerContext): Promise<void> {  }
+
+  @GetApi('/test')
+  @Communicator()
+  static async testGetHandlerComm(ctxt: HandlerContext): Promise<void> {  }
 
   @Workflow()
-  static async testWorkflow(ctxt: WorkflowContext): Promise<void> {
-  }
+  static async testWorkflow(ctxt: WorkflowContext): Promise<void> {  }
 
   @Communicator()
-  static async testCommunicator(ctxt: CommunicatorContext, message: string): Promise<void> {
-  }
+  static async testCommunicator(ctxt: CommunicatorContext, message: string): Promise<void> {  }
 
   @Transaction()
-  static async testTransaction(ctxt: TransactionContext<Knex>, message: string): Promise<void> {
-  }
+  static async testTransaction(ctxt: TransactionContext<Knex>, message: string): Promise<void> {  }
 
   @StoredProcedure()
-  static async testProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {
-  }
+  static async testProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {  }
 
   @StoredProcedure({ readOnly: true })
-  static async testReadOnlyProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {
-  }
+  static async testReadOnlyProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {  }
 
   @StoredProcedure({ isolationLevel: "REPEATABLE READ" })
-  static async testRepeatableReadProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {
-  }
+  static async testRepeatableReadProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {  }
 
   @StoredProcedure({ readOnly: true, isolationLevel: "READ COMMITTED" })
-  static async testConfiguredProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {
-  }
+  static async testConfiguredProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {  }
 
   @StoredProcedure({ executeLocally: true})
-  static async testLocalProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {
-  }
+  static async testLocalProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {  }
 
   @StoredProcedure({ readOnly: true, executeLocally: true })
-  static async testLocalReadOnlyProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {
-  }
+  static async testLocalReadOnlyProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {  }
 
   @StoredProcedure({ isolationLevel: "REPEATABLE READ", executeLocally: true })
-  static async testLocalRepeatableReadProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {
-  }
+  static async testLocalRepeatableReadProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {  }
 
   @StoredProcedure({ readOnly: true, isolationLevel: "READ COMMITTED", executeLocally: true })
-  static async testLocalConfiguredProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {
-  }
+  static async testLocalConfiguredProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {  }
 
   @DBOSInitializer()
-  static async testDBOSInitializer(ctxt: InitContext): Promise<void> {
-  }
+  static async testDBOSInitializer(ctxt: InitContext): Promise<void> {  }
 
   @DBOSDeploy()
-  static async testDBOSDeploy(ctxt: InitContext): Promise<void> {
-  }
+  static async testDBOSDeploy(ctxt: InitContext): Promise<void> {  }
 }
 `;
 
 export const sampleDbosClassAliased = /*ts*/`
 import {
-  GetApi as TestGetApi, PostApi as TestPostApi, HandlerContext,
+  DBOS as TestDBOS,
+  GetApi as TestGetApi, PostApi as TestPostApi,
+  PutApi as TestPutApi, PatchApi as TestPatchApi,
+  DeleteApi as TestDeleteApi, HandlerContext,
   Workflow as TestWorkflow, WorkflowContext,
   Communicator as TestCommunicator, CommunicatorContext,
   Transaction as TestTransaction, TransactionContext,
@@ -100,78 +110,83 @@ import { Knex } from 'knex';
 
 export class Test {
   @TestGetApi('/test')
-  static async testGetHandler(ctxt: HandlerContext): Promise<void> {
-  }
+  static async testGetHandler(ctxt: HandlerContext): Promise<void> {  }
 
   @TestPostApi('/test-post')
-  static async testPostHandler(ctxt: HandlerContext): Promise<void> {
-  }
+  static async testPostHandler(ctxt: HandlerContext): Promise<void> {  }
+
+  @TestPatchApi('/test-patch')
+  static async testPatchHandler(ctxt: HandlerContext): Promise<void> {  }
+
+  @TestPutApi('/test-put')
+  static async testPutHandler(ctxt: HandlerContext): Promise<void> {  }
+
+  @TestDeleteApi('/test-put')
+  static async testDeleteHandler(ctxt: HandlerContext): Promise<void> {  }
+
+  @TestDBOS.getApi('/test')
+  static async testGetHandler_v2(ctxt: HandlerContext): Promise<void> {  }
+
+  @TestDBOS.postApi('/test')
+  static async testPostHandler_v2(ctxt: HandlerContext): Promise<void> {  }
+
+  @TestDBOS.patchApi('/test')
+  static async testPatchHandler_v2(ctxt: HandlerContext): Promise<void> {  }
+
+  @TestDBOS.putApi('/test')
+  static async testPutHandler_v2(ctxt: HandlerContext): Promise<void> {  }
+
+  @TestDBOS.deleteApi('/test')
+  static async testDeleteHandler_v2(ctxt: HandlerContext): Promise<void> {  }
 
   @TestGetApi('/test')
   @TestWorkflow()
-  static async testGetHandlerWorkflow(ctxt: HandlerContext): Promise<void> {
-  }
+  static async testGetHandlerWorkflow(ctxt: HandlerContext): Promise<void> {  }
 
   @TestGetApi('/test')
   @TestTransaction()
-  static async testGetHandlerTx(ctxt: HandlerContext): Promise<void> {
-  }
+  static async testGetHandlerTx(ctxt: HandlerContext): Promise<void> {  }
 
   @TestGetApi('/test')
   @TestCommunicator()
-  static async testGetHandlerComm(ctxt: HandlerContext): Promise<void> {
-  }
+  static async testGetHandlerComm(ctxt: HandlerContext): Promise<void> {  }
 
   @TestWorkflow()
-  static async testWorkflow(ctxt: WorkflowContext): Promise<void> {
-  }
+  static async testWorkflow(ctxt: WorkflowContext): Promise<void> {  }
 
   @TestCommunicator()
-  static async testCommunicator(ctxt: CommunicatorContext, message: string): Promise<void> {
-  }
+  static async testCommunicator(ctxt: CommunicatorContext, message: string): Promise<void> {  }
 
   @TestTransaction()
-  static async testTransaction(ctxt: TransactionContext<Knex>, message: string): Promise<void> {
-  }
+  static async testTransaction(ctxt: TransactionContext<Knex>, message: string): Promise<void> {  }
 
   @TestStoredProcedure()
-  static async testProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {
-  }
+  static async testProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {  }
 
   @TestStoredProcedure({ readOnly: true })
-  static async testReadOnlyProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {
-  }
+  static async testReadOnlyProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {  }
 
   @TestStoredProcedure({ isolationLevel: "REPEATABLE READ" })
-  static async testRepeatableReadProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {
-  }
+  static async testRepeatableReadProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {  }
 
   @TestStoredProcedure({ readOnly: true, isolationLevel: "READ COMMITTED" })
-  static async testConfiguredProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {
-  }
+  static async testConfiguredProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {  }
 
   @TestStoredProcedure({ executeLocally: true})
-  static async testLocalProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {
-  }
+  static async testLocalProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {  }
 
   @TestStoredProcedure({ readOnly: true, executeLocally: true })
-  static async testLocalReadOnlyProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {
-  }
+  static async testLocalReadOnlyProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {  }
 
   @TestStoredProcedure({ isolationLevel: "REPEATABLE READ", executeLocally: true })
-  static async testLocalRepeatableReadProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {
-  }
+  static async testLocalRepeatableReadProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {  }
 
   @TestStoredProcedure({ readOnly: true, isolationLevel: "READ COMMITTED", executeLocally: true })
-  static async testLocalConfiguredProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {
-  }
-
+  static async testLocalConfiguredProcedure(ctxt: StoredProcedureContext, message: string): Promise<void> {  }
 
   @TestInitializer()
-  static async testDBOSInitializer(ctxt: InitContext): Promise<void> {
-  }
+  static async testDBOSInitializer(ctxt: InitContext): Promise<void> {  }
 
   @TestDeploy()
-  static async testDBOSDeploy(ctxt: InitContext): Promise<void> {
-  }
+  static async testDBOSDeploy(ctxt: InitContext): Promise<void> {  }
 }`;

--- a/packages/dbos-compiler/tests/test-utility.ts
+++ b/packages/dbos-compiler/tests/test-utility.ts
@@ -63,7 +63,7 @@ declare module "@dbos-inc/dbos-sdk" {
     isolationLevel?: "READ UNCOMMITTED" | "READ COMMITTED" | "REPEATABLE READ" | "SERIALIZABLE";
     readOnly?: boolean;
   }
-  export interface CommunicatorConfig {
+  export interface StepConfig {
     retriesAllowed?: boolean;
     intervalSeconds?: number;
     maxAttempts?: number;
@@ -77,8 +77,13 @@ declare module "@dbos-inc/dbos-sdk" {
 
   export function GetApi(url:string);
   export function PostApi(url:string);
+  export function PutApi(url:string);
+  export function PatchApi(url:string);
+  export function DeleteApi(url:string);
+
   export function Workflow(config?: WorkflowConfig);
-  export function Communicator(config?: CommunicatorConfig);
+  export function Communicator(config?: StepConfig);
+  export function Step(config?: StepConfig);
   export function Transaction(config?: TransactionConfig);
   export function StoredProcedure(config?: StoredProcedureConfig);
   export function DBOSDeploy();
@@ -90,5 +95,17 @@ declare module "@dbos-inc/dbos-sdk" {
   export interface TransactionContext<T> extends DBOSContext { }
   export interface StoredProcedureContext extends DBOSContext { }
   export interface InitContext extends DBOSContext {}
+
+  export class DBOS {
+    static workflow(config?: WorkflowConfig);
+    static transaction(config?: TransactionConfig);
+    static step(config?: StepConfig);
+    static getApi(url: string);
+    static postApi(url: string);
+    static putApi(url: string);
+    static patchApi(url: string);
+    static deleteApi(url: string);
+  }
+
 }
 `;

--- a/packages/dbos-compiler/tests/test-utility.ts
+++ b/packages/dbos-compiler/tests/test-utility.ts
@@ -92,6 +92,7 @@ declare module "@dbos-inc/dbos-sdk" {
   export interface HandlerContext extends DBOSContext { }
   export interface WorkflowContext extends DBOSContext { }
   export interface CommunicatorContext extends DBOSContext { }
+  export interface StepContext extends DBOSContext { }
   export interface TransactionContext<T> extends DBOSContext { }
   export interface StoredProcedureContext extends DBOSContext { }
   export interface InitContext extends DBOSContext {}

--- a/tests/proc-test/src/operations.test.ts
+++ b/tests/proc-test/src/operations.test.ts
@@ -178,7 +178,7 @@ describe("operations-test", () => {
     try {
 
       const wfUUID = uuidv1();
-      const user = "txAndProcWF";
+      const user = "txAndProcWFv2";
       const res = await DBOS.withNextWorkflowID(wfUUID, async () => {
         return await StoredProcTest.txAndProcGreetingWorkflow_v2(user);
       })

--- a/tests/proc-test/src/operations.ts
+++ b/tests/proc-test/src/operations.ts
@@ -125,8 +125,8 @@ export class StoredProcTest {
   @DBOS.workflow()
   static async txAndProcGreetingWorkflow_v2(user: string): Promise<{ count: number; greeting: string; }> {
     // Retrieve the number of times this user has been greeted.
-    const count = await this.getGreetCountTx_v2(user);
-    const greeting = await DBOS.invoke(this).helloProcedure(user);
+    const count = await StoredProcTest.getGreetCountTx_v2(user);
+    const greeting = await DBOS.invoke(StoredProcTest).helloProcedure(user);
 
     return { count, greeting };
   }


### PR DESCRIPTION
This PR adds support to dbos-compiler for the new v2 API (i.e. `@DBOS.workflow` decorators et. al.). This PR does *NOT* add a `@DBOS.storedProc` decorator...that will come in a separate PR