### PR TITLE
Better Database Connection Parameter Management

### DIFF
--- a/dbos-config.schema.json
+++ b/dbos-config.schema.json
@@ -82,13 +82,7 @@
           "type": "array",
           "description": "Specify a list of user DB rollback commands to run"
         }
-      },
-      "required": [
-        "hostname",
-        "port",
-        "username",
-        "password"
-      ]
+      }
     },
     "telemetry": {
       "type": "object",
@@ -186,8 +180,5 @@
       "type": "string",
       "deprecated": true
     }
-  },
-  "required": [
-    "database"
-  ]
+  }
 }

--- a/packages/create/templates/dbos-drizzle/dbos-config.yaml
+++ b/packages/create/templates/dbos-drizzle/dbos-config.yaml
@@ -5,11 +5,6 @@
 
 language: node
 database:
-  hostname: localhost
-  port: 5432
-  username: postgres
-  password: ${PGPASSWORD}
-  connectionTimeoutMillis: 3000
   app_db_client: drizzle
   migrate:
     - npx drizzle-kit migrate

--- a/packages/create/templates/dbos-knex/dbos-config.yaml
+++ b/packages/create/templates/dbos-knex/dbos-config.yaml
@@ -5,13 +5,7 @@
 
 language: node
 database:
-  hostname: localhost
-  port: 5432
-  username: postgres
-  password: ${PGPASSWORD}
-  connectionTimeoutMillis: 3000
   app_db_client: knex
-  local_suffix: false
   migrate:
     - npx knex migrate:latest
   rollback:

--- a/packages/create/templates/dbos-prisma/dbos-config.yaml
+++ b/packages/create/templates/dbos-prisma/dbos-config.yaml
@@ -5,11 +5,6 @@
 
 language: node
 database:
-  hostname: 'localhost'
-  port: 5432
-  username: 'postgres'
-  password: ${PGPASSWORD}
-  connectionTimeoutMillis: 3000
   app_db_client: prisma
   migrate:
     - npx prisma migrate deploy

--- a/packages/create/templates/dbos-typeorm/dbos-config.yaml
+++ b/packages/create/templates/dbos-typeorm/dbos-config.yaml
@@ -5,11 +5,6 @@
 
 language: node
 database:
-  hostname: 'localhost'
-  port: 5432
-  username: 'postgres'
-  password: ${PGPASSWORD}
-  connectionTimeoutMillis: 3000
   app_db_client: typeorm
   migrate:
     - npx typeorm migration:run -d dist/datasource.js

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -218,7 +218,6 @@ if (!process.argv.slice(2).length) {
 //Finally, terminates the program with the exit code.
 export async function runAndLog(action: (configFile: ConfigFile, logger: GlobalLogger) => Promise<number> | number) {
   let logger = new GlobalLogger();
-  const _ = parseConfigFile(); // Validate config file
   const configFile = loadConfigFile(dbosConfigFilePath);
   let terminate = undefined;
   if (configFile.telemetry?.OTLPExporter) {

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -26,7 +26,7 @@ export interface DBOSCLIStartOptions {
   configfile?: string;
   appDir?: string;
   appVersion?: string | boolean;
-  logWhileParsing?: boolean;
+  logWhileParsing?: boolean; // Not a real option--a workaround to prevent the parser's log lines from printing twice
 }
 
 export interface DBOSConfigureOptions {

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -91,7 +91,7 @@ program
   .option('--app-version <string>', 'override DBOS__APPVERSION environment variable')
   .option('--no-app-version', 'ignore DBOS__APPVERSION environment variable')
   .action(async (options: DBOSDebugOptions) => {
-    const [dbosConfig, runtimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(options, options.proxy !== undefined);
+    const [dbosConfig, runtimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(options);
     await debugWorkflow(dbosConfig, runtimeConfig, options.uuid, options.proxy);
   });
 

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -26,7 +26,7 @@ export interface DBOSCLIStartOptions {
   configfile?: string;
   appDir?: string;
   appVersion?: string | boolean;
-  logWhileParsing?: boolean; // Not a real option--a workaround to prevent the parser's log lines from printing twice
+  skipLoggingInParse?: boolean; // Not a real option--a workaround to prevent the parser's log lines from printing twice
 }
 
 export interface DBOSConfigureOptions {
@@ -60,7 +60,7 @@ program
     if (options?.configfile) {
       console.warn("\x1b[33m%s\x1b[0m", "The --configfile option is deprecated. Please use --appDir instead.");
     }
-    options.logWhileParsing = false;
+    options.skipLoggingInParse = true;
     const [dbosConfig, runtimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(options);
     // If no start commands are provided, start the DBOS runtime
     if (runtimeConfig.start.length === 0) {

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -26,6 +26,7 @@ export interface DBOSCLIStartOptions {
   configfile?: string;
   appDir?: string;
   appVersion?: string | boolean;
+  logWhileParsing?: boolean;
 }
 
 export interface DBOSConfigureOptions {
@@ -59,6 +60,7 @@ program
     if (options?.configfile) {
       console.warn("\x1b[33m%s\x1b[0m", "The --configfile option is deprecated. Please use --appDir instead.");
     }
+    options.logWhileParsing = false;
     const [dbosConfig, runtimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(options);
     // If no start commands are provided, start the DBOS runtime
     if (runtimeConfig.start.length === 0) {

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -115,7 +115,7 @@ export function retrieveApplicationName(configFile: ConfigFile): string {
 export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOptions) {
   // Load database connection parameters. If they're not in dbos-config.yaml, load from .dbos/db_connection. Else, use defaults.
   const databaseConnection = loadDatabaseConnection();
-  if (cliOptions?.logWhileParsing !== false) {
+  if (cliOptions?.skipLoggingInParse !== true) {
     const logger = new GlobalLogger();
     if (configFile["database"]["hostname"]) {
       logger.info("Loading database connection parameters from dbos-config.yaml");
@@ -190,7 +190,7 @@ export interface ParseOptions {
   configfile?: string;
   appDir?: string;
   appVersion?: string | boolean;
-  logWhileParsing?: boolean;
+  skipLoggingInParse?: boolean;
 }
 
 /*

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -14,7 +14,6 @@ import fs from "fs";
 import { loadDatabaseConnection } from "./db_connection";
 
 
-
 export const dbosConfigFilePath = "dbos-config.yaml";
 const dbosConfigSchemaPath = path.join(findPackageRoot(__dirname), 'dbos-config.schema.json');
 const dbosConfigSchema = DBOSJSON.parse(readFileSync(dbosConfigSchemaPath)) as object;
@@ -178,7 +177,7 @@ export interface ParseOptions {
  * Parse `dbosConfigFilePath` and return DBOSConfig and DBOSRuntimeConfig
  * Considers DBOSCLIStartOptions if provided, which takes precedence over config file
  * */
-export function parseConfigFile(cliOptions?: ParseOptions, useProxy: boolean = false): [DBOSConfig, DBOSRuntimeConfig] {
+export function parseConfigFile(cliOptions?: ParseOptions): [DBOSConfig, DBOSRuntimeConfig] {
   if (cliOptions?.appDir) {
     process.chdir(cliOptions.appDir);
   }

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -115,7 +115,7 @@ export function retrieveApplicationName(configFile: ConfigFile): string {
 export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOptions) {
   // Load database connection parameters. If they're not in dbos-config.yaml, load from .dbos/db_connection. Else, use defaults.
   const databaseConnection = loadDatabaseConnection();
-  if (cliOptions?.skipLoggingInParse !== true) {
+  if (!cliOptions?.skipLoggingInParse) {
     const logger = new GlobalLogger();
     if (configFile["database"]["hostname"]) {
       logger.info("Loading database connection parameters from dbos-config.yaml");

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -12,6 +12,7 @@ import path from "path";
 import validator from "validator";
 import fs from "fs";
 import { loadDatabaseConnection } from "./db_connection";
+import { GlobalLogger } from "../telemetry/logs";
 
 
 export const dbosConfigFilePath = "dbos-config.yaml";
@@ -111,15 +112,15 @@ export function retrieveApplicationName(configFile: ConfigFile): string {
   return appName;
 }
 
-export function constructPoolConfig(configFile: ConfigFile) {
+export function constructPoolConfig(configFile: ConfigFile, logger: GlobalLogger = new GlobalLogger()) {
   // Load database connection parameters. If they're not in dbos-config.yaml, load from .dbos/db_connection. Else, use defaults.
   const databaseConnection = loadDatabaseConnection()
   if (configFile["database"]["hostname"]) {
-    console.log("Loading database connection parameters from dbos-config.yaml")
+    logger.info("Loading database connection parameters from dbos-config.yaml")
   } else if (databaseConnection["hostname"]) {
-    console.log("Loading database connection paraeters from .dbos/db_connection")
+    logger.info("Loading database connection parameters from .dbos/db_connection")
   } else {
-    console.log("Using default database connection parameters")
+    logger.info("Using default database connection parameters")
   }
   configFile["database"]["hostname"] = configFile["database"]["hostname"] || databaseConnection["hostname"] || "localhost";
   configFile["database"]["port"] = configFile["database"]["port"] || databaseConnection["port"] || 5432;

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -114,15 +114,15 @@ export function retrieveApplicationName(configFile: ConfigFile): string {
 
 export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOptions) {
   // Load database connection parameters. If they're not in dbos-config.yaml, load from .dbos/db_connection. Else, use defaults.
-  const databaseConnection = loadDatabaseConnection()
+  const databaseConnection = loadDatabaseConnection();
   if (cliOptions?.logWhileParsing !== false) {
-    const logger = new GlobalLogger()
+    const logger = new GlobalLogger();
     if (configFile["database"]["hostname"]) {
-      logger.info("Loading database connection parameters from dbos-config.yaml")
+      logger.info("Loading database connection parameters from dbos-config.yaml");
     } else if (databaseConnection["hostname"]) {
-      logger.info("Loading database connection parameters from .dbos/db_connection")
+      logger.info("Loading database connection parameters from .dbos/db_connection");
     } else {
-      logger.info("Using default database connection parameters")
+      logger.info("Using default database connection parameters");
     }
   }
   configFile["database"]["hostname"] = configFile["database"]["hostname"] || databaseConnection["hostname"] || "localhost";

--- a/src/dbos-runtime/db_connection.ts
+++ b/src/dbos-runtime/db_connection.ts
@@ -1,0 +1,39 @@
+import * as path from 'path';
+import * as fs from 'fs';
+
+const DB_CONNECTION_PATH = path.join(".dbos", "db_connection");
+
+interface DatabaseConnection {
+    hostname: string | null;
+    port: number | null;
+    username: string | null;
+    password: string | null;
+    local_suffix: boolean | null;
+}
+
+export function loadDatabaseConnection(): DatabaseConnection {
+    try {
+        const rawData = fs.readFileSync(DB_CONNECTION_PATH, 'utf8');
+        const data = JSON.parse(rawData) as DatabaseConnection;
+        return {
+            hostname: data.hostname ?? null,
+            port: data.port ?? null,
+            username: data.username ?? null,
+            password: data.password ?? null,
+            local_suffix: data.local_suffix ?? null,
+        };
+    } catch {
+        return {
+            hostname: null,
+            port: null,
+            username: null,
+            password: null,
+            local_suffix: null,
+        };
+    }
+}
+
+export function saveDatabaseConnection(connection: DatabaseConnection): void {
+    fs.mkdirSync(".dbos", { recursive: true });
+    fs.writeFileSync(DB_CONNECTION_PATH, JSON.stringify(connection));
+}

--- a/src/dbos-runtime/db_connection.ts
+++ b/src/dbos-runtime/db_connection.ts
@@ -23,7 +23,7 @@ export function loadDatabaseConnection(): DatabaseConnection {
             password: data.password ?? null,
             local_suffix: data.local_suffix ?? null,
         };
-    } catch {
+    } catch (e) {
         return {
             hostname: null,
             port: null,

--- a/src/dbos-runtime/db_connection.ts
+++ b/src/dbos-runtime/db_connection.ts
@@ -4,7 +4,7 @@ import { readFileSync } from "../utils";
 
 const DB_CONNECTION_PATH = path.join(".dbos", "db_connection");
 
-interface DatabaseConnection {
+export interface DatabaseConnection {
     hostname: string | null;
     port: number | null;
     username: string | null;

--- a/src/dbos-runtime/db_connection.ts
+++ b/src/dbos-runtime/db_connection.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
-import * as fs from 'fs';
+import * as fs from 'fs'
+import { readFileSync } from "../utils";
 
 const DB_CONNECTION_PATH = path.join(".dbos", "db_connection");
 
@@ -13,7 +14,7 @@ interface DatabaseConnection {
 
 export function loadDatabaseConnection(): DatabaseConnection {
     try {
-        const rawData = fs.readFileSync(DB_CONNECTION_PATH, 'utf8');
+        const rawData = readFileSync(DB_CONNECTION_PATH, 'utf8');
         const data = JSON.parse(rawData) as DatabaseConnection;
         return {
             hostname: data.hostname ?? null,

--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -8,7 +8,7 @@ import { schemaExistsQuery, txnOutputIndexExistsQuery, txnOutputTableExistsQuery
 import { db_wizard } from "./db_wizard";
 
 export async function migrate(configFile: ConfigFile, logger: GlobalLogger) {
-  let poolConfig: PoolConfig = constructPoolConfig(configFile)
+  let poolConfig: PoolConfig = constructPoolConfig(configFile, logger)
   poolConfig = await db_wizard(poolConfig);
   logger.info(`Starting migration: creating database ${poolConfig.database} if it does not exist`);
   await createDBIfDoesNotExist(poolConfig, logger);
@@ -19,7 +19,7 @@ export async function migrate(configFile: ConfigFile, logger: GlobalLogger) {
     migrationCommands?.forEach((cmd) => {
       logger.info(`Executing migration command: ${cmd}`);
       const migrateCommandOutput = execSync(cmd, { encoding: 'utf-8' });
-      logger.info(migrateCommandOutput.trimEnd());
+      console.log(migrateCommandOutput.trimEnd());
     });
   } catch (e) {
     logMigrationError(e, logger, "Error running migration")

--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -8,7 +8,7 @@ import { schemaExistsQuery, txnOutputIndexExistsQuery, txnOutputTableExistsQuery
 import { db_wizard } from "./db_wizard";
 
 export async function migrate(configFile: ConfigFile, logger: GlobalLogger) {
-  let poolConfig: PoolConfig = constructPoolConfig(configFile, logger)
+  let poolConfig: PoolConfig = constructPoolConfig(configFile)
   poolConfig = await db_wizard(poolConfig);
   logger.info(`Starting migration: creating database ${poolConfig.database} if it does not exist`);
   await createDBIfDoesNotExist(poolConfig, logger);

--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -8,11 +8,9 @@ import { schemaExistsQuery, txnOutputIndexExistsQuery, txnOutputTableExistsQuery
 import { db_wizard } from "./db_wizard";
 
 export async function migrate(configFile: ConfigFile, logger: GlobalLogger) {
-  const userDBName = configFile.database.app_db_name;
-  logger.info(`Starting migration: creating database ${userDBName} if it does not exist`);
-
   let poolConfig: PoolConfig = constructPoolConfig(configFile)
   poolConfig = await db_wizard(poolConfig);
+  logger.info(`Starting migration: creating database ${poolConfig.database} if it does not exist`);
   await createDBIfDoesNotExist(poolConfig, logger);
 
   const migrationCommands = configFile.database.migrate;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,22 +2,9 @@ import fs from "fs";
 import path from "path";
 
 /*
- * Use the node.js `fs` module to read the content of a file
- * Handles cases where:
- * - the file does not exist
- * - the file is not a valid file
+ * A wrapper of readFileSync used for mocking in tests
  **/
 export function readFileSync(path: string, encoding: BufferEncoding = "utf8"): string {
-  // First, check the file
-  fs.stat(path, (error: NodeJS.ErrnoException | null, stats: fs.Stats) => {
-    if (error) {
-      throw new Error(`checking on ${path}. ${error.code}: ${error.errno}`);
-    } else if (!stats.isFile()) {
-      throw new Error(`config file ${path} is not a file`);
-    }
-  });
-
-  // Then, read its content
   return fs.readFileSync(path, { encoding } );
 }
 

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -401,7 +401,7 @@ describe("dbos-config", () => {
       `;
       jest.restoreAllMocks();
       jest.spyOn(utils, "readFileSync").mockReturnValue(localMockDBOSConfigYamlString);
-      const [dbosConfig, _]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(mockCLIOptions, true); // Use proxy
+      const [dbosConfig, _]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(mockCLIOptions);
 
       // Test pool config options
       const poolConfig: PoolConfig = dbosConfig.poolConfig;

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -408,7 +408,7 @@ describe("dbos-config", () => {
       expect(poolConfig.host).toBe("some host");
       expect(poolConfig.port).toBe(1234);
       expect(poolConfig.user).toBe("some user");
-      expect(poolConfig.password).toBe("PROXY-MODE"); // Should be set to "PROXY-MODE"
+      expect(poolConfig.password).toBe("dbos");
       expect(poolConfig.database).toBe("some_db");
       process.env.PGPASSWORD = dbPassword;
     });

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -150,6 +150,24 @@ describe("dbos-config", () => {
       expect(dbosConfig.poolConfig.database).toEqual("some_app");
     });
 
+    test("using dbconnection file", () => {
+      const localMockDBOSConfigYamlString = `
+        name: some-app
+      `;
+      jest.spyOn(utils, "readFileSync").mockReturnValueOnce(localMockDBOSConfigYamlString);
+      const mockDatabaseConnectionFile = `
+        {"hostname": "example.com", "port": 2345, "username": "example", "password": "password", "local_suffix": true}
+      `
+      jest.spyOn(utils, "readFileSync").mockReturnValueOnce(mockDatabaseConnectionFile);
+      jest.spyOn(utils, "readFileSync").mockReturnValueOnce("SQL STATEMENTS");
+      const [dbosConfig, _dbosRuntimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(mockCLIOptions);
+      expect(dbosConfig.poolConfig.host).toEqual("example.com");
+      expect(dbosConfig.poolConfig.port).toEqual(2345);
+      expect(dbosConfig.poolConfig.user).toEqual("example");
+      expect(dbosConfig.poolConfig.password).toEqual("password");
+      expect(dbosConfig.poolConfig.database).toEqual("some_app_local");
+    });
+
     test("config file specifies the wrong language", () => {
       const localMockDBOSConfigYamlString = `
       language: 'python'

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -134,6 +134,22 @@ describe("dbos-config", () => {
       expect(dbosConfig.poolConfig.database).toEqual("some_app");
     });
 
+    test("config file loads mixed params", () => {
+      const localMockDBOSConfigYamlString = `
+        name: some-app
+        database:
+          hostname: 'some host'
+      `;
+      jest.spyOn(utils, "readFileSync").mockReturnValueOnce(localMockDBOSConfigYamlString);
+      jest.spyOn(utils, "readFileSync").mockReturnValueOnce("SQL STATEMENTS");
+      const [dbosConfig, _dbosRuntimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(mockCLIOptions);
+      expect(dbosConfig.poolConfig.host).toEqual("some host");
+      expect(dbosConfig.poolConfig.port).toEqual(5432);
+      expect(dbosConfig.poolConfig.user).toEqual("postgres");
+      expect(dbosConfig.poolConfig.password).toEqual(process.env.PGPASSWORD);
+      expect(dbosConfig.poolConfig.database).toEqual("some_app");
+    });
+
     test("config file specifies the wrong language", () => {
       const localMockDBOSConfigYamlString = `
       language: 'python'

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -423,31 +423,6 @@ describe("dbos-config", () => {
       expect(() => parseConfigFile(mockCLIOptions)).toThrow(DBOSInitializationError);
     });
 
-    test("parseConfigFile allows undefined password for debug mode with proxy", async () => {
-      const dbPassword = process.env.PGPASSWORD;
-      delete process.env.PGPASSWORD;
-      const localMockDBOSConfigYamlString = `
-        database:
-          hostname: 'some host'
-          port: 1234
-          username: 'some user'
-          password: \${PGPASSWORD}
-          app_db_name: 'some_db'
-      `;
-      jest.restoreAllMocks();
-      jest.spyOn(utils, "readFileSync").mockReturnValue(localMockDBOSConfigYamlString);
-      const [dbosConfig, _]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(mockCLIOptions);
-
-      // Test pool config options
-      const poolConfig: PoolConfig = dbosConfig.poolConfig;
-      expect(poolConfig.host).toBe("some host");
-      expect(poolConfig.port).toBe(1234);
-      expect(poolConfig.user).toBe("some user");
-      expect(poolConfig.password).toBe("dbos");
-      expect(poolConfig.database).toBe("some_db");
-      process.env.PGPASSWORD = dbPassword;
-    });
-
     test("parseConfigFile throws on an invalid db name", async () => {
       const invalidNames = ["some_DB", "123db", "very_very_very_long_very_very_very_long_very_very__database_name", "largeDB", ""];
       for (const dbName of invalidNames) {


### PR DESCRIPTION
- Remove database connection parameters from `dbos-config.yaml` by default (though they can still be there)
- Instead, read and store database connection parameters in a hidden local file, `.dbos/db_connection`, which is **not committed to version control**.
- If no connection parameters are given, use local connection defaults.
- Clearly print where database connection parameters are being read from at DBOS startup.