### PR TITLE
Prevent different workflows starting with the same ID

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -57,7 +57,8 @@ export function isClientError(dbosErrorCode: number) {
     dbosErrorCode === WorkflowPermissionDeniedError ||
     dbosErrorCode === TopicPermissionDeniedError ||
     dbosErrorCode === ConflictingUUIDError ||
-    dbosErrorCode === NotRegisteredError
+    dbosErrorCode === NotRegisteredError ||
+    dbosErrorCode === ConflictingWorkflowError
   );
 }
 
@@ -199,5 +200,12 @@ const InvalidWorkflowTransition = 21;
 export class DBOSInvalidWorkflowTransitionError extends DBOSError {
   constructor(msg?: string) {
     super(msg ?? "Invalid workflow state", InvalidWorkflowTransition);
+  }
+}
+
+const ConflictingWorkflowError = 22;
+export class DBOSConflictingWorkflowError extends DBOSError {
+  constructor(workflowID: string, msg: string) {
+    super(`Conflicting workflow invocation with the same ID (${workflowID}): ${msg}`, ConflictingWorkflowError);
   }
 }

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -261,8 +261,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
       this.logger.warn(`Workflow (${initStatus.workflowUUID}) already exists in queue: ${resRow.queue_name}, but the provided queue name is: ${initStatus.queueName}. The queue is not updated.`);
     }
     if (msg !== "") {
-      this.logger.error(`Workflow (${initStatus.workflowUUID}) already exists with a different function: ${msg}`);
-      // throw new DBOSConflictingWorkflowError(initStatus.workflowUUID, msg);
+      throw new DBOSConflictingWorkflowError(initStatus.workflowUUID, msg);
     }
 
     const recovery_attempts = resRow.recovery_attempts;

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -260,9 +260,9 @@ export class PostgresSystemDatabase implements SystemDatabase {
       // This is a warning because a different queue name is not necessarily an error.
       this.logger.warn(`Workflow (${initStatus.workflowUUID}) already exists in queue: ${resRow.queue_name}, but the provided queue name is: ${initStatus.queueName}. The queue is not updated.`);
     }
-    if (msg !== "") {
-      throw new DBOSConflictingWorkflowError(initStatus.workflowUUID, msg);
-    }
+    // if (msg !== "") {
+    //   throw new DBOSConflictingWorkflowError(initStatus.workflowUUID, msg);
+    // }
 
     const recovery_attempts = resRow.recovery_attempts;
     if (recovery_attempts >= initStatus.maxRetries && initStatus.recovery) {

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -246,8 +246,9 @@ export class PostgresSystemDatabase implements SystemDatabase {
     // Check the started workflow matches the expected name, class_name, config_name, and queue_name
     // A mismatch indicates a workflow starting with the same UUID but different functions, which should not be allowed.
     const resRow = result.rows[0];
+    initStatus.configName = initStatus.configName || "";
     resRow.config_name = resRow.config_name || "";
-    resRow.queue_name = resRow.queue_name || undefined;
+    resRow.queue_name = resRow.queue_name === null ? undefined : resRow.queue_name; // Convert null in SQL to undefined
     let msg = "";
     if (resRow.name !== initStatus.name) {
       msg = `Workflow already exists with a different function name: ${resRow.name}, but the provided function name is: ${initStatus.name}`;

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -260,9 +260,10 @@ export class PostgresSystemDatabase implements SystemDatabase {
       // This is a warning because a different queue name is not necessarily an error.
       this.logger.warn(`Workflow (${initStatus.workflowUUID}) already exists in queue: ${resRow.queue_name}, but the provided queue name is: ${initStatus.queueName}. The queue is not updated.`);
     }
-    // if (msg !== "") {
-    //   throw new DBOSConflictingWorkflowError(initStatus.workflowUUID, msg);
-    // }
+    if (msg !== "") {
+      this.logger.error(`Workflow (${initStatus.workflowUUID}) already exists with a different function: ${msg}`);
+      // throw new DBOSConflictingWorkflowError(initStatus.workflowUUID, msg);
+    }
 
     const recovery_attempts = resRow.recovery_attempts;
     if (recovery_attempts >= initStatus.maxRetries && initStatus.recovery) {

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -3,7 +3,7 @@
 import { deserializeError, serializeError } from "serialize-error";
 import { DBOSExecutor, dbosNull, DBOSNull } from "./dbos-executor";
 import { DatabaseError, Pool, PoolClient, Notification, PoolConfig, Client } from "pg";
-import { DBOSWorkflowConflictUUIDError, DBOSNonExistentWorkflowError, DBOSDeadLetterQueueError } from "./error";
+import { DBOSWorkflowConflictUUIDError, DBOSNonExistentWorkflowError, DBOSDeadLetterQueueError, DBOSConflictingWorkflowError } from "./error";
 import { GetWorkflowQueueInput, GetWorkflowQueueOutput, GetWorkflowsInput, GetWorkflowsOutput, StatusString, WorkflowStatus } from "./workflow";
 import {
   notifications,
@@ -202,7 +202,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
   }
 
   async initWorkflowStatus<T extends any[]>(initStatus: WorkflowStatusInternal, args: T): Promise<{args: T, status: string}> {
-    const result = await this.pool.query<{recovery_attempts: number, status: string}>(
+    const result = await this.pool.query<{recovery_attempts: number, status: string, name: string, class_name: string, config_name: string, queue_name?: string}>(
       `INSERT INTO ${DBOSExecutor.systemDBSchemaName}.workflow_status (
         workflow_uuid,
         status,
@@ -223,7 +223,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
        ON CONFLICT (workflow_uuid)
         DO UPDATE SET
           recovery_attempts = CASE WHEN $16 THEN workflow_status.recovery_attempts + 1 ELSE workflow_status.recovery_attempts END
-        RETURNING recovery_attempts, status`,
+        RETURNING recovery_attempts, status, name, class_name, config_name, queue_name`,
       [
         initStatus.workflowUUID,
         initStatus.status,
@@ -243,17 +243,40 @@ export class PostgresSystemDatabase implements SystemDatabase {
         initStatus.recovery,
       ]
     );
-    const recovery_attempts = result.rows[0].recovery_attempts;
+    // Check the started workflow matches the expected name, class_name, config_name, and queue_name
+    // A mismatch indicates a workflow starting with the same UUID but different functions, which should not be allowed.
+    const resRow = result.rows[0];
+    resRow.config_name = resRow.config_name || "";
+    resRow.queue_name = resRow.queue_name || undefined;
+    let msg = "";
+    if (resRow.name !== initStatus.name) {
+      msg = `Workflow already exists with a different function name: ${resRow.name}, but the provided function name is: ${initStatus.name}`;
+    } else if (resRow.class_name !== initStatus.className) {
+      msg = `Workflow already exists with a different class name: ${resRow.class_name}, but the provided class name is: ${initStatus.className}`;
+    } else if (resRow.config_name !== initStatus.configName) {
+      msg = `Workflow already exists with a different config name: ${resRow.config_name}, but the provided config name is: ${initStatus.configName}`;
+    } else if (resRow.queue_name !== initStatus.queueName) {
+      msg = `Workflow already exists with a different queue name: ${resRow.queue_name}, but the provided queue name is: ${initStatus.queueName}`;
+    }
+    if (msg !== "") {
+      throw new DBOSConflictingWorkflowError(initStatus.workflowUUID, msg);
+    }
+
+    const recovery_attempts = resRow.recovery_attempts;
     if (recovery_attempts >= initStatus.maxRetries && initStatus.recovery) {
       await this.pool.query(`UPDATE ${DBOSExecutor.systemDBSchemaName}.workflow_status SET status=$1 WHERE workflow_uuid=$2 AND status=$3`, [StatusString.RETRIES_EXCEEDED, initStatus.workflowUUID, StatusString.PENDING]);
       throw new DBOSDeadLetterQueueError(initStatus.workflowUUID, initStatus.maxRetries);
     }
-    const status = result.rows[0].status;
+    const status = resRow.status;
 
+    const serializedInputs = DBOSJSON.stringify(args);
     const { rows } = await this.pool.query<workflow_inputs>(
       `INSERT INTO ${DBOSExecutor.systemDBSchemaName}.workflow_inputs (workflow_uuid, inputs) VALUES($1, $2) ON CONFLICT (workflow_uuid) DO UPDATE SET workflow_uuid = excluded.workflow_uuid  RETURNING inputs`,
-      [initStatus.workflowUUID, DBOSJSON.stringify(args)]
+      [initStatus.workflowUUID, serializedInputs]
     );
+    if (serializedInputs !== rows[0].inputs) {
+      this.logger.warn(`Workflow inputs for ${initStatus.workflowUUID} changed since the first call! Use the original inputs.`);
+    }
     return {args: DBOSJSON.parse(rows[0].inputs) as T, status};
   }
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -255,7 +255,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     } else if (resRow.class_name !== initStatus.className) {
       msg = `Workflow already exists with a different class name: ${resRow.class_name}, but the provided class name is: ${initStatus.className}`;
     } else if (resRow.config_name !== initStatus.configName) {
-      msg = `Workflow already exists with a different config name: ${resRow.config_name}, but the provided config name is: ${initStatus.configName}`;
+      msg = `Workflow already exists with a different class configuration: ${resRow.config_name}, but the provided class configuration is: ${initStatus.configName}`;
     } else if (resRow.queue_name !== initStatus.queueName) {
       // This is a warning because a different queue name is not necessarily an error.
       this.logger.warn(`Workflow (${initStatus.workflowUUID}) already exists in queue: ${resRow.queue_name}, but the provided queue name is: ${initStatus.queueName}. The queue is not updated.`);

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -256,7 +256,8 @@ export class PostgresSystemDatabase implements SystemDatabase {
     } else if (resRow.config_name !== initStatus.configName) {
       msg = `Workflow already exists with a different config name: ${resRow.config_name}, but the provided config name is: ${initStatus.configName}`;
     } else if (resRow.queue_name !== initStatus.queueName) {
-      msg = `Workflow already exists with a different queue name: ${resRow.queue_name}, but the provided queue name is: ${initStatus.queueName}`;
+      // This is a warning because a different queue name is not necessarily an error.
+      this.logger.warn(`Workflow (${initStatus.workflowUUID}) already exists in queue: ${resRow.queue_name}, but the provided queue name is: ${initStatus.queueName}. The queue is not updated.`);
     }
     if (msg !== "") {
       throw new DBOSConflictingWorkflowError(initStatus.workflowUUID, msg);

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -301,69 +301,69 @@ describe("queued-wf-tests-simple", () => {
         expect(await queueEntriesAreCleanedUp()).toBe(true);
     }, 60000);
 
-    // class TestDuplicateID {
-    //     @DBOS.workflow()
-    //     static async testWorkflow(var1: string) {
-    //         await DBOS.sleepms(10);
-    //         return var1;
-    //     }
+    class TestDuplicateID {
+        @DBOS.workflow()
+        static async testWorkflow(var1: string) {
+            await DBOS.sleepms(10);
+            return var1;
+        }
 
-    //     @DBOS.workflow()
-    //     static async testDupWorkflow() {
-    //         await DBOS.sleepms(10);
-    //         return;
-    //     }
-    // }
+        @DBOS.workflow()
+        static async testDupWorkflow() {
+            await DBOS.sleepms(10);
+            return;
+        }
+    }
 
-    // class TestDuplicateIDdup {
-    //     @DBOS.workflow()
-    //     static async testWorkflow(var1: string) {
-    //         await DBOS.sleepms(10);
-    //         return var1;
-    //     }
-    // }
+    class TestDuplicateIDdup {
+        @DBOS.workflow()
+        static async testWorkflow(var1: string) {
+            await DBOS.sleepms(10);
+            return var1;
+        }
+    }
 
-    // class TestDuplicateIDins extends ConfiguredInstance {
-    //     constructor(name: string) {
-    //         super(name);
-    //     }
+    class TestDuplicateIDins extends ConfiguredInstance {
+        constructor(name: string) {
+            super(name);
+        }
 
-    //     async initialize() {
-    //         return Promise.resolve();
-    //     }
+        async initialize() {
+            return Promise.resolve();
+        }
 
-    //     @DBOS.workflow()
-    //     async testWorkflow(var1: string) {
-    //         await DBOS.sleepms(10);
-    //         return var1;
-    //     }
-    // }
+        @DBOS.workflow()
+        async testWorkflow(var1: string) {
+            await DBOS.sleepms(10);
+            return var1;
+        }
+    }
 
-    // test("duplicate-workflow-id", async() => {
-    //     const wfid = uuidv4();
-    //     const handle1 = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testWorkflow('abc');
-    //     // Call with a different function name within the same class is not allowed.
-    //     await expect(DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testDupWorkflow()).rejects.toThrow(DBOSConflictingWorkflowError);
-    //     // Call the same function name in a different class is not allowed.
-    //     await expect(DBOS.startWorkflow(TestDuplicateIDdup, {workflowID: wfid}).testWorkflow('abc')).rejects.toThrow(DBOSConflictingWorkflowError);
-    //     await expect(handle1.getResult()).resolves.toBe('abc');
+    test("duplicate-workflow-id", async() => {
+        const wfid = uuidv4();
+        const handle1 = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testWorkflow('abc');
+        // Call with a different function name within the same class is not allowed.
+        await expect(DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testDupWorkflow()).rejects.toThrow(DBOSConflictingWorkflowError);
+        // Call the same function name in a different class is not allowed.
+        await expect(DBOS.startWorkflow(TestDuplicateIDdup, {workflowID: wfid}).testWorkflow('abc')).rejects.toThrow(DBOSConflictingWorkflowError);
+        await expect(handle1.getResult()).resolves.toBe('abc');
 
-    //     // Calling itself again should be fine
-    //     const handle2 = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testWorkflow('abc');
-    //     await expect(handle2.getResult()).resolves.toBe('abc');
+        // Calling itself again should be fine
+        const handle2 = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testWorkflow('abc');
+        await expect(handle2.getResult()).resolves.toBe('abc');
 
-    //     // Call the same function in a different configured class is not allowed.
-    //     const myObj = DBOS.configureInstance(TestDuplicateIDins, 'myname');
-    //     await expect(DBOS.startWorkflow(myObj, {workflowID: wfid}).testWorkflow('abc')).rejects.toThrow(DBOSConflictingWorkflowError);
+        // Call the same function in a different configured class is not allowed.
+        const myObj = DBOS.configureInstance(TestDuplicateIDins, 'myname');
+        await expect(DBOS.startWorkflow(myObj, {workflowID: wfid}).testWorkflow('abc')).rejects.toThrow(DBOSConflictingWorkflowError);
 
-    //     // Call the same function in a different queue would generate a warning, but is allowed.
-    //     const handleQ = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid, queueName: queue.name}).testWorkflow('abc');
-    //     await expect(handleQ.getResult()).resolves.toBe('abc');
+        // Call the same function in a different queue would generate a warning, but is allowed.
+        const handleQ = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid, queueName: queue.name}).testWorkflow('abc');
+        await expect(handleQ.getResult()).resolves.toBe('abc');
 
-    //     // Call with a different input would generate a warning, but still use the recorded input.
-    //     const handle3 = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testWorkflow('def');
-    //     await expect(handle3.getResult()).resolves.toBe('abc');
-    // });
+        // Call with a different input would generate a warning, but still use the recorded input.
+        const handle3 = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testWorkflow('def');
+        await expect(handle3.getResult()).resolves.toBe('abc');
+    });
 });
 
 class TestWFs

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -301,69 +301,69 @@ describe("queued-wf-tests-simple", () => {
         expect(await queueEntriesAreCleanedUp()).toBe(true);
     }, 60000);
 
-    class TestDuplicateID {
-        @DBOS.workflow()
-        static async testWorkflow(var1: string) {
-            await DBOS.sleepms(10);
-            return var1;
-        }
+    // class TestDuplicateID {
+    //     @DBOS.workflow()
+    //     static async testWorkflow(var1: string) {
+    //         await DBOS.sleepms(10);
+    //         return var1;
+    //     }
 
-        @DBOS.workflow()
-        static async testDupWorkflow() {
-            await DBOS.sleepms(10);
-            return;
-        }
-    }
+    //     @DBOS.workflow()
+    //     static async testDupWorkflow() {
+    //         await DBOS.sleepms(10);
+    //         return;
+    //     }
+    // }
 
-    class TestDuplicateIDdup {
-        @DBOS.workflow()
-        static async testWorkflow(var1: string) {
-            await DBOS.sleepms(10);
-            return var1;
-        }
-    }
+    // class TestDuplicateIDdup {
+    //     @DBOS.workflow()
+    //     static async testWorkflow(var1: string) {
+    //         await DBOS.sleepms(10);
+    //         return var1;
+    //     }
+    // }
 
-    class TestDuplicateIDins extends ConfiguredInstance {
-        constructor(name: string) {
-            super(name);
-        }
+    // class TestDuplicateIDins extends ConfiguredInstance {
+    //     constructor(name: string) {
+    //         super(name);
+    //     }
 
-        async initialize() {
-            return Promise.resolve();
-        }
+    //     async initialize() {
+    //         return Promise.resolve();
+    //     }
 
-        @DBOS.workflow()
-        async testWorkflow(var1: string) {
-            await DBOS.sleepms(10);
-            return var1;
-        }
-    }
+    //     @DBOS.workflow()
+    //     async testWorkflow(var1: string) {
+    //         await DBOS.sleepms(10);
+    //         return var1;
+    //     }
+    // }
 
-    test("duplicate-workflow-id", async() => {
-        const wfid = uuidv4();
-        const handle1 = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testWorkflow('abc');
-        // Call with a different function name within the same class is not allowed.
-        await expect(DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testDupWorkflow()).rejects.toThrow(DBOSConflictingWorkflowError);
-        // Call the same function name in a different class is not allowed.
-        await expect(DBOS.startWorkflow(TestDuplicateIDdup, {workflowID: wfid}).testWorkflow('abc')).rejects.toThrow(DBOSConflictingWorkflowError);
-        await expect(handle1.getResult()).resolves.toBe('abc');
+    // test("duplicate-workflow-id", async() => {
+    //     const wfid = uuidv4();
+    //     const handle1 = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testWorkflow('abc');
+    //     // Call with a different function name within the same class is not allowed.
+    //     await expect(DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testDupWorkflow()).rejects.toThrow(DBOSConflictingWorkflowError);
+    //     // Call the same function name in a different class is not allowed.
+    //     await expect(DBOS.startWorkflow(TestDuplicateIDdup, {workflowID: wfid}).testWorkflow('abc')).rejects.toThrow(DBOSConflictingWorkflowError);
+    //     await expect(handle1.getResult()).resolves.toBe('abc');
 
-        // Calling itself again should be fine
-        const handle2 = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testWorkflow('abc');
-        await expect(handle2.getResult()).resolves.toBe('abc');
+    //     // Calling itself again should be fine
+    //     const handle2 = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testWorkflow('abc');
+    //     await expect(handle2.getResult()).resolves.toBe('abc');
 
-        // Call the same function in a different configured class is not allowed.
-        const myObj = DBOS.configureInstance(TestDuplicateIDins, 'myname');
-        await expect(DBOS.startWorkflow(myObj, {workflowID: wfid}).testWorkflow('abc')).rejects.toThrow(DBOSConflictingWorkflowError);
+    //     // Call the same function in a different configured class is not allowed.
+    //     const myObj = DBOS.configureInstance(TestDuplicateIDins, 'myname');
+    //     await expect(DBOS.startWorkflow(myObj, {workflowID: wfid}).testWorkflow('abc')).rejects.toThrow(DBOSConflictingWorkflowError);
 
-        // Call the same function in a different queue would generate a warning, but is allowed.
-        const handleQ = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid, queueName: queue.name}).testWorkflow('abc');
-        await expect(handleQ.getResult()).resolves.toBe('abc');
+    //     // Call the same function in a different queue would generate a warning, but is allowed.
+    //     const handleQ = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid, queueName: queue.name}).testWorkflow('abc');
+    //     await expect(handleQ.getResult()).resolves.toBe('abc');
 
-        // Call with a different input would generate a warning, but still use the recorded input.
-        const handle3 = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testWorkflow('def');
-        await expect(handle3.getResult()).resolves.toBe('abc');
-    });
+    //     // Call with a different input would generate a warning, but still use the recorded input.
+    //     const handle3 = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testWorkflow('def');
+    //     await expect(handle3.getResult()).resolves.toBe('abc');
+    // });
 });
 
 class TestWFs

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -1,4 +1,4 @@
-import { StatusString, WorkflowHandle, DBOS } from "../src";
+import { StatusString, WorkflowHandle, DBOS, ConfiguredInstance } from "../src";
 import { DBOSConfig } from "../src/dbos-executor";
 import { generateDBOSTestConfig, setUpDBOSTestDb } from "./helpers";
 import { WorkflowQueue } from "../src";
@@ -18,6 +18,7 @@ import {
     // DEBUG_TRIGGER_WORKFLOW_ENQUEUE,
     setDebugTrigger
 } from "../src/debugpoint";
+import { DBOSConflictingWorkflowError } from "../src/error";
 
 
 const queue = new WorkflowQueue("testQ");
@@ -299,6 +300,69 @@ describe("queued-wf-tests-simple", () => {
         expect((await wfh.getStatus())?.status).toBe('SUCCESS');
         expect(await queueEntriesAreCleanedUp()).toBe(true);
     }, 60000);
+
+    class TestDuplicateID {
+        @DBOS.workflow()
+        static async testWorkflow(var1: string) {
+            await DBOS.sleepms(10);
+            return var1;
+        }
+
+        @DBOS.workflow()
+        static async testDupWorkflow() {
+            await DBOS.sleepms(10);
+            return;
+        }
+    }
+
+    class TestDuplicateIDdup {
+        @DBOS.workflow()
+        static async testWorkflow(var1: string) {
+            await DBOS.sleepms(10);
+            return var1;
+        }
+    }
+
+    class TestDuplicateIDins extends ConfiguredInstance {
+        constructor(name: string) {
+            super(name);
+        }
+
+        async initialize() {
+            return Promise.resolve();
+        }
+
+        @DBOS.workflow()
+        async testWorkflow(var1: string) {
+            await DBOS.sleepms(10);
+            return var1;
+        }
+    }
+
+    test("duplicate-workflow-id", async() => {
+        const wfid = uuidv4();
+        const handle1 = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testWorkflow('abc');
+        // Call with a different function name within the same class is not allowed.
+        await expect(DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testDupWorkflow()).rejects.toThrow(DBOSConflictingWorkflowError);
+        // Call the same function name in a different class is not allowed.
+        await expect(DBOS.startWorkflow(TestDuplicateIDdup, {workflowID: wfid}).testWorkflow('abc')).rejects.toThrow(DBOSConflictingWorkflowError);
+        await expect(handle1.getResult()).resolves.toBe('abc');
+
+        // Calling itself again should be fine
+        const handle2 = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testWorkflow('abc');
+        await expect(handle2.getResult()).resolves.toBe('abc');
+
+        // Call the same function in a different configured class is not allowed.
+        const myObj = DBOS.configureInstance(TestDuplicateIDins, 'myname');
+        await expect(DBOS.startWorkflow(myObj, {workflowID: wfid}).testWorkflow('abc')).rejects.toThrow(DBOSConflictingWorkflowError);
+
+        // Call the same function in a different queue is not allowed.
+        await expect(DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid, queueName: queue.name}).testWorkflow('abc')).rejects.toThrow(DBOSConflictingWorkflowError);
+
+        // Call with a different input would generate a warning, but still use the recorded input.
+        const handle3 = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testWorkflow('def');
+        await expect(handle3.getResult()).resolves.toBe('abc');
+    });
 });
 
 class TestWFs

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -69,12 +69,11 @@ describe("queued-wf-tests-simple", () => {
         TestWFs.wfid = wfid;
 
         const wfh = await DBOS.startWorkflow(TestWFs, {workflowID: wfid, queueName: queue.name}).testWorkflow('abc', '123');
-        expect(await wfh.getResult()).toBe('abcd123');
+        await expect(wfh.getResult()).resolves.toBe('abcd123');
         expect((await wfh.getStatus())?.queueName).toBe('testQ');
 
-        await DBOS.withNextWorkflowID(wfid, async () => {
-            expect(await TestWFs.testWorkflow('abc', '123')).toBe('abcd123');
-        });
+        const wfh2 = await DBOS.startWorkflow(TestWFs, {workflowID: wfid, queueName: queue.name}).testWorkflow('abc', '123');
+        await expect(wfh2.getResult()).resolves.toBe('abcd123');
         expect(TestWFs.wfCounter).toBe(1);
         expect(TestWFs.stepCounter).toBe(1);
 

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -356,8 +356,9 @@ describe("queued-wf-tests-simple", () => {
         const myObj = DBOS.configureInstance(TestDuplicateIDins, 'myname');
         await expect(DBOS.startWorkflow(myObj, {workflowID: wfid}).testWorkflow('abc')).rejects.toThrow(DBOSConflictingWorkflowError);
 
-        // Call the same function in a different queue is not allowed.
-        await expect(DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid, queueName: queue.name}).testWorkflow('abc')).rejects.toThrow(DBOSConflictingWorkflowError);
+        // Call the same function in a different queue would generate a warning, but is allowed.
+        const handleQ = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid, queueName: queue.name}).testWorkflow('abc');
+        await expect(handleQ.getResult()).resolves.toBe('abc');
 
         // Call with a different input would generate a warning, but still use the recorded input.
         const handle3 = await DBOS.startWorkflow(TestDuplicateID, {workflowID: wfid}).testWorkflow('def');

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -69,11 +69,12 @@ describe("queued-wf-tests-simple", () => {
         TestWFs.wfid = wfid;
 
         const wfh = await DBOS.startWorkflow(TestWFs, {workflowID: wfid, queueName: queue.name}).testWorkflow('abc', '123');
-        await expect(wfh.getResult()).resolves.toBe('abcd123');
+        expect(await wfh.getResult()).toBe('abcd123');
         expect((await wfh.getStatus())?.queueName).toBe('testQ');
 
-        const wfh2 = await DBOS.startWorkflow(TestWFs, {workflowID: wfid, queueName: queue.name}).testWorkflow('abc', '123');
-        await expect(wfh2.getResult()).resolves.toBe('abcd123');
+        await DBOS.withNextWorkflowID(wfid, async () => {
+            expect(await TestWFs.testWorkflow('abc', '123')).toBe('abcd123');
+        });
         expect(TestWFs.wfCounter).toBe(1);
         expect(TestWFs.stepCounter).toBe(1);
 


### PR DESCRIPTION
This PR addresses issue https://github.com/dbos-inc/dbos-transact-ts/issues/725 where duplicate workflow ID breaks the existing workflow. The solution is to check the recorded function name, class name, and config name (if any) before proceeding to start the workflow. If there's any difference, throw a `DBOSConflictingWorkflowError` with a clear error message.

This PR also checks the recorded input versus the provided input, and the provided queue name versus the original queue name, and print a warning message if they don't match.