### PR TITLE
Better Step Errors

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Span } from "@opentelemetry/sdk-trace-base";
-import { DBOSError, DBOSInitializationError, DBOSWorkflowConflictUUIDError, DBOSNotRegisteredError, DBOSDebuggerError, DBOSConfigKeyTypeError, DBOSFailedSqlTransactionError } from "./error";
+import { DBOSError, DBOSInitializationError, DBOSWorkflowConflictUUIDError, DBOSNotRegisteredError, DBOSDebuggerError, DBOSConfigKeyTypeError, DBOSFailedSqlTransactionError, DBOSMaxStepRetriesError } from "./error";
 import {
   InvokedHandle,
   Workflow,
@@ -1422,6 +1422,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
     // After reaching the maximum number of retries, throw an DBOSError.
     let result: R | DBOSNull = dbosNull;
     let err: Error | DBOSNull = dbosNull;
+    const errors: Error[] = []
     if (ctxt.retriesAllowed) {
       let numAttempts = 0;
       let intervalSeconds: number = ctxt.intervalSeconds;
@@ -1445,6 +1446,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
           result = cresult!
         } catch (error) {
           const e = error as Error
+          errors.push(e);
           this.logger.warn(`Error in step being automatically retried. Attempt ${numAttempts} of ${ctxt.maxAttempts}. ${e.stack}`);
           span.addEvent(`Step attempt ${numAttempts + 1} failed`, { "retryIntervalSeconds": intervalSeconds, "error": (error as Error).message }, performance.now());
           if (numAttempts < ctxt.maxAttempts) {
@@ -1479,7 +1481,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
     // `result` can only be dbosNull when the step timed out
     if (result === dbosNull) {
       // Record the error, then throw it.
-      err = err === dbosNull ? new DBOSError("Step reached maximum retries.", 1) : err;
+      err = err === dbosNull ? new DBOSMaxStepRetriesError(stepFn.name, ctxt.maxAttempts, errors) : err;
       await this.systemDatabase.recordOperationError(wfCtx.workflowUUID, ctxt.functionID, err as Error);
       ctxt.span.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
       this.tracer.endSpan(ctxt.span);

--- a/src/error.ts
+++ b/src/error.ts
@@ -214,7 +214,8 @@ const MaximumRetriesError = 23;
 export class DBOSMaxStepRetriesError extends DBOSError {
   readonly errors;
   constructor(stepName: string, maxRetries: number, errors: Error[]) {
-    super(`Step ${stepName} has exceeded its maximum of ${maxRetries} retries. Previous errors: ${errors.map(e => e.message).join(', ')}`, MaximumRetriesError);
+    const formattedErrors = errors.map((error, index) => `Error ${index + 1}: ${error.message}`).join('. ')
+    super(`Step ${stepName} has exceeded its maximum of ${maxRetries} retries. Previous errors: ${formattedErrors}`, MaximumRetriesError);
     this.errors = errors;
   }
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -209,3 +209,12 @@ export class DBOSConflictingWorkflowError extends DBOSError {
     super(`Conflicting workflow invocation with the same ID (${workflowID}): ${msg}`, ConflictingWorkflowError);
   }
 }
+
+const MaximumRetriesError = 23;
+export class DBOSMaxStepRetriesError extends DBOSError {
+  readonly errors;
+  constructor(stepName: string, maxRetries: number, errors: Error[]) {
+    super(`Step ${stepName} has exceeded its maximum of ${maxRetries} retries. Previous errors: ${errors.map(e => e.message).join(', ')}`, MaximumRetriesError);
+    this.errors = errors;
+  }
+}


### PR DESCRIPTION
If a step is configured with automatic retries, capture the error message thrown by each retry and include them as a property of the final error object thrown by the step.

Addresses https://github.com/dbos-inc/dbos-transact-ts/issues/724