### PR TITLE
Update templates and fix dbosignore

### DIFF
--- a/packages/create/.npmignore
+++ b/packages/create/.npmignore
@@ -13,24 +13,15 @@ tsconfig.json
 
 # Include the templates code, but not node_modules or dist
 !templates/**
-templates/hello/.dbos
-templates/hello/dist
-templates/hello/node_modules
-templates/hello-prisma/.dbos
-templates/hello-prisma/dist
-templates/hello-prisma/node_modules
-templates/hello-typeorm/.dbos
-templates/hello-typeorm/dist
-templates/hello-typeorm/node_modules
-templates/hello-drizzle/.dbos
-templates/hello-drizzle/dist
-templates/hello-drizzle/node_modules
-templates/hello-express/.dbos
-templates/hello-express/dist
-templates/hello-express/node_modules
-templates/hello-nextjs/.dbos
-templates/hello-nextjs/dist
-templates/hello-nextjs/node_modules
-templates/hello-contexts/.dbos
-templates/hello-contexts/dist
-templates/hello-contexts/node_modules
+templates/dbos-knex/.dbos
+templates/dbos-knex/dist
+templates/dbos-knex/node_modules
+templates/dbos-prisma/.dbos
+templates/dbos-prisma/dist
+templates/dbos-prisma/node_modules
+templates/dbos-typeorm/.dbos
+templates/dbos-typeorm/dist
+templates/dbos-typeorm/node_modules
+templates/dbos-drizzle/.dbos
+templates/dbos-drizzle/dist
+templates/dbos-drizzle/node_modules

--- a/packages/create/init.ts
+++ b/packages/create/init.ts
@@ -150,7 +150,7 @@ export async function init(appName: string, templateName: string) {
 }
 
 // Templates that will be downloaded through the demo apps repository
-export const DEMO_TEMPLATES = ['dbos-node-starter']
+const DEMO_TEMPLATES = ['dbos-node-starter', 'dbos-nextjs-starter'];
 
 // Return a list of available templates
 export function listTemplates(): string[] {

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -64,11 +64,11 @@ async function createZipData(logger: CLILogger): Promise<string> {
 
   const ignorePatterns = parseIgnoreFile(dbosIgnoreFilePath);
   const globIgnorePatterns = ignorePatterns.map((pattern) => {
-    let convertedPattern = convertPathForGlob(path.join(process.cwd(), pattern));
-    if (convertedPattern.endsWith('/')) {
-      convertedPattern = path.join(pattern, "**"); // Recursively ignore directories
+    pattern = convertPathForGlob(path.join(process.cwd(), pattern));
+    if (pattern.endsWith('/')) {
+      pattern = path.join(pattern, "**"); // Recursively ignore directories
     }
-    return convertedPattern;
+    return pattern;
   });
   const hardcodedIgnorePatterns = [ `**/${dbosEnvPath}/**`, "**/node_modules/**", "**/dist/**", "**/.git/**", `**/${dbosConfigFilePath}`, "**/venv/**", "**/.venv/**", "**/.python-version"];
 

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -63,10 +63,13 @@ async function createZipData(logger: CLILogger): Promise<string> {
   const dbosIgnoreFilePath = '.dbosignore';
 
   const ignorePatterns = parseIgnoreFile(dbosIgnoreFilePath);
-  const globIgnorePatterns = ignorePatterns.map((pattern) =>
-    pattern.startsWith('!') ? `!${pattern.slice(1)}` : `**/${pattern}`
-  ) ;
-
+  const globIgnorePatterns = ignorePatterns.map((pattern) => {
+    let convertedPattern = convertPathForGlob(path.join(process.cwd(), pattern));
+    if (convertedPattern.endsWith('/')) {
+      convertedPattern = path.join(pattern, "**"); // Recursively ignore directories
+    }
+    return convertedPattern;
+  });
   const hardcodedIgnorePatterns = [ `**/${dbosEnvPath}/**`, "**/node_modules/**", "**/dist/**", "**/.git/**", `**/${dbosConfigFilePath}`, "**/venv/**", "**/.venv/**", "**/.python-version"];
 
   const files = await fg(globPattern, {


### PR DESCRIPTION
- Include the new `dbos-nextjs-starter` in the create command.
- Fix the ignore patterns of dbosignore. Need to append `**` if the pattern ends with `/`. Otherwise, nothing in that folder can be matched.