### PR TITLE
Queues max worker concurrency

### DIFF
--- a/migrations/20252101000000_workflow_queues_executor_id.js
+++ b/migrations/20252101000000_workflow_queues_executor_id.js
@@ -1,0 +1,13 @@
+exports.up = function (knex) {
+    return knex.schema.withSchema('dbos')
+      .table('workflow_queue', function (table) {
+        table.text('executor_id');
+      });
+};
+
+exports.down = function (knex) {
+    return knex.schema.withSchema('dbos')
+      .table('workflow_queue', function (table) {
+        table.dropColumn('executor_id');
+      });
+}

--- a/schemas/system_db_schema.ts
+++ b/schemas/system_db_schema.ts
@@ -54,6 +54,7 @@ export interface event_dispatch_kv {
 export interface workflow_queue {
   workflow_uuid: string;
   queue_name: string;
+  executor_id: string;
   created_at_epoch_ms: number; // This time is provided by the database
   started_at_epoch_ms?: number; // This time is provided by the client
   completed_at_epoch_ms?: number; // This time is provided by the client

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1014,7 +1014,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     }
   }
 
-  async  findAndMarkStartableWorkflows(queue: WorkflowQueue, executorID: string): Promise<string[]> {
+  async findAndMarkStartableWorkflows(queue: WorkflowQueue, executorID: string): Promise<string[]> {
     const startTimeMs = new Date().getTime();
     const limiterPeriodMS = queue.rateLimit ? queue.rateLimit.periodSec * 1000 : 0;
     const claimedIDs: string[] = [];
@@ -1034,23 +1034,27 @@ export class PostgresSystemDatabase implements SystemDatabase {
         }
       }
 
-      // Select not-yet-completed functions in the queue ordered by the
-      //   time at which they were enqueued.
-      // If there is a concurrency limit N, select only the N most recent
-      //   functions, else select all of them.
-      // Started functions count toward concurrency, will be filtered below
+      // Dequeue functions eligible for this worker and ordered by the time at which they were enqueued.
+      // If there is a global or local concurrency limit N, select only the N oldest enqueued
+      // functions, else select all of them.
       let query = trx<workflow_queue>(`${DBOSExecutor.systemDBSchemaName}.workflow_queue`)
         .whereNull('completed_at_epoch_ms')
         .andWhere('queue_name', queue.name)
+        .andWhere(function() {
+          this.whereNull("executor_id")
+          .orWhere("executor_id", executorID);
+        })
         .select();
       query = query.orderBy('created_at_epoch_ms', 'asc');
-      if (queue.concurrency !== undefined) {
+      if (queue.worker_concurrency !== undefined) {
+        query = query.limit(queue.worker_concurrency);
+      } else if (queue.concurrency !== undefined) {
         query = query.limit(queue.concurrency);
       }
 
       // From the functions retrieved, get the workflow IDs of the functions
       // that have not yet been started so we can start them.
-      const rows = await query.select(['workflow_uuid', 'started_at_epoch_ms']);
+      const rows = await query.select(['workflow_uuid', 'started_at_epoch_ms', 'executor_id']);
       const workflowIDs = rows
         .filter((row) => !row.started_at_epoch_ms)
         .map(row => row.workflow_uuid);
@@ -1072,7 +1076,8 @@ export class PostgresSystemDatabase implements SystemDatabase {
           claimedIDs.push(id);
           await trx<workflow_queue>(`${DBOSExecutor.systemDBSchemaName}.workflow_queue`)
             .where('workflow_uuid', id)
-            .update('started_at_epoch_ms', startTimeMs);
+            .update('started_at_epoch_ms', startTimeMs)
+            .update('executor_id', executorID);
         }
         // If we did not update this record, probably someone else did.  Count in either case.
         ++numRecentQueries;

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1041,7 +1041,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
         .whereNull('completed_at_epoch_ms')
         .andWhere('queue_name', queue.name)
         .andWhere(function() {
-          this.whereNull("executor_id")
+          void this.whereNull("executor_id")
           .orWhere("executor_id", executorID);
         })
         .select();

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1046,8 +1046,8 @@ export class PostgresSystemDatabase implements SystemDatabase {
         })
         .select();
       query = query.orderBy('created_at_epoch_ms', 'asc');
-      if (queue.worker_concurrency !== undefined) {
-        query = query.limit(queue.worker_concurrency);
+      if (queue.workerConcurrency !== undefined) {
+        query = query.limit(queue.workerConcurrency);
       } else if (queue.concurrency !== undefined) {
         query = query.limit(queue.concurrency);
       }

--- a/src/wfqueue.ts
+++ b/src/wfqueue.ts
@@ -14,7 +14,7 @@ interface QueueRateLimit {
 }
 
 export class WorkflowQueue {
-    constructor(readonly name: string, readonly concurrency?: number, readonly rateLimit?: QueueRateLimit) {
+    constructor(readonly name: string, readonly concurrency?: number, readonly rateLimit?: QueueRateLimit, readonly worker_concurrency?: number) {
         if (wfQueueRunner.wfQueuesByName.has(name)) {
             throw new DBOSInitializationError(`Workflow Queue '${name}' defined multiple times`);
         }

--- a/src/wfqueue.ts
+++ b/src/wfqueue.ts
@@ -14,7 +14,7 @@ interface QueueRateLimit {
 }
 
 interface QueueParameters {
-    worker_concurrency?: number;
+    workerConcurrency?: number;
     concurrency?: number;
     rateLimit?: QueueRateLimit;
 }
@@ -23,7 +23,7 @@ export class WorkflowQueue {
     readonly name: string;
     readonly concurrency?: number;
     readonly rateLimit?: QueueRateLimit;
-    readonly worker_concurrency?: number;
+    readonly workerConcurrency?: number;
 
     constructor(name: string, queueParameters: QueueParameters);
     constructor(name: string, concurrency?: number, rateLimit?: QueueRateLimit);
@@ -39,7 +39,7 @@ export class WorkflowQueue {
             // Handle the case where the second argument is QueueParameters
             this.concurrency = arg2.concurrency;
             this.rateLimit = arg2.rateLimit;
-            this.worker_concurrency = arg2.worker_concurrency;
+            this.workerConcurrency = arg2.workerConcurrency;
         } else {
             // Handle the case where the second argument is a number
             this.concurrency = arg2;

--- a/src/wfqueue.ts
+++ b/src/wfqueue.ts
@@ -13,8 +13,39 @@ interface QueueRateLimit {
     periodSec: number;
 }
 
+interface QueueParameters {
+    worker_concurrency?: number;
+    concurrency?: number;
+    rateLimit?: QueueRateLimit;
+}
+
 export class WorkflowQueue {
-    constructor(readonly name: string, readonly concurrency?: number, readonly rateLimit?: QueueRateLimit, readonly worker_concurrency?: number) {
+    readonly name: string;
+    readonly concurrency?: number;
+    readonly rateLimit?: QueueRateLimit;
+    readonly worker_concurrency?: number;
+
+    constructor(name: string, queueParameters: QueueParameters);
+    constructor(name: string, concurrency?: number, rateLimit?: QueueRateLimit);
+
+    constructor(
+        name: string,
+        arg2?: QueueParameters | number,
+        rateLimit?: QueueRateLimit,
+    ) {
+        this.name = name;
+
+        if (typeof arg2 === "object" && arg2 !== null) {
+            // Handle the case where the second argument is QueueParameters
+            this.concurrency = arg2.concurrency;
+            this.rateLimit = arg2.rateLimit;
+            this.worker_concurrency = arg2.worker_concurrency;
+        } else {
+            // Handle the case where the second argument is a number
+            this.concurrency = arg2;
+            this.rateLimit = rateLimit;
+        }
+
         if (wfQueueRunner.wfQueuesByName.has(name)) {
             throw new DBOSInitializationError(`Workflow Queue '${name}' defined multiple times`);
         }

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -434,15 +434,18 @@ describe("queued-wf-tests-concurrent-workers", () => {
           // Wait for all workers to complete
           await Promise.all(workers.map((w) => w.promise));
         } finally {
-          // Kill all worker processes
+          // Kill all worker processes, regardless of whether they exited successfully
           for (const { process } of workers) {
             process.kill();
           }
         }
 
-        await DBOS.launch();
-        expect(await queueEntriesAreCleanedUp()).toBe(true);
-        await DBOS.shutdown();
+        try {
+          await DBOS.launch();
+          expect(await queueEntriesAreCleanedUp()).toBe(true);
+        } finally {
+          await DBOS.shutdown();
+        }
     }, 60000);
 });
 

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -25,6 +25,7 @@ const queue = new WorkflowQueue("testQ");
 const serialqueue = new WorkflowQueue("serialQ", 1);
 const serialqueueLimited = new WorkflowQueue("serialQL", 1, {limitPerPeriod: 10, periodSec: 1});
 const childqueue = new WorkflowQueue("childQ", 3);
+const workerConcurrencyQueue = new WorkflowQueue("workerQ", undefined, undefined, 1);
 
 const qlimit = 5;
 const qperiod = 2
@@ -47,7 +48,7 @@ async function queueEntriesAreCleanedUp() {
 
 describe("queued-wf-tests-simple", () => {
     let config: DBOSConfig;
-  
+
     beforeAll(async () => {
         config = generateDBOSTestConfig();
         await setUpDBOSTestDb(config);
@@ -63,7 +64,7 @@ describe("queued-wf-tests-simple", () => {
     afterEach(async () => {
         await DBOS.shutdown();
     }, 10000);
-  
+
     test("simple-queue", async () => {
         const wfid = uuidv4();
         TestWFs.wfid = wfid;
@@ -91,6 +92,10 @@ describe("queued-wf-tests-simple", () => {
 
     test("test_one_at_a_time_with_limiter", async() => {
         await runOneAtATime(serialqueueLimited);
+    }, 10000);
+
+    test.only("test_one_at_a_time_with_worker_concurrency", async () => {
+        await runOneAtATime(workerConcurrencyQueue);
     }, 10000);
 
     test("test-queue_rate_limit", async() => {

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -446,7 +446,7 @@ describe("queued-wf-tests-concurrent-workers", () => {
         } finally {
           await DBOS.shutdown();
         }
-    }, 60000);
+    }, 120000);
 });
 
 class TestWFs

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -410,8 +410,13 @@ describe("queued-wf-tests-concurrent-workers", () => {
                 if (stderr) console.error(`Worker ${i} stderr: ${stderr}`);
               })
               .catch((error) => {
-                console.error(`Worker ${i} failed: ${error.message}`);
-                throw error;
+                if (error instanceof Error) {
+                  console.error(`Worker ${i} failed: ${error.message}`);
+                  throw error;
+                } else {
+                  console.error(`Worker ${i} failed with an unknown error: ${String(error)}`);
+                  throw new Error(`Worker ${i} failed with an unknown error`);
+                }
               });
 
               workerPromises.push(workerPromise);

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -23,7 +23,7 @@ import { DBOSConflictingWorkflowError } from "../src/error";
 
 const queue = new WorkflowQueue("testQ");
 const serialqueue = new WorkflowQueue("serialQ", 1);
-const serialqueueLimited = new WorkflowQueue("serialQL", {concurrency: 1, rateLimit: {limitPerPeriod: 10, periodSec: 1}});
+const serialqueueLimited = new WorkflowQueue("serialQL", { concurrency: 1, rateLimit: { limitPerPeriod: 10, periodSec: 1 } });
 const childqueue = new WorkflowQueue("childQ", 3);
 const workerConcurrencyQueue = new WorkflowQueue("workerQ", { workerConcurrency: 1 });
 
@@ -380,7 +380,7 @@ describe("queued-wf-tests-concurrent-workers", () => {
         DBOS.setConfig(config);
     });
 
-    test.only("test_worker_concurrency", async () => {
+    test("test_worker_concurrency", async () => {
         await DBOS.launch();
 
         // Queue N tasks then shutdown DBOS so we don't dequeue

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -94,7 +94,7 @@ describe("queued-wf-tests-simple", () => {
         await runOneAtATime(serialqueueLimited);
     }, 10000);
 
-    test.only("test_one_at_a_time_with_worker_concurrency", async () => {
+    test("test_one_at_a_time_with_worker_concurrency", async () => {
         await runOneAtATime(workerConcurrencyQueue);
     }, 10000);
 
@@ -288,7 +288,7 @@ describe("queued-wf-tests-simple", () => {
                 'DIE_ON_PURPOSE': 'true',
             }
         });
-    
+
         expect(stderr).toBeDefined();
         expect(stdout).toBeDefined();
 

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -25,7 +25,7 @@ const queue = new WorkflowQueue("testQ");
 const serialqueue = new WorkflowQueue("serialQ", 1);
 const serialqueueLimited = new WorkflowQueue("serialQL", 1, {limitPerPeriod: 10, periodSec: 1});
 const childqueue = new WorkflowQueue("childQ", 3);
-const workerConcurrencyQueue = new WorkflowQueue("workerQ", undefined, undefined, 1);
+const workerConcurrencyQueue = new WorkflowQueue("workerQ", { worker_concurrency: 1 });
 
 const qlimit = 5;
 const qperiod = 2

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -380,14 +380,14 @@ describe("queued-wf-tests-concurrent-workers", () => {
         DBOS.setConfig(config);
     });
 
-    test("test_worker_concurrency", async () => {
+    test.only("test_worker_concurrency", async () => {
         await DBOS.launch();
 
         // Queue N tasks then shutdown DBOS so we don't dequeue
         const N = 10;
         const handles: WorkflowHandle<void>[] = [];
         for (let i = 0; i < N; ++i) {
-            const h = await DBOS.startWorkflow(WFQ, { queueName: workerConcurrencyQueue.name }).noop();
+            const h = await DBOS.startWorkflow(TestWFs, { queueName: workerConcurrencyQueue.name }).noop();
             handles.push(h);
         }
         await DBOS.shutdown(); // Do not want to take queued jobs from here

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -25,7 +25,7 @@ const queue = new WorkflowQueue("testQ");
 const serialqueue = new WorkflowQueue("serialQ", 1);
 const serialqueueLimited = new WorkflowQueue("serialQL", 1, {limitPerPeriod: 10, periodSec: 1});
 const childqueue = new WorkflowQueue("childQ", 3);
-const workerConcurrencyQueue = new WorkflowQueue("workerQ", { worker_concurrency: 1 });
+const workerConcurrencyQueue = new WorkflowQueue("workerQ", { workerConcurrency: 1 });
 
 const qlimit = 5;
 const qperiod = 2

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -23,7 +23,7 @@ import { DBOSConflictingWorkflowError } from "../src/error";
 
 const queue = new WorkflowQueue("testQ");
 const serialqueue = new WorkflowQueue("serialQ", 1);
-const serialqueueLimited = new WorkflowQueue("serialQL", 1, {limitPerPeriod: 10, periodSec: 1});
+const serialqueueLimited = new WorkflowQueue("serialQL", {concurrency: 1, rateLimit: {limitPerPeriod: 10, periodSec: 1}});
 const childqueue = new WorkflowQueue("childQ", 3);
 const workerConcurrencyQueue = new WorkflowQueue("workerQ", { workerConcurrency: 1 });
 

--- a/tests/wfqueueworker.ts
+++ b/tests/wfqueueworker.ts
@@ -2,6 +2,8 @@ import { DBOS } from '../src';
 import { generateDBOSTestConfig } from './helpers';
 import { sleepms } from "../src/utils";
 
+// This declaration is just for registration in DBOS internal operations registry
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 class TestWFs
 {
       @DBOS.workflow()

--- a/tests/wfqueueworker.ts
+++ b/tests/wfqueueworker.ts
@@ -1,8 +1,6 @@
-import { DBOS, WorkflowQueue } from '../src';
+import { DBOS } from '../src';
 import { generateDBOSTestConfig } from './helpers';
 import { sleepms } from "../src/utils";
-
-const workerConcurrencyQueue = new WorkflowQueue("workerQ", { worker_concurrency: 1 });
 
 class TestWFs
 {
@@ -21,8 +19,17 @@ async function main() {
   await sleepms(5000);
 
   await DBOS.shutdown();
+
+  process.exit(0);
 }
 
 if (require.main === module) {
-  main().then(()=>{}).catch((e)=>{console.log(e)});
+  main()
+    .then(() => {
+      process.exit(0);
+    })
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    });
 }

--- a/tests/wfqueueworker.ts
+++ b/tests/wfqueueworker.ts
@@ -2,6 +2,7 @@ import { DBOS, WorkflowQueue } from '../src';
 import { generateDBOSTestConfig } from './helpers';
 import { sleepms } from "../src/utils";
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const workerConcurrencyQueue = new WorkflowQueue("workerQ", { workerConcurrency: 1 });
 
 // This declaration is just for registration in DBOS internal operations registry

--- a/tests/wfqueueworker.ts
+++ b/tests/wfqueueworker.ts
@@ -1,0 +1,28 @@
+import { DBOS, WorkflowQueue } from '../src';
+import { generateDBOSTestConfig } from './helpers';
+import { sleepms } from "../src/utils";
+
+const workerConcurrencyQueue = new WorkflowQueue("workerQ", { worker_concurrency: 1 });
+
+class TestWFs
+{
+      @DBOS.workflow()
+    static async noop() {
+        return Promise.resolve();
+    }
+}
+
+async function main() {
+  const config = generateDBOSTestConfig();
+  DBOS.setConfig(config);
+  await DBOS.launch();
+
+  // Sleep for several poll intervals
+  await sleepms(5000);
+
+  await DBOS.shutdown();
+}
+
+if (require.main === module) {
+  main().then(()=>{}).catch((e)=>{console.log(e)});
+}


### PR DESCRIPTION
- Implement worker concurrency limits for workflow queues. Same logic as in https://github.com/dbos-inc/dbos-transact-py/pull/177
- `worker_concurrency` is only available in a new constructor using an object as input -- much easier to use as we add arguments to the class.

Sanity check on the distributed test:

![Screenshot 2025-01-23 at 18 03 15](https://github.com/user-attachments/assets/164f4a55-7dc5-4067-a28f-8fb587e38a92)
