### PR TITLE
do not start our http server during DBOS.launch()

### DIFF
--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -167,14 +167,6 @@ export class DBOS {
       });
     }
 
-    // Create the DBOS HTTP server
-    //  This may be a no-op if there are no registered endpoints
-    const server = new DBOSHttpServer(DBOSExecutor.globalInstance);
-    if (DBOS.runtimeConfig) {
-      // This will not listen if there's no decorated endpoint
-      DBOS.appServer = await server.appListen(DBOS.runtimeConfig.port);
-    }
-
     if (httpApps) {
       if (httpApps.koaApp) {
         DBOS.logger.info("Setting up Koa tracing middleware");


### PR DESCRIPTION
Today this way of automatically starting our server is not compatible with how we allow users to specify their own `start` command. 

Specifically, if I pass a `start` command to `runtimeConfig`, the current logic will fail and crash if there is already a server listening on our default port (3000).

We can revisit what magic we want to do about that HTTP server, in the future...