### PR TITLE
Detect Invalid Config Setting

### DIFF
--- a/packages/create/templates/dbos-knex/dbos-config.yaml
+++ b/packages/create/templates/dbos-knex/dbos-config.yaml
@@ -11,6 +11,7 @@ database:
   password: ${PGPASSWORD}
   connectionTimeoutMillis: 3000
   app_db_client: knex
+  local_suffix: false
   migrate:
     - npx knex migrate:latest
   rollback:

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -207,7 +207,7 @@ export function parseConfigFile(cliOptions?: ParseOptions, useProxy: boolean = f
   }
 
   if (configFile.database.local_suffix === true && configFile.database.hostname === "localhost") {
-    throw new DBOSInitializationError(`Invalid configuration: local_suffix may only be true when connecting to remote databases, not to localhost`)
+    throw new DBOSInitializationError(`Invalid configuration (${configFilePath}): local_suffix may only be true when connecting to remote databases, not to localhost`)
   }
 
   const schemaValidator = ajv.compile(dbosConfigSchema);

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -206,6 +206,10 @@ export function parseConfigFile(cliOptions?: ParseOptions, useProxy: boolean = f
     }
   }
 
+  if (configFile.database.local_suffix === true && configFile.database.hostname === "localhost") {
+    throw new DBOSInitializationError(`Invalid configuration: local_suffix may only be true when connecting to remote databases, not to localhost`)
+  }
+
   const schemaValidator = ajv.compile(dbosConfigSchema);
   if (!schemaValidator(configFile)) {
     const errorMessages = prettyPrintAjvErrors(schemaValidator);

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -285,7 +285,6 @@ describe("dbos-config", () => {
       expect(poolConfig.password).toBe(process.env.PGPASSWORD);
       expect(poolConfig.connectionTimeoutMillis).toBe(3000);
       expect(poolConfig.database).toBe("some_db_local");
-      expect(dbosConfig.poolConfig.ssl).toBe(false);
     });
 
     test("local_suffix works without app_db_name", async () => {

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -267,7 +267,7 @@ describe("dbos-config", () => {
     test("local_suffix works", async () => {
       const localMockDBOSConfigYamlString = `
         database:
-          hostname: 'localhost'
+          hostname: 'remote.com'
           port: 1234
           username: 'some user'
           password: \${PGPASSWORD}
@@ -279,7 +279,7 @@ describe("dbos-config", () => {
       jest.spyOn(utils, "readFileSync").mockReturnValue(localMockDBOSConfigYamlString);
       const [dbosConfig, _dbosRuntimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(mockCLIOptions);
       const poolConfig = dbosConfig.poolConfig;
-      expect(poolConfig.host).toBe("localhost");
+      expect(poolConfig.host).toBe("remote.com");
       expect(poolConfig.port).toBe(1234);
       expect(poolConfig.user).toBe("some user");
       expect(poolConfig.password).toBe(process.env.PGPASSWORD);
@@ -292,7 +292,7 @@ describe("dbos-config", () => {
       const localMockDBOSConfigYamlString = `
         name: some-app
         database:
-          hostname: 'localhost'
+          hostname: 'remote.com'
           port: 1234
           username: 'some user'
           password: \${PGPASSWORD}
@@ -303,6 +303,21 @@ describe("dbos-config", () => {
       const [dbosConfig, _dbosRuntimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(mockCLIOptions);
       const poolConfig = dbosConfig.poolConfig;
       expect(poolConfig.database).toBe("some_app_local");
+    });
+
+    test("local_suffix cannot be used with localhost", () => {
+      const localMockDBOSConfigYamlString = `
+        name: some-app
+        database:
+          hostname: 'localhost'
+          port: 1234
+          username: 'some user'
+          password: \${PGPASSWORD}
+          local_suffix: true
+      `;
+      jest.restoreAllMocks();
+      jest.spyOn(utils, "readFileSync").mockReturnValue(localMockDBOSConfigYamlString);
+      expect(() => parseConfigFile(mockCLIOptions)).toThrow(DBOSInitializationError);
     });
 
     test("ssl defaults off for localhost", async () => {


### PR DESCRIPTION
`local_suffix` may only be true when connecting a remote database, not to `localhost`