### PR TITLE
Add parameters to startWorkflow

### DIFF
--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -121,6 +121,11 @@ function httpApiDec(verb: APITypes, url: string) {
   }
 }
 
+export interface StartWorkflowParams {
+  workflowID?: string;
+  queueName?: string;
+}
+
 export class DBOS {
   ///////
   // Lifecycle
@@ -445,25 +450,25 @@ export class DBOS {
     }
   }
 
-  static startWorkflow<T extends ConfiguredInstance>(targetClass: T): InvokeFunctionsAsyncInst<T>;
-  static startWorkflow<T extends object>(targetClass: T): InvokeFunctionsAsync<T>;
-  static startWorkflow<T extends object>(target: T): InvokeFunctionsAsync<T> {
+  static startWorkflow<T extends ConfiguredInstance>(targetClass: T, params?: StartWorkflowParams): InvokeFunctionsAsyncInst<T>;
+  static startWorkflow<T extends object>(targetClass: T, params?: StartWorkflowParams): InvokeFunctionsAsync<T>;
+  static startWorkflow<T extends object>(target: T, params?: StartWorkflowParams): InvokeFunctionsAsync<T> {
     if (typeof target === 'function') {
-      return DBOS.proxyInvokeWF(target, null) as unknown as InvokeFunctionsAsync<T>;
+      return DBOS.proxyInvokeWF(target, null, params) as unknown as InvokeFunctionsAsync<T>;
     }
     else {
-      return DBOS.proxyInvokeWF(target, target as ConfiguredInstance) as unknown as InvokeFunctionsAsync<T>;
+      return DBOS.proxyInvokeWF(target, target as ConfiguredInstance, params) as unknown as InvokeFunctionsAsync<T>;
     }
   }
 
-  static proxyInvokeWF<T extends object>(object: T, configuredInstance: ConfiguredInstance | null):
+  static proxyInvokeWF<T extends object>(object: T, configuredInstance: ConfiguredInstance | null, inParams?: StartWorkflowParams):
     InvokeFunctionsAsync<T>
   {
     const ops = getRegisteredOperations(object);
     const proxy: Record<string, unknown> = {};
 
     const pctx = getCurrentContextStore();
-    let wfId = pctx?.idAssignedForNextWorkflow;
+    let wfId = inParams?.workflowID ?? pctx?.idAssignedForNextWorkflow;
 
     // If this is called from within a workflow, this is a child workflow,
     //  For OAOO, we will need a consistent ID formed from the parent WF and call number
@@ -472,18 +477,18 @@ export class DBOS {
 
       const funcId = wfctx.functionIDGetIncrement();
       wfId = wfId || (wfctx.workflowUUID + "-" + funcId);
-      const params : WorkflowParams = {
+      const wfParams : WorkflowParams = {
         workflowUUID: wfId,
         parentCtx: wfctx,
         configuredInstance,
-        queueName: pctx?.queueAssignedForWorkflows
+        queueName: inParams?.queueName ?? pctx?.queueAssignedForWorkflows
       };
 
       for (const op of ops) {
         proxy[op.name] = op.workflowConfig
           ? (...args: unknown[]) => DBOSExecutor.globalInstance!.internalWorkflow(
              (op.registeredFunction as WorkflowFunction<unknown[], unknown>),
-             params, wfctx.workflowUUID, funcId, ...args)
+             wfParams, wfctx.workflowUUID, funcId, ...args)
           : undefined;
       }
 
@@ -517,7 +522,7 @@ export class DBOS {
 
     const wfParams: InternalWorkflowParams = {
       workflowUUID: wfId,
-      queueName: pctx?.queueAssignedForWorkflows,
+      queueName: inParams?.queueName ?? pctx?.queueAssignedForWorkflows,
       configuredInstance,
       parentCtx,
     };

--- a/tests/contextfreeapi.test.ts
+++ b/tests/contextfreeapi.test.ts
@@ -68,6 +68,12 @@ class TestFunctions
     const kv2 = await DBOS.getEvent<string>(wfid, "key2");
     return kv1+','+kv2;
   }
+
+  static awaitThis: Promise<void> | undefined = undefined;
+  @DBOS.workflow()
+  static async awaitAPromise() {
+    await TestFunctions.awaitThis;
+  }
 }
 
 const testTableName = "dbos_test_kv";
@@ -214,18 +220,32 @@ async function main5() {
   });
   expect(res).toBe('done');
 
-  // Validate that it had the queue
-  /*
-  // To do when workflow can be suspended...
-  const wfqcontent = await DBOS.getWorkflowQueue({queueName: wfq.name});
-  expect (wfqcontent.workflows.length).toBe(1);
-  */
+
   const wfs = await DBOS.getWorkflows({workflowName: 'doWorkflow'});
   expect(wfs.workflowUUIDs.length).toBeGreaterThanOrEqual(1);
   expect(wfs.workflowUUIDs.length).toBe(1);
   const wfstat = await DBOS.getWorkflowStatus(wfs.workflowUUIDs[0]);
   expect(wfstat?.queueName).toBe('wfq');
 
+  // Check queues in startWorkflow
+  let resolve: ()=>void = ()=>{};
+  TestFunctions.awaitThis = new Promise<void>((r) => {
+    resolve = r;
+  });
+
+  const wfhq = await DBOS.startWorkflow(TestFunctions, {workflowID: 'waitPromiseWF', queueName: wfq.name}).awaitAPromise()
+  const wfstatsw = await DBOS.getWorkflowStatus('waitPromiseWF');
+  expect(wfstatsw?.queueName).toBe('wfq');
+
+  // Validate that it had the queue
+  const wfqcontent = await DBOS.getWorkflowQueue({queueName: wfq.name});
+  expect(wfqcontent.workflows.length).toBe(1);
+  expect(wfqcontent.workflows[0].workflowID).toBe('waitPromiseWF');
+
+  resolve(); // Let WF finish
+  await wfhq.getResult();
+
+  // Quick check on scheduled WFs
   await sleepms(2000);
   expect (TestFunctions.nSchedCalls).toBeGreaterThanOrEqual(2);
 
@@ -238,7 +258,6 @@ async function main6() {
   DBOS.setConfig(config);
   await DBOS.launch();
 
-  // This or: DBOS.startWorkflow(TestFunctions).getEventWorkflow('wfidset'); ?
   const wfhandle = await DBOS.startWorkflow(TestFunctions).getEventWorkflow('wfidset');
   await DBOS.withNextWorkflowID('wfidset', async() => {
     await TestFunctions.setEventWorkflow('a', 'b');

--- a/tests/contextfreeinst.test.ts
+++ b/tests/contextfreeinst.test.ts
@@ -241,8 +241,6 @@ async function main5() {
   resolve(); // Let WF finish
   await wfhq.getResult();
 
-  // Quick check on scheduled WFs
-  
   await DBOS.shutdown();
 }
 


### PR DESCRIPTION
Allow setting of workflow ID and queue as part of startWorkflow syntax.
Remove a couple of comments that don't mean anything any more.