### PR TITLE
Error Later Without Password

### DIFF
--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -200,8 +200,6 @@ export function parseConfigFile(cliOptions?: ParseOptions, useProxy: boolean = f
       const pgPassword: string | undefined = process.env.PGPASSWORD;
       if (pgPassword) {
         configFile.database.password = pgPassword;
-      } else {
-        throw new DBOSInitializationError(`DBOS configuration (${configFilePath}) does not contain database password`);
       }
     }
   }


### PR DESCRIPTION
This allows the DB Wizard to proceed and connect to a database even if a password isn't initially defined.