### PR TITLE
Fix publish; adjust deprecation

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -21,8 +21,9 @@ jobs:
           packages/create,
           packages/dbos-cloud,
           packages/dbos-compiler,
-          packages/dbos-sqs,
+          packages/dbos-confluent-kafka,
           packages/dbos-kafkajs,
+          packages/dbos-sqs,
         ]
     steps:
       - name: Checkout

--- a/src/httpServer/middleware.ts
+++ b/src/httpServer/middleware.ts
@@ -141,12 +141,16 @@ export function KoaGlobalMiddleware(...koaMiddleware: Koa.Middleware[]) {
 
 
 /////////////////////////////////
-/* OPEN API DECORATORS */
+/* OPEN API DECORATORS (Moved) */
 /////////////////////////////////
 
+/**
+ * @deprecated The `@OpenApiSecurityScheme` decorator function has moved to an extension package.
+ * Please install @dbos-inc/dbos-openapi, and update your import.
+ */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function OpenApiSecurityScheme(securityScheme: unknown) {
-  throw new Error("DBOS no longer supports OpenAPI generation as of DBOSv2.0.")
+  throw new Error("@OpenApiSecurityScheme has been moved to the @dbos-inc/dbos-openapi package as of v2.0");
 }
 
 /////////////////////////////////


### PR DESCRIPTION
Two small touchups:
  confluent kafka accidentally left out of 
  As a matter of good habit, use @deprecated on removed code, so the compiler helps people catch problems quicker.