### PR TITLE
Fix queue recovery

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -1805,7 +1805,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
         );
         if (pendingWorkflow.queueName) {
           try {
-            await this.systemDatabase.reEnqueueWorkflow(pendingWorkflow.workflowUUID);
+            await this.systemDatabase.clearQueueAssignment(pendingWorkflow.workflowUUID);
           } catch (e) {
             // If this is a serialization failure, i.e., some other DBOS process is trying to re-enqueue or complete the workflow, skip it.
             if (this.userDatabase.isRetriableTransactionError(e)) {

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -1798,12 +1798,11 @@ export class DBOSExecutor implements DBOSExecutorContext {
             // If this is a serialization failure, i.e., some other DBOS process is trying to re-enqueue or complete the workflow, skip it.
             if (this.userDatabase.isRetriableTransactionError(e)) {
               this.logger.warn(`Failed to re-enqueue workflow ${pendingWorkflow.workflowUUID}: ${(e as Error).message}`);
+              continue;
             } else {
               throw new DBOSWorkflowRecoveryError(pendingWorkflow.workflowUUID, (e as Error).message);
             }
-            continue;
           }
-          continue;
         } else {
           pendingWorkflows.push(pendingWorkflow.workflowUUID);
         }

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -1,6 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Span } from "@opentelemetry/sdk-trace-base";
-import { DBOSError, DBOSInitializationError, DBOSWorkflowConflictUUIDError, DBOSNotRegisteredError, DBOSDebuggerError, DBOSConfigKeyTypeError, DBOSFailedSqlTransactionError, DBOSMaxStepRetriesError, DBOSWorkflowRecoveryError  } from "./error";
+import { Span } from '@opentelemetry/sdk-trace-base';
+import {
+  DBOSError,
+  DBOSInitializationError,
+  DBOSWorkflowConflictUUIDError,
+  DBOSNotRegisteredError,
+  DBOSDebuggerError,
+  DBOSConfigKeyTypeError,
+  DBOSFailedSqlTransactionError,
+  DBOSMaxStepRetriesError,
+  DBOSWorkflowRecoveryError,
+} from './error';
 import {
   InvokedHandle,
   Workflow,
@@ -1790,14 +1800,18 @@ export class DBOSExecutor implements DBOSExecutorContext {
       const foundPendingWorkflows = await this.systemDatabase.getPendingWorkflows(execID);
       // Re-enqueue workflows member of a queue
       for (const pendingWorkflow of foundPendingWorkflows) {
-        this.logger.debug(`Recovering workflow: ${pendingWorkflow.workflowUUID}. Queue name: ${pendingWorkflow.queueName}`)
+        this.logger.debug(
+          `Recovering workflow: ${pendingWorkflow.workflowUUID}. Queue name: ${pendingWorkflow.queueName}`,
+        );
         if (pendingWorkflow.queueName) {
           try {
             await this.systemDatabase.reEnqueueWorkflow(pendingWorkflow.workflowUUID);
           } catch (e) {
             // If this is a serialization failure, i.e., some other DBOS process is trying to re-enqueue or complete the workflow, skip it.
             if (this.userDatabase.isRetriableTransactionError(e)) {
-              this.logger.warn(`Failed to re-enqueue workflow ${pendingWorkflow.workflowUUID}: ${(e as Error).message}`);
+              this.logger.warn(
+                `Failed to re-enqueue workflow ${pendingWorkflow.workflowUUID}: ${(e as Error).message}`,
+              );
               continue;
             } else {
               throw new DBOSWorkflowRecoveryError(pendingWorkflow.workflowUUID, (e as Error).message);

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -1803,7 +1803,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
         this.logger.debug(`Recovering workflow: ${wID}. Workflow status: ${JSON.stringify(workflowStatus)}`);
         if (workflowStatus?.queueName) {
           try {
-            await this.systemDatabase.reEnqueueWorkflow(wID, this.#getQueueByName(workflowStatus.queueName));
+            await this.systemDatabase.reEnqueueWorkflow(wID);
           } catch (e) {
             // If this is a serialization failure, i.e., some other DBOS process is trying to re-enqueue or complete the workflow, skip it.
             if (this.userDatabase.isRetriableTransactionError(e)) {

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -1795,13 +1795,24 @@ export class DBOSExecutor implements DBOSExecutorContext {
         this.logger.debug(`Skip local recovery because it's running in a VM: ${process.env.DBOS__VMID}`);
         continue;
       }
-      this.logger.debug(`Recovering workflows of executor: ${execID}`);
+      this.logger.debug(`Recovering workflows assigned to executor: ${execID}`);
       const wIDs = await this.systemDatabase.getPendingWorkflows(execID);
       // Re-enqueue workflows member of a queue
       for (const wID of wIDs) {
         const workflowStatus = await this.systemDatabase.getWorkflowStatus(wID); // This really sucks and we should be able to get more than an ID from getPendingWorkflows
+        this.logger.debug(`Recovering workflow: ${wID}. Workflow status: ${JSON.stringify(workflowStatus)}`);
         if (workflowStatus?.queueName) {
-          await this.systemDatabase.reEnqueueWorkflow(wID, this.#getQueueByName(workflowStatus.queueName));
+          try {
+            await this.systemDatabase.reEnqueueWorkflow(wID, this.#getQueueByName(workflowStatus.queueName));
+          } catch (e) {
+            // If this is a serialization failure, i.e., some other DBOS process is trying to re-enqueue or complete the workflow, skip it.
+            if (this.userDatabase.isRetriableTransactionError(e)) {
+              this.logger.warn(`Failed to re-enqueue workflow ${wID}: ${(e as Error).message}`);
+            } else {
+              throw e;
+            }
+            continue;
+          }
           continue;
         } else {
           pendingWorkflows.push(wID);

--- a/src/error.ts
+++ b/src/error.ts
@@ -236,10 +236,3 @@ export class DBOSMaxStepRetriesError extends DBOSError {
     this.errors = errors;
   }
 }
-
-const WorkflowRecoveryError = 24;
-export class DBOSWorkflowRecoveryError extends DBOSError {
-  constructor(workflowID: string, msg: string) {
-    super(`Error recovering workflow ${workflowID}: ${msg}`, WorkflowRecoveryError);
-  }
-}

--- a/src/error.ts
+++ b/src/error.ts
@@ -236,3 +236,10 @@ export class DBOSMaxStepRetriesError extends DBOSError {
     this.errors = errors;
   }
 }
+
+const WorkflowRecoveryError = 24;
+export class DBOSWorkflowRecoveryError extends DBOSError {
+  constructor(workflowID: string, msg: string) {
+    super(`Error recovering workflow ${workflowID}: ${msg}`, WorkflowRecoveryError);
+  }
+}

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -327,7 +327,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     // Every time we init the status, we increment `recovery_attempts` by 1.
     // Thus, when this number becomes equal to `maxRetries + 1`, we should mark the workflow as `RETRIES_EXCEEDED`.
     const attempts = resRow.recovery_attempts;
-    if (attempts > initStatus.maxRetries) {
+    if (attempts > initStatus.maxRetries + 1) {
       await this.pool.query(
         `UPDATE ${DBOSExecutor.systemDBSchemaName}.workflow_status SET status=$1 WHERE workflow_uuid=$2 AND status=$3`,
         [StatusString.RETRIES_EXCEEDED, initStatus.workflowUUID, StatusString.PENDING],

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -66,7 +66,7 @@ export interface SystemDatabase {
   resumeWorkflow(workflowID: string): Promise<void>;
 
   enqueueWorkflow(workflowId: string, queue: WorkflowQueue): Promise<void>;
-  reEnqueueWorkflow(workflowId: string, queue: WorkflowQueue): Promise<void>;
+  reEnqueueWorkflow(workflowId: string): Promise<void>;
   dequeueWorkflow(workflowId: string, queue: WorkflowQueue): Promise<void>;
   findAndMarkStartableWorkflows(queue: WorkflowQueue, executorID: string): Promise<string[]>;
 
@@ -1243,7 +1243,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     );
   }
 
-  async reEnqueueWorkflow(workflowId: string, queue: WorkflowQueue): Promise<void> {
+  async reEnqueueWorkflow(workflowId: string): Promise<void> {
     const client: PoolClient = await this.pool.connect();
     await client.query("BEGIN ISOLATION LEVEL READ COMMITTED");
     await client.query<workflow_queue>(

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1173,22 +1173,22 @@ export class PostgresSystemDatabase implements SystemDatabase {
       'desc',
     );
     if (input.workflowName) {
-      query = query.where("name", input.workflowName);
+      query = query.where('name', input.workflowName);
     }
     if (input.authenticatedUser) {
-      query = query.where("authenticated_user", input.authenticatedUser);
+      query = query.where('authenticated_user', input.authenticatedUser);
     }
     if (input.startTime) {
-      query = query.where("created_at", ">=", new Date(input.startTime).getTime());
+      query = query.where('created_at', '>=', new Date(input.startTime).getTime());
     }
     if (input.endTime) {
-      query = query.where("created_at", "<=", new Date(input.endTime).getTime());
+      query = query.where('created_at', '<=', new Date(input.endTime).getTime());
     }
     if (input.status) {
-      query = query.where("status", input.status);
+      query = query.where('status', input.status);
     }
     if (input.applicationVersion) {
-      query = query.where("application_version", input.applicationVersion);
+      query = query.where('application_version', input.applicationVersion);
     }
     if (input.limit) {
       query = query.limit(input.limit);
@@ -1196,7 +1196,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     const rows = await query.select('workflow_uuid');
     const workflowUUIDs = rows.map((row) => row.workflow_uuid);
     return {
-      workflowUUIDs: workflowUUIDs,
+      workflowUUIDs: workflowUUIDs
     };
   }
 
@@ -1206,13 +1206,13 @@ export class PostgresSystemDatabase implements SystemDatabase {
       'desc',
     );
     if (input.queueName) {
-      query = query.where("queue_name", input.queueName);
+      query = query.where('queue_name', input.queueName);
     }
     if (input.startTime) {
-      query = query.where("created_at_epoch_ms", ">=", new Date(input.startTime).getTime());
+      query = query.where('created_at_epoch_ms', '>=', new Date(input.startTime).getTime());
     }
     if (input.endTime) {
-      query = query.where("created_at_at_epoch_ms", "<=", new Date(input.endTime).getTime());
+      query = query.where('created_at_at_epoch_ms', '<=', new Date(input.endTime).getTime());
     }
     if (input.limit) {
       query = query.limit(input.limit);

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -66,6 +66,7 @@ export interface SystemDatabase {
   resumeWorkflow(workflowID: string): Promise<void>;
 
   enqueueWorkflow(workflowId: string, queue: WorkflowQueue): Promise<void>;
+  reEnqueueWorkflow(workflowId: string, queue: WorkflowQueue): Promise<void>;
   dequeueWorkflow(workflowId: string, queue: WorkflowQueue): Promise<void>;
   findAndMarkStartableWorkflows(queue: WorkflowQueue, executorID: string): Promise<string[]>;
 
@@ -1238,6 +1239,17 @@ export class PostgresSystemDatabase implements SystemDatabase {
       DO NOTHING;
     `,
       [workflowId, queue.name],
+    );
+  }
+
+  async reEnqueueWorkflow(workflowId: string, queue: WorkflowQueue): Promise<void> {
+    const _res = await this.pool.query<workflow_queue>(
+      `
+          UPDATE ${DBOSExecutor.systemDBSchemaName}.workflow_queue
+          SET started_at_epoch_ms = NULL, executor_id = NULL
+          WHERE workflow_uuid = $1;
+        `,
+      [workflowId]
     );
   }
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1173,22 +1173,22 @@ export class PostgresSystemDatabase implements SystemDatabase {
       'desc',
     );
     if (input.workflowName) {
-      query = query.where('name', input.workflowName);
+      query = query.where("name", input.workflowName);
     }
     if (input.authenticatedUser) {
-      query = query.where('authenticated_user', input.authenticatedUser);
+      query = query.where("authenticated_user", input.authenticatedUser);
     }
     if (input.startTime) {
-      query = query.where('created_at', '>=', new Date(input.startTime).getTime());
+      query = query.where("created_at", ">=", new Date(input.startTime).getTime());
     }
     if (input.endTime) {
-      query = query.where('created_at', '<=', new Date(input.endTime).getTime());
+      query = query.where("created_at", "<=", new Date(input.endTime).getTime());
     }
     if (input.status) {
-      query = query.where('status', input.status);
+      query = query.where("status", input.status);
     }
     if (input.applicationVersion) {
-      query = query.where('application_version', input.applicationVersion);
+      query = query.where("application_version", input.applicationVersion);
     }
     if (input.limit) {
       query = query.limit(input.limit);
@@ -1206,13 +1206,13 @@ export class PostgresSystemDatabase implements SystemDatabase {
       'desc',
     );
     if (input.queueName) {
-      query = query.where('queue_name', input.queueName);
+      query = query.where("queue_name", input.queueName);
     }
     if (input.startTime) {
-      query = query.where('created_at_epoch_ms', '>=', new Date(input.startTime).getTime());
+      query = query.where("created_at_epoch_ms", ">=", new Date(input.startTime).getTime());
     }
     if (input.endTime) {
-      query = query.where('created_at_at_epoch_ms', '<=', new Date(input.endTime).getTime());
+      query = query.where("created_at_at_epoch_ms", "<=", new Date(input.endTime).getTime());
     }
     if (input.limit) {
       query = query.limit(input.limit);
@@ -1221,6 +1221,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     const workflows = rows.map((row) => {
       return {
         workflowID: row.workflow_uuid,
+        executorID: row.executor_id,
         queueName: row.queue_name,
         createdAt: row.created_at_epoch_ms,
         startedAt: row.started_at_epoch_ms,
@@ -1231,7 +1232,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
   }
 
   async enqueueWorkflow(workflowId: string, queue: WorkflowQueue): Promise<void> {
-    const _res = await this.pool.query<workflow_queue>(
+    await this.pool.query<workflow_queue>(
       `
       INSERT INTO ${DBOSExecutor.systemDBSchemaName}.workflow_queue (workflow_uuid, queue_name)
       VALUES ($1, $2)
@@ -1243,29 +1244,41 @@ export class PostgresSystemDatabase implements SystemDatabase {
   }
 
   async reEnqueueWorkflow(workflowId: string, queue: WorkflowQueue): Promise<void> {
-    const _res = await this.pool.query<workflow_queue>(
+    const client: PoolClient = await this.pool.connect();
+    await client.query("BEGIN ISOLATION LEVEL READ COMMITTED");
+    await client.query<workflow_queue>(
       `
-          UPDATE ${DBOSExecutor.systemDBSchemaName}.workflow_queue
-          SET started_at_epoch_ms = NULL, executor_id = NULL
-          WHERE workflow_uuid = $1;
-        `,
+      UPDATE ${DBOSExecutor.systemDBSchemaName}.workflow_queue
+      SET started_at_epoch_ms = NULL, executor_id = NULL
+      WHERE workflow_uuid = $1;
+    `,
       [workflowId]
     );
+    await client.query<workflow_status>(
+      `
+      UPDATE ${DBOSExecutor.systemDBSchemaName}.workflow_status
+      SET status = $2
+      WHERE workflow_uuid = $1;
+    `,
+      [workflowId, StatusString.ENQUEUED]
+    );
+    await client.query("COMMIT");
+    client.release();
   }
 
   async dequeueWorkflow(workflowId: string, queue: WorkflowQueue): Promise<void> {
     if (queue.rateLimit) {
       const time = new Date().getTime();
-      const _res = await this.pool.query<workflow_queue>(
+      await this.pool.query<workflow_queue>(
         `
         UPDATE ${DBOSExecutor.systemDBSchemaName}.workflow_queue
         SET completed_at_epoch_ms = $2
         WHERE workflow_uuid = $1;
       `,
-        [workflowId, time],
+        [workflowId, time]
       );
     } else {
-      const _res = await this.pool.query<workflow_queue>(
+      await this.pool.query<workflow_queue>(
         `
         DELETE FROM ${DBOSExecutor.systemDBSchemaName}.workflow_queue
         WHERE workflow_uuid = $1;

--- a/src/wfqueue.ts
+++ b/src/wfqueue.ts
@@ -117,8 +117,10 @@ class WFQueueRunner {
     const logger = exec.logger;
     logger.info('Workflow queues:');
     for (const [qn, q] of this.wfQueuesByName) {
-      const conc = q.concurrency !== undefined ? `${q.concurrency}` : 'No concurrency limit set';
-      logger.info(`    ${qn}: ${conc}`);
+        const conc = q.concurrency !== undefined ? `global concurrency limit: ${q.concurrency}` : 'No concurrency limit set';
+        logger.info(`    ${qn}: ${conc}`);
+        const workerconc = q.workerConcurrency !== undefined ? `worker concurrency limit: ${q.workerConcurrency}` : 'No worker concurrency limit set';
+        logger.info(`    ${qn}: ${workerconc}`);
     }
   }
 }

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -97,6 +97,11 @@ export interface GetWorkflowQueueOutput {
   }[];
 }
 
+export interface GetPendingWorkflowsOutput {
+  workflowUUID: string;
+  queueName?: string;
+}
+
 export interface PgTransactionId {
   txid: string;
 }

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -89,6 +89,7 @@ export interface GetWorkflowQueueInput {
 export interface GetWorkflowQueueOutput {
   workflows: {
     workflowID: string; // Workflow ID
+    executorID?: string; // Workflow executor ID
     queueName: string; // Workflow queue name
     createdAt: number; // Time that queue entry was created
     startedAt?: number; // Time that workflow was started, if started

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -80,10 +80,17 @@ export class Event {
   set(): void {
     if (this._resolve) {
       this._resolve();
+      this._resolve = null;
     }
   }
 
   wait(): Promise<void> {
     return this._promise;
+  }
+
+  clear(): void {
+    this._promise = new Promise((resolve) => {
+      this._resolve = resolve;
+    });
   }
 }

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -414,6 +414,17 @@ describe('queued-wf-tests-simple', () => {
       await TestQueueRecovery.event.wait();
       return i;
     }
+
+    static cnt = 0;
+    static blockedWorkflows = 2;
+    static startEvents = Array.from({ length: TestQueueRecovery.blockedWorkflows }, () => new Event());
+    static stopEvent = new Event();
+    @DBOS.workflow()
+    static async blockedWorkflow(i: number) {
+      TestQueueRecovery.startEvents[i].set();
+      TestQueueRecovery.cnt++;
+      await TestQueueRecovery.stopEvent.wait();
+    }
   }
 
   test('test-queue-recovery', async () => {
@@ -423,11 +434,15 @@ describe('queued-wf-tests-simple', () => {
     const originalHandle = await DBOS.startWorkflow(TestQueueRecovery, { workflowID: wfid }).testWorkflow();
     for (const e of TestQueueRecovery.taskEvents) {
       await e.wait();
+      e.clear();
     }
     expect(TestQueueRecovery.taskCount).toEqual(5);
 
     // Recover the workflow, then resume it. There should be one handle for the workflow and another for each task.
     const recoveryHandles = await DBOS.recoverPendingWorkflows();
+    for (const e of TestQueueRecovery.taskEvents) {
+      await e.wait();
+    }
     expect(recoveryHandles.length).toBe(TestQueueRecovery.queuedSteps + 1);
     TestQueueRecovery.event.set();
 
@@ -445,6 +460,96 @@ describe('queued-wf-tests-simple', () => {
     // Verify all queue entries eventually get cleaned up
     expect(await queueEntriesAreCleanedUp()).toBe(true);
   });
+
+  test('test-queue-concurrency-under-recovery', async () => {
+    const recoveryQueue = new WorkflowQueue('recoveryQ', { concurrency: 2 });
+    const wfid1 = uuidv4();
+    const wfh1 = await DBOS.startWorkflow(TestQueueRecovery, {
+      workflowID: wfid1,
+      queueName: recoveryQueue.name,
+    }).blockedWorkflow(0);
+    const wfid2 = uuidv4();
+    const wfh2 = await DBOS.startWorkflow(TestQueueRecovery, {
+      workflowID: wfid2,
+      queueName: recoveryQueue.name,
+    }).blockedWorkflow(1);
+    const wfid3 = uuidv4();
+    const wfh3 = await DBOS.startWorkflow(TestWFs, {
+      workflowID: wfid3,
+      queueName: recoveryQueue.name,
+    }).noop();
+
+    for (const e of TestQueueRecovery.startEvents) {
+      await e.wait();
+      e.clear();
+    }
+    expect(TestQueueRecovery.cnt).toBe(2);
+
+    const workflows = await DBOS.getWorkflowQueue({ queueName: recoveryQueue.name });
+    expect(workflows.workflows.length).toBe(3);
+    expect(workflows.workflows[2].workflowID).toBe(wfid1);
+    expect(workflows.workflows[2].executorID).toBe('local');
+    expect((await wfh1.getStatus())?.status).toBe(StatusString.PENDING);
+    expect(workflows.workflows[1].workflowID).toBe(wfid2);
+    expect(workflows.workflows[1].executorID).toBe('local');
+    expect((await wfh2.getStatus())?.status).toBe(StatusString.PENDING);
+    expect(workflows.workflows[0].workflowID).toBe(wfid3);
+    expect(workflows.workflows[0].executorID).toBe(null);
+    expect((await wfh3.getStatus())?.status).toBe(StatusString.ENQUEUED);
+
+    // Manually update the database to pretend wf3 is PENDING and comes from a different executor
+    const systemDBClient = new Client({
+      user: config.poolConfig.user,
+      port: config.poolConfig.port,
+      host: config.poolConfig.host,
+      password: config.poolConfig.password,
+      database: config.system_database,
+    });
+    await systemDBClient.connect();
+    try {
+      await systemDBClient.query(
+        "UPDATE dbos.workflow_status SET executor_id = 'test-vmid-2', status = 'PENDING' WHERE workflow_uuid = $1",
+        [wfh3.workflowID],
+      );
+
+      // Trigger workflow recovery. The two first workflows should still be blocked but the 3rd one enqueued
+      const recovered_handles = await DBOS.recoverPendingWorkflows(['test-vmid-2']);
+      expect(recovered_handles.length).toBe(1);
+      expect(recovered_handles[0].workflowID).toBe(wfid3);
+      expect((await wfh1.getStatus())?.status).toBe(StatusString.PENDING);
+      expect((await wfh2.getStatus())?.status).toBe(StatusString.PENDING);
+      expect((await wfh3.getStatus())?.status).toBe(StatusString.ENQUEUED);
+
+      // Trigger workflow recovery for "local". The two first workflows should be re-enqueued then dequeued again
+      const recovered_handles_local = await DBOS.recoverPendingWorkflows(['local']);
+      expect(recovered_handles_local.length).toBe(2);
+      for (const h of recovered_handles_local) {
+        expect([wfid1, wfid2]).toContain(h.workflowID);
+      }
+      for (const e of TestQueueRecovery.startEvents) {
+        await e.wait();
+      }
+      expect(TestQueueRecovery.cnt).toBe(4);
+      expect((await wfh1.getStatus())?.status).toBe(StatusString.PENDING);
+      expect((await wfh2.getStatus())?.status).toBe(StatusString.PENDING);
+      expect((await wfh3.getStatus())?.status).toBe(StatusString.ENQUEUED);
+
+      // Unblock the two first workflows
+      TestQueueRecovery.stopEvent.set();
+      // Verify all queue entries eventually get cleaned up.
+      expect(await wfh1.getResult()).toBe(null);
+      expect(await wfh2.getResult()).toBe(null);
+      expect(await wfh3.getResult()).toBe(null);
+      const result = await systemDBClient.query(
+        'SELECT executor_id FROM dbos.workflow_status WHERE workflow_uuid = $1',
+        [wfh3.workflowID],
+      );
+      expect(result.rows).toEqual([{ executor_id: 'local' }]);
+      expect(await queueEntriesAreCleanedUp()).toBe(true);
+    } finally {
+      await systemDBClient.end();
+    }
+  }, 20000);
 
   class TestCancelQueues {
     static startEvent = new Event();
@@ -626,149 +731,47 @@ describe('queued-wf-tests-concurrent-workers', () => {
   }, 120000);
 });
 
-// Test that queued worfklows to recover are re-enqueued
-describe('queued-wf-tests-recovery', () => {
-  let config: DBOSConfig;
-  let systemDBClient: Client;
+class TestWFs {
+  static wfCounter = 0;
+  static stepCounter = 0;
+  static wfid: string;
 
-  beforeAll(async () => {
-    config = generateDBOSTestConfig();
-    await setUpDBOSTestDb(config);
-    DBOS.setConfig(config);
-  });
+  static reset() {
+    TestWFs.wfCounter = 0;
+    TestWFs.stepCounter = 0;
+  }
 
-  beforeEach(async () => {
-    TestWFs.reset();
-    await DBOS.launch();
-    systemDBClient = new Client({
-      user: config.poolConfig.user,
-      port: config.poolConfig.port,
-      host: config.poolConfig.host,
-      password: config.poolConfig.password,
-      database: config.system_database,
-    });
-    await systemDBClient.connect();
-  });
+  @DBOS.workflow()
+  static async testWorkflow(var1: string, var2: string) {
+    expect(DBOS.workflowID).toBe(TestWFs.wfid);
+    ++TestWFs.wfCounter;
+    var1 = await TestWFs.testStep(var1);
+    return Promise.resolve(var1 + var2);
+  }
 
-  afterEach(async () => {
-    await DBOS.shutdown();
-    await systemDBClient.end();
-  }, 10000);
+  @DBOS.workflow()
+  static async testWorkflowSimple(var1: string, var2: string) {
+    ++TestWFs.wfCounter;
+    return Promise.resolve(var1 + var2);
+  }
 
-  test('queued-wf-recovery', async () => {
-    // Configure the promise to block the workflows
-    TestWFs.blockedWorkflowPromise = new Promise<void>((resolve, _rj) => {
-      TestWFs.blockedWorkflowResolve = resolve;
-    });
-    const recoveryQueue = new WorkflowQueue('recoveryQ', { concurrency: 2 });
-    const wfid1 = uuidv4();
-    const wfh1 = await DBOS.startWorkflow(TestWFs, {
-      workflowID: wfid1,
-      queueName: recoveryQueue.name,
-    }).blockedWorkflow();
-    const wfid2 = uuidv4();
-    const wfh2 = await DBOS.startWorkflow(TestWFs, {
-      workflowID: wfid2,
-      queueName: recoveryQueue.name,
-    }).blockedWorkflow();
-    const wfid3 = uuidv4();
-    const wfh3 = await DBOS.startWorkflow(TestWFs, {
-      workflowID: wfid3,
-      queueName: recoveryQueue.name,
-    }).noop();
+  @DBOS.step()
+  static async testStep(str: string) {
+    ++TestWFs.stepCounter;
+    return Promise.resolve(str + 'd');
+  }
 
-    // Wait for a couple queue polling interval and verify two workflows are being executed
-    await sleepms(2000);
-    const workflows = await DBOS.getWorkflowQueue({ queueName: recoveryQueue.name });
-    expect(workflows.workflows.length).toBe(3);
-    expect(workflows.workflows[2].workflowID).toBe(wfid1);
-    expect(workflows.workflows[2].executorID).toBe('local');
-    expect((await wfh1.getStatus())?.status).toBe(StatusString.PENDING);
-    expect(workflows.workflows[1].workflowID).toBe(wfid2);
-    expect(workflows.workflows[1].executorID).toBe('local');
-    expect((await wfh2.getStatus())?.status).toBe(StatusString.PENDING);
-    expect(workflows.workflows[0].workflowID).toBe(wfid3);
-    expect(workflows.workflows[0].executorID).toBe(null);
-    expect((await wfh3.getStatus())?.status).toBe(StatusString.ENQUEUED);
+  @DBOS.workflow()
+  static async testWorkflowTime(var1: string, var2: string): Promise<number> {
+    expect(var1).toBe('abc');
+    expect(var2).toBe('123');
+    return Promise.resolve(new Date().getTime());
+  }
 
-    // Manually update the database to pretend wf3 is PENDING and comes from a different executor
-    await systemDBClient.query(
-      "UPDATE dbos.workflow_status SET executor_id = 'test-vmid-2', status = 'PENDING' WHERE workflow_uuid = $1",
-      [wfh3.workflowID],
-    );
-
-    // Trigger workflow recovery. The two first workflows should still be blocked but the 3rd one enqueued
-    await DBOS.recoverPendingWorkflows(['test-vmid-2']);
-    expect((await wfh1.getStatus())?.status).toBe(StatusString.PENDING);
-    expect((await wfh2.getStatus())?.status).toBe(StatusString.PENDING);
-    expect((await wfh3.getStatus())?.status).toBe(StatusString.ENQUEUED);
-
-    // Unblock the two first workflows
-    TestWFs.blockedWorkflowResolve?.();
-    expect(await wfh1.getResult()).toBe(null);
-    expect(await wfh2.getResult()).toBe(null);
-    // Now the third workflow should have been dequeeud and complete
-    expect(await wfh3.getResult()).toBe(null);
-    // (And executed by local)
-    const result = await systemDBClient.query('SELECT executor_id FROM dbos.workflow_status WHERE workflow_uuid = $1', [
-      wfh3.workflowID,
-    ]);
-    expect(result.rows).toEqual([{ executor_id: 'local' }]);
-
-    TestWFs.blockedWorkflowPromise = undefined;
-  }, 20000);
-});
-
-class TestWFs
-{
-    static wfCounter = 0;
-    static stepCounter = 0;
-    static wfid: string;
-
-    static reset() {
-        TestWFs.wfCounter = 0;
-        TestWFs.stepCounter = 0;
-    }
-
-    @DBOS.workflow()
-    static async testWorkflow(var1: string, var2: string) {
-        expect(DBOS.workflowID).toBe(TestWFs.wfid);
-        ++TestWFs.wfCounter;
-        var1 = await TestWFs.testStep(var1);
-        return Promise.resolve(var1 + var2);
-    }
-
-    @DBOS.workflow()
-    static async testWorkflowSimple(var1: string, var2: string) {
-        ++TestWFs.wfCounter;
-        return Promise.resolve(var1 + var2);
-    }
-
-    @DBOS.step()
-    static async testStep(str: string) {
-        ++TestWFs.stepCounter;
-        return Promise.resolve(str + 'd');
-    }
-
-    @DBOS.workflow()
-    static async testWorkflowTime(var1: string, var2: string): Promise<number> {
-        expect (var1).toBe("abc");
-        expect (var2).toBe("123");
-        return Promise.resolve(new Date().getTime());
-    }
-
-    static blockedWorkflowResolve?: () => void;
-    static blockedWorkflowPromise?: Promise<void>;
-    @DBOS.workflow()
-    static async blockedWorkflow(): Promise<void> {
-        await TestWFs.blockedWorkflowPromise;
-        return Promise.resolve();
-    }
-
-    @DBOS.workflow()
-    static async noop() {
-        return Promise.resolve();
-    }
+  @DBOS.workflow()
+  static async noop() {
+    return Promise.resolve();
+  }
 }
 
 class TestWFs2 {

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -9,7 +9,7 @@ import { WF } from './wfqtestprocess';
 
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import { Client } from "pg";
+import { Client } from 'pg';
 
 const execFileAsync = promisify(execFile);
 
@@ -627,91 +627,96 @@ describe('queued-wf-tests-concurrent-workers', () => {
 });
 
 // Test that queued worfklows to recover are re-enqueued
-describe("queued-wf-tests-recovery", () => {
-    let config: DBOSConfig;
-    let systemDBClient: Client;
+describe('queued-wf-tests-recovery', () => {
+  let config: DBOSConfig;
+  let systemDBClient: Client;
 
-    beforeAll(async () => {
-        config = generateDBOSTestConfig();
-        await setUpDBOSTestDb(config);
-        DBOS.setConfig(config);
+  beforeAll(async () => {
+    config = generateDBOSTestConfig();
+    await setUpDBOSTestDb(config);
+    DBOS.setConfig(config);
+  });
+
+  beforeEach(async () => {
+    TestWFs.reset();
+    await DBOS.launch();
+    systemDBClient = new Client({
+      user: config.poolConfig.user,
+      port: config.poolConfig.port,
+      host: config.poolConfig.host,
+      password: config.poolConfig.password,
+      database: config.system_database,
     });
+    await systemDBClient.connect();
+  });
 
-    beforeEach(async () => {
-        TestWFs.reset();
-        await DBOS.launch();
-        systemDBClient = new Client({
-            user: config.poolConfig.user,
-            port: config.poolConfig.port,
-            host: config.poolConfig.host,
-            password: config.poolConfig.password,
-            database: config.system_database,
-        });
-        await systemDBClient.connect();
+  afterEach(async () => {
+    await DBOS.shutdown();
+    await systemDBClient.end();
+  }, 10000);
+
+  test('queued-wf-recovery', async () => {
+    // Configure the promise to block the workflows
+    TestWFs.blockedWorkflowPromise = new Promise<void>((resolve, _rj) => {
+      TestWFs.blockedWorkflowResolve = resolve;
     });
+    const recoveryQueue = new WorkflowQueue('recoveryQ', { concurrency: 2 });
+    const wfid1 = uuidv4();
+    const wfh1 = await DBOS.startWorkflow(TestWFs, {
+      workflowID: wfid1,
+      queueName: recoveryQueue.name,
+    }).blockedWorkflow();
+    const wfid2 = uuidv4();
+    const wfh2 = await DBOS.startWorkflow(TestWFs, {
+      workflowID: wfid2,
+      queueName: recoveryQueue.name,
+    }).blockedWorkflow();
+    const wfid3 = uuidv4();
+    const wfh3 = await DBOS.startWorkflow(TestWFs, {
+      workflowID: wfid3,
+      queueName: recoveryQueue.name,
+    }).noop();
 
-    afterEach(async () => {
-        await DBOS.shutdown();
-        await systemDBClient.end();
-    }, 10000);
+    // Wait for a couple queue polling interval and verify two workflows are being executed
+    await sleepms(2000);
+    const workflows = await DBOS.getWorkflowQueue({ queueName: recoveryQueue.name });
+    expect(workflows.workflows.length).toBe(3);
+    expect(workflows.workflows[2].workflowID).toBe(wfid1);
+    expect(workflows.workflows[2].executorID).toBe('local');
+    expect((await wfh1.getStatus())?.status).toBe(StatusString.PENDING);
+    expect(workflows.workflows[1].workflowID).toBe(wfid2);
+    expect(workflows.workflows[1].executorID).toBe('local');
+    expect((await wfh2.getStatus())?.status).toBe(StatusString.PENDING);
+    expect(workflows.workflows[0].workflowID).toBe(wfid3);
+    expect(workflows.workflows[0].executorID).toBe(null);
+    expect((await wfh3.getStatus())?.status).toBe(StatusString.ENQUEUED);
 
-    test("queued-wf-recovery", async () => {
-        // Configure the promise to block the workflows
-        TestWFs.blockedWorkflowPromise = new Promise<void>((resolve, _rj) => {
-            TestWFs.blockedWorkflowResolve = resolve;
-        });
-        const recoveryQueue = new WorkflowQueue("recoveryQ", { concurrency: 2 });
-        const wfid1 = uuidv4();
-        const wfh1 = await DBOS.startWorkflow(TestWFs, {
-            workflowID: wfid1,
-            queueName: recoveryQueue.name,
-        }).blockedWorkflow();
-        const wfid2 = uuidv4();
-        const wfh2 = await DBOS.startWorkflow(TestWFs, {
-            workflowID: wfid2,
-            queueName: recoveryQueue.name,
-        }).blockedWorkflow();
-        const wfid3 = uuidv4();
-        const wfh3 = await DBOS.startWorkflow(TestWFs, {
-            workflowID: wfid3,
-            queueName: recoveryQueue.name,
-        }).noop();
+    // Manually update the database to pretend wf3 is PENDING and comes from a different executor
+    await systemDBClient.query(
+      "UPDATE dbos.workflow_status SET executor_id = 'test-vmid-2', status = 'PENDING' WHERE workflow_uuid = $1",
+      [wfh3.workflowID],
+    );
 
-        // Wait for a couple queue polling interval and verify two workflows are being executed
-        await sleepms(2000);
-        const workflows = await DBOS.getWorkflowQueue({ queueName: recoveryQueue.name });
-        expect(workflows.workflows.length).toBe(3);
-        expect(workflows.workflows[2].workflowID).toBe(wfid1);
-        expect(workflows.workflows[2].executorID).toBe("local");
-        expect((await wfh1.getStatus())?.status).toBe(StatusString.PENDING);
-        expect(workflows.workflows[1].workflowID).toBe(wfid2);
-        expect(workflows.workflows[1].executorID).toBe("local");
-        expect((await wfh2.getStatus())?.status).toBe(StatusString.PENDING);
-        expect(workflows.workflows[0].workflowID).toBe(wfid3);
-        expect(workflows.workflows[0].executorID).toBe(null);
-        expect((await wfh3.getStatus())?.status).toBe(StatusString.ENQUEUED);
+    // Trigger workflow recovery. The two first workflows should still be blocked but the 3rd one enqueued
+    await DBOS.recoverPendingWorkflows(['test-vmid-2']);
+    expect((await wfh1.getStatus())?.status).toBe(StatusString.PENDING);
+    expect((await wfh2.getStatus())?.status).toBe(StatusString.PENDING);
+    expect((await wfh3.getStatus())?.status).toBe(StatusString.ENQUEUED);
 
-        // Manually update the database to pretend wf3 is PENDING and comes from a different executor
-        await systemDBClient.query("UPDATE dbos.workflow_status SET executor_id = 'test-vmid-2', status = 'PENDING' WHERE workflow_uuid = $1", [wfh3.workflowID]);
+    // Unblock the two first workflows
+    TestWFs.blockedWorkflowResolve?.();
+    expect(await wfh1.getResult()).toBe(null);
+    expect(await wfh2.getResult()).toBe(null);
+    // Now the third workflow should have been dequeeud and complete
+    expect(await wfh3.getResult()).toBe(null);
+    // (And executed by local)
+    const result = await systemDBClient.query('SELECT executor_id FROM dbos.workflow_status WHERE workflow_uuid = $1', [
+      wfh3.workflowID,
+    ]);
+    expect(result.rows).toEqual([{ executor_id: 'local' }]);
 
-        // Trigger workflow recovery. The two first workflows should still be blocked but the 3rd one enqueued
-        await DBOS.recoverPendingWorkflows(["test-vmid-2"]);
-        expect((await wfh1.getStatus())?.status).toBe(StatusString.PENDING);
-        expect((await wfh2.getStatus())?.status).toBe(StatusString.PENDING);
-        expect((await wfh3.getStatus())?.status).toBe(StatusString.ENQUEUED);
-
-        // Unblock the two first workflows
-        TestWFs.blockedWorkflowResolve?.();
-        expect(await wfh1.getResult()).toBe(null);
-        expect(await wfh2.getResult()).toBe(null);
-        // Now the third workflow should have been dequeeud and complete
-        expect(await wfh3.getResult()).toBe(null);
-        // (And executed by local)
-        const result = await systemDBClient.query("SELECT executor_id FROM dbos.workflow_status WHERE workflow_uuid = $1", [wfh3.workflowID]);
-        expect(result.rows).toEqual([{ executor_id: "local" }]);
-
-        TestWFs.blockedWorkflowPromise = undefined;
-    }, 20000);
+    TestWFs.blockedWorkflowPromise = undefined;
+  }, 20000);
 });
 
 class TestWFs

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -703,7 +703,7 @@ describe("queued-wf-tests-recovery", () => {
         expect((await wfh3.getStatus())?.status).toBe(StatusString.ENQUEUED);
 
         // Unblock the two first workflows
-        await TestWFs.blockedWorkflowResolve?.();
+        TestWFs.blockedWorkflowResolve?.();
         expect(await wfh1.getResult()).toBe(null);
         expect(await wfh2.getResult()).toBe(null);
         // Now the third workflow should have been dequeeud and complete


### PR DESCRIPTION
When performing recovery, we now re-enqueue workflows that came from a queue. This allows tasks from a queue to respect the concurrency limits.
Re-enqueue = reset the start time and executor assignment in the queue table. This ensures the task is re-inserted in the same position in the queue.