### PR TITLE
v2 API touchups

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -74,7 +74,8 @@ export function assertCurrentDBOSContext(): DBOSContext {
 }
 
 export function assertCurrentWorkflowContext(): WorkflowContextImpl {
-  if (!isInWorkflowCtx(asyncLocalCtx.getStore()!)) {
+  const ctxs = getCurrentContextStore();
+  if (!ctxs || !isInWorkflowCtx(ctxs)) {
     throw new DBOSInvalidWorkflowTransitionError();
   }
   const ctx = assertCurrentDBOSContext();

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -55,6 +55,7 @@ import { ConfiguredInstance } from ".";
 import { StoredProcedureFunc } from "./procedure";
 import { APITypes } from "./httpServer/handlerTypes";
 import { HandlerRegistrationBase } from "./httpServer/handler";
+import { set } from "lodash";
 
 // Declare all the HTTP applications a user can pass to the DBOS object during launch()
 // This allows us to add a DBOS tracing middleware (extract W3C Trace context, set request ID, etc)
@@ -137,6 +138,13 @@ export class DBOS {
   static setConfig(config: DBOSConfig, runtimeConfig?: DBOSRuntimeConfig) {
     DBOS.dbosConfig = config;
     DBOS.runtimeConfig = runtimeConfig;
+  }
+
+  // For unit testing purposes only
+  static setAppConfig<T>(key: string, newValue: T): void {
+    const conf = DBOS.dbosConfig?.application;
+    if (!conf) throw new DBOSExecutorNotInitializedError();
+    set(conf, key, newValue);
   }
 
   static async launch(httpApps?: DBOSHttpApps) {

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -271,7 +271,7 @@ export class DBOS {
   static get logger(): DLogger {
     const ctx = getCurrentDBOSContext();
     if (ctx) return ctx.logger;
-    const executor = DBOS.executor;
+    const executor = DBOSExecutor.globalInstance;
     if (executor) return executor.logger;
     return new GlobalLogger();
   }

--- a/tests/contextfreeapi.test.ts
+++ b/tests/contextfreeapi.test.ts
@@ -1,6 +1,8 @@
 import { DBOS, WorkflowQueue } from '../src';
 import { generateDBOSTestConfig, setUpDBOSTestDb, TestKvTable } from './helpers';
 
+DBOS.logger.info("This should not cause a kaboom.");
+
 class TestFunctions
 {
   @DBOS.transaction()

--- a/tests/contextfreeapi.test.ts
+++ b/tests/contextfreeapi.test.ts
@@ -17,6 +17,7 @@ class TestFunctions
   @DBOS.workflow()
   static async doWorkflow() {
     await TestFunctions.doTransaction("");
+    expect(DBOS.getConfig('is_in_unit_test', false)).toBe(true);
     return 'done';
   }
 
@@ -138,6 +139,7 @@ async function main() {
   const config = generateDBOSTestConfig(); // Optional.  If you don't, it'll open the YAML file...
   await setUpDBOSTestDb(config);
   DBOS.setConfig(config);
+  DBOS.setAppConfig('is_in_unit_test', true);
   await DBOS.launch();
 
   const res = await TestFunctions.doWorkflow();
@@ -212,6 +214,7 @@ async function main5() {
   const config = generateDBOSTestConfig();
   await setUpDBOSTestDb(config);
   DBOS.setConfig(config);
+  DBOS.setAppConfig('is_in_unit_test', true);
   await DBOS.launch();
 
   const res = await DBOS.withWorkflowQueue(wfq.name, async ()=>{

--- a/tests/v2v1apimix.test.ts
+++ b/tests/v2v1apimix.test.ts
@@ -275,6 +275,12 @@ async function mainInst() {
   const res211 = await inst.doWorkflowV2_V1V1();
   expect(res211).toBe('wv2selected tv1step sv1 done');
 
+  const resX = await DBOS.invoke(ChildWorkflowsV1).childTx();
+  expect(resX.startsWith('selected')).toBeTruthy();
+
+  const resS = await DBOS.invoke(TestFunctions).doStepV1('bare');
+  expect(resS).toBe('step bare done');
+
   await DBOS.shutdown();
 }
 


### PR DESCRIPTION
These were found during conversion of demo apps to v2:
* setAppConfig - used in unit tests (was provided by testingRuntime as setConfig)
* Calling v1 transaction/step functions using DBOS.invoke(), from outside of workflows
* Using DBOS.logger before launch