### PR TITLE
Create from demo repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7293,14 +7293,15 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "license": "MIT",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -12550,7 +12551,8 @@
     },
     "node_modules/validator": {
       "version": "13.12.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -13226,17 +13228,11 @@
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^5.3.8",
-        "axios": "^1.7.4",
         "chalk": "4.1.2",
         "commander": "^12.0.0",
-        "fast-glob": "^3.3.2",
-        "open": "^10.1.0",
-        "prompt-sync": "^4.2.0",
+        "fast-glob": "^3.3.3",
         "update-notifier": "^7.0.0",
-        "validator": "^13.11.0",
-        "winston": "^3.12.0",
-        "winston-transport": "^4.7.0",
-        "yaml": "^2.5.0"
+        "validator": "^13.12.0"
       },
       "bin": {
         "create": "dist/cli.js"
@@ -13247,16 +13243,6 @@
         "@types/update-notifier": "^6.0.8",
         "@types/validator": "^13.11.9",
         "typescript": "^5.4.5"
-      }
-    },
-    "packages/create/node_modules/yaml": {
-      "version": "2.5.0",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "packages/dbos-cloud": {

--- a/packages/create/.npmignore
+++ b/packages/create/.npmignore
@@ -25,3 +25,12 @@ templates/hello-typeorm/node_modules
 templates/hello-drizzle/.dbos
 templates/hello-drizzle/dist
 templates/hello-drizzle/node_modules
+templates/hello-express/.dbos
+templates/hello-express/dist
+templates/hello-express/node_modules
+templates/hello-nextjs/.dbos
+templates/hello-nextjs/dist
+templates/hello-nextjs/node_modules
+templates/hello-contexts/.dbos
+templates/hello-contexts/dist
+templates/hello-contexts/node_modules

--- a/packages/create/cli.ts
+++ b/packages/create/cli.ts
@@ -32,6 +32,7 @@ program
     }
     else {
       const templates = listTemplates();
+      // TODO: add descriptions for each template.
       template = await select(
         {
           message: 'Choose a template to use:',
@@ -45,7 +46,12 @@ program
           validate: isValidApplicationName,
         });
     }
-    await init(appName, template);
+    try {
+      await init(appName, template);
+    } catch (e) {
+      console.error((e as Error).message);
+      process.exit(1);
+    }
   })
   .allowUnknownOption(false);
 

--- a/packages/create/cli.ts
+++ b/packages/create/cli.ts
@@ -41,8 +41,7 @@ program
       appName = await input(
         {
           message: 'What is the application/directory name to create?',
-          // Providing a default value
-          default: 'dbos-hello-app',
+          default: template, // Default to the template name
           validate: isValidApplicationName,
         });
     }

--- a/packages/create/cli.ts
+++ b/packages/create/cli.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
-import { init } from './init.js';
+import { init, isValidApplicationName, listTemplates } from './init.js';
 import fs from 'fs'
 import path from "path";
 import { Package } from "update-notifier";
-import { input } from "@inquirer/prompts";
+import { input, select } from "@inquirer/prompts";
 
 const program = new Command();
 
@@ -31,17 +31,18 @@ program
       template = template || 'hello';
     }
     else {
-      template = await input(
+      const templates = listTemplates();
+      template = await select(
         {
-          message: 'What is the template to use for the application?',
-          // Providing a default value
-          default: 'hello',
+          message: 'Choose a template to use:',
+          choices: templates.map(t => ({ name: t, value: t })),
         });
       appName = await input(
         {
           message: 'What is the application/directory name to create?',
           // Providing a default value
           default: 'dbos-hello-app',
+          validate: isValidApplicationName,
         });
     }
     await init(appName, template);

--- a/packages/create/github-create.ts
+++ b/packages/create/github-create.ts
@@ -1,0 +1,83 @@
+import chalk from "chalk";
+import fs from "fs";
+import path from "path";
+
+const DEMO_REPO_API = 'https://api.github.com/repos/dbos-inc/dbos-demo-apps';
+const TS_DEMO_PATH = 'typescript/';
+const BRANCH = 'main';
+export const IGNORE_PATTERNS = ['.dbos/', 'node_modules/', 'dist/', '.git/', 'venv/', '.venv/', '.direnv/', '.devenv/'];
+export const IGNORE_REGEX = new RegExp(`^.*\\/(${IGNORE_PATTERNS.join('|')}).*$`);
+
+type GitHubTree = {
+  sha: string;
+  url: string;
+  tree: GitHubTreeItem[];
+  truncated: boolean;
+};
+
+type GitHubTreeItem = {
+  path: string;
+  mode: string;
+  type: string;
+  sha: string;
+  url: string;
+  size: number;
+};
+
+type GitHubItem = {
+  sha: string;
+  node_id: string;
+  url: string;
+  content: string;
+  encoding: string;
+  size: number;
+};
+
+export async function createTemplateFromGitHub(appName: string, templateName: string) {
+  console.log(`Creating a new application named ${chalk.bold(appName)} from the template ${chalk.bold(templateName)}`);
+  const tree = await fetchGitHubTree(BRANCH);
+
+  const templatePath = `${TS_DEMO_PATH}${templateName}/`;
+  const filesToDownload = tree.filter((item) => item.path.startsWith(templatePath) && item.type === 'blob');
+
+  // Download every file from the template
+  await Promise.all(
+    filesToDownload
+      .filter((item) => !IGNORE_REGEX.test(item.path))
+      .map(async (item) => {
+        const content = await fetchGitHubItem(item.url);
+        const filePath = item.path.replace(templatePath, '');
+        const targetPath = `${appName}/${filePath}`;
+        await fs.promises.mkdir(path.dirname(targetPath), { recursive: true });
+        await fs.promises.writeFile(targetPath, content, {mode: parseInt(item.mode, 8)});
+      })
+  );
+  console.log(`Downloaded ${filesToDownload.length} files from the template GitHub repository`);
+}
+
+async function fetchGitHub(url: string): Promise<Response> {
+  // TODO: add GitHub token to headers if exists.
+  const response = await fetch(url);
+  if (!response.ok) {
+    if (response.headers.get('x-ratelimit-remaining') === '0') {
+      throw new Error(
+        'Error fetching from GitHub API: rate limit exceeded.\r\nPlease wait a few minutes and try again.',
+      );
+    }
+    throw new Error(`Error fetching content from GitHub ${url}: ${response.status} ${response.statusText}`);
+  }
+
+  return response;
+}
+
+async function fetchGitHubTree(tag: string) {
+  const response = await fetchGitHub(`${DEMO_REPO_API}/git/trees/${tag}?recursive=1`);
+  const { tree } = (await response.json()) as GitHubTree;
+  return tree;
+}
+
+async function fetchGitHubItem(url: string) {
+  const response = await fetchGitHub(url);
+  const { content: contentBase64 } = (await response.json()) as GitHubItem;
+  return atob(contentBase64); // Decode base64
+}

--- a/packages/create/github-create.ts
+++ b/packages/create/github-create.ts
@@ -1,4 +1,3 @@
-import { input } from "@inquirer/prompts";
 import chalk from "chalk";
 import fs from "fs";
 import path from "path";
@@ -8,7 +7,7 @@ const TS_DEMO_PATH = 'typescript/';
 const BRANCH = 'main';
 export const IGNORE_PATTERNS = ['.dbos/', 'node_modules/', 'dist/', '.git/', 'venv/', '.venv/', '.direnv/', '.devenv/'];
 export const IGNORE_REGEX = new RegExp(`^.*\\/(${IGNORE_PATTERNS.join('|')}).*$`);
-let GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 
 type GitHubTree = {
   sha: string;
@@ -37,14 +36,6 @@ type GitHubItem = {
 
 export async function createTemplateFromGitHub(appName: string, templateName: string) {
   console.log(`Creating a new application named ${chalk.bold(appName)} from the template ${chalk.bold(templateName)}`);
-  // Prompt user to pptionally provide a GitHub personal access token
-  if (!GITHUB_TOKEN) {
-    GITHUB_TOKEN = await input(
-      {
-        message: '(Optional) Enter your GitHub personal access token to increase the rate limit for downloading the template',
-        default: '',
-      });
-  }
 
   const tree = await fetchGitHubTree(BRANCH);
 

--- a/packages/create/github-create.ts
+++ b/packages/create/github-create.ts
@@ -1,3 +1,4 @@
+import { input } from "@inquirer/prompts";
 import chalk from "chalk";
 import fs from "fs";
 import path from "path";
@@ -7,7 +8,7 @@ const TS_DEMO_PATH = 'typescript/';
 const BRANCH = 'main';
 export const IGNORE_PATTERNS = ['.dbos/', 'node_modules/', 'dist/', '.git/', 'venv/', '.venv/', '.direnv/', '.devenv/'];
 export const IGNORE_REGEX = new RegExp(`^.*\\/(${IGNORE_PATTERNS.join('|')}).*$`);
-const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+let GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 
 type GitHubTree = {
   sha: string;
@@ -36,6 +37,15 @@ type GitHubItem = {
 
 export async function createTemplateFromGitHub(appName: string, templateName: string) {
   console.log(`Creating a new application named ${chalk.bold(appName)} from the template ${chalk.bold(templateName)}`);
+  // Prompt user to pptionally provide a GitHub personal access token
+  if (!GITHUB_TOKEN) {
+    GITHUB_TOKEN = await input(
+      {
+        message: '(Optional) Enter your GitHub personal access token to increase the rate limit for downloading the template',
+        default: '',
+      });
+  }
+
   const tree = await fetchGitHubTree(BRANCH);
 
   const templatePath = `${TS_DEMO_PATH}${templateName}/`;

--- a/packages/create/init.ts
+++ b/packages/create/init.ts
@@ -45,11 +45,14 @@ export const copy = async (
   );
 }
 
-function isValidApplicationName(appName: string): boolean {
+export function isValidApplicationName(appName: string): boolean | string {
   if (appName.length < 3 || appName.length > 30) {
-    return false;
+    return "Application name must be between 3 and 30 characters long";
   }
-  return validator.matches(appName, "^[a-z0-9-_]+$");
+  if (!validator.matches(appName, "^[a-z0-9-_]+$")) {
+    return "Application name can only contain lowercase letters, numbers, hyphens and underscores";
+  }
+  return true;
 }
 
 const filesAllowedInEmpty = ['.gitignore', 'readme.md'];
@@ -108,7 +111,7 @@ function mergeGitignoreFiles(existingFilePath: string, templateFilePath: string,
 
 
 export async function init(appName: string, templateName: string) {
-  if (!isValidApplicationName(appName)) {
+  if (isValidApplicationName(appName) !== true) {
     throw new Error(`Invalid application name: ${appName}. Application name must be between 3 and 30 characters long and can only contain lowercase letters, numbers, hyphens and underscores. Exiting...`);
   }
 
@@ -135,4 +138,21 @@ export async function init(appName: string, templateName: string) {
   execSync("npm i --no-fund --loglevel=error", {cwd: appName, stdio: 'inherit'})
   execSync("npm install --no-fund --save-dev @dbos-inc/dbos-cloud@latest", {cwd: appName, stdio: 'inherit'})
   console.log("Application initialized successfully!")
+}
+
+// Templates that will be downloaded through the demo apps repository
+export const DEMO_TEMPLATES = ['dbos-node-starter']
+
+// Return a list of available templates
+export function listTemplates(): string[] {
+  const __dirname = fileURLToPath(new URL('.', import.meta.url));
+  const templatePath = path.resolve(__dirname, '..', 'templates');
+  const items = fs.readdirSync(templatePath, { withFileTypes: true });
+  const templates = items
+      .filter(item => item.isDirectory())
+      .map(folder => folder.name);
+
+  // Insert demo templates at the beginning of the list
+  templates.unshift(...DEMO_TEMPLATES);
+  return templates;
 }

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -26,16 +26,10 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^5.3.8",
-    "axios": "^1.7.4",
     "chalk": "4.1.2",
     "commander": "^12.0.0",
-    "fast-glob": "^3.3.2",
-    "open": "^10.1.0",
-    "prompt-sync": "^4.2.0",
+    "fast-glob": "^3.3.3",
     "update-notifier": "^7.0.0",
-    "validator": "^13.11.0",
-    "winston": "^3.12.0",
-    "winston-transport": "^4.7.0",
-    "yaml": "^2.5.0"
+    "validator": "^13.12.0"
   }
 }


### PR DESCRIPTION
This PR improves the `create` command:
- Provide a list of valid templates to select from.
- Support creating demo apps from their GitHub repo (currently only dbos-node-starter).
- Improving error messages by adding colors and bold fonts.

Will add more templates and clean up the templates in a separate PR.