### PR TITLE
Ignore .python-version

### DIFF
--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -67,7 +67,7 @@ async function createZipData(logger: CLILogger): Promise<string> {
     pattern.startsWith('!') ? `!${pattern.slice(1)}` : `**/${pattern}`
   ) ;
 
-  const hardcodedIgnorePatterns = [ `**/${dbosEnvPath}/**`, "**/node_modules/**", "**/dist/**", "**/.git/**", `**/${dbosConfigFilePath}`, "**/venv/**", "**/.venv/**"];
+  const hardcodedIgnorePatterns = [ `**/${dbosEnvPath}/**`, "**/node_modules/**", "**/dist/**", "**/.git/**", `**/${dbosConfigFilePath}`, "**/venv/**", "**/.venv/**", "./.python-version"];
 
   const files = await fg(globPattern, {
     dot: true,

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -67,7 +67,7 @@ async function createZipData(logger: CLILogger): Promise<string> {
     pattern.startsWith('!') ? `!${pattern.slice(1)}` : `**/${pattern}`
   ) ;
 
-  const hardcodedIgnorePatterns = [ `**/${dbosEnvPath}/**`, "**/node_modules/**", "**/dist/**", "**/.git/**", `**/${dbosConfigFilePath}`, "**/venv/**", "**/.venv/**", "./.python-version"];
+  const hardcodedIgnorePatterns = [ `**/${dbosEnvPath}/**`, "**/node_modules/**", "**/dist/**", "**/.git/**", `**/${dbosConfigFilePath}`, "**/venv/**", "**/.venv/**", "**/.python-version"];
 
   const files = await fg(globPattern, {
     dot: true,


### PR DESCRIPTION
The inclusion of a `./python-version` file may cause DBOS Cloud to install packages for the wrong version. This file should be ignored in the cloud.  Thanks [@camspilly](https://github.com/camspilly) for reporting!