### PR TITLE
Don't publish artifact to GH

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -41,10 +41,10 @@ jobs:
         with:
           name: packages
           path: out/dbos-inc-*.tgz
-      - name: Publish Packages
-        run: npm publish --workspaces --include-workspace-root
-        # boolean properties from NBGV step appears to be converted into *capitalized* strings
-        # so explicitly string compare PublicRelease output value
-        if: ${{ steps.nbgv.outputs.PublicRelease == 'True'}}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Publish Packages
+      #   run: npm publish --workspaces --include-workspace-root
+      #   # boolean properties from NBGV step appears to be converted into *capitalized* strings
+      #   # so explicitly string compare PublicRelease output value
+      #   if: ${{ steps.nbgv.outputs.PublicRelease == 'True'}}
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We have all of our packages on npm. No longer need to publish the package to GH for every PR.