### PR TITLE
Test & Improve Queue Semantics

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -1965,7 +1965,12 @@ export class DBOSExecutor implements DBOSExecutorContext {
   }
 
   async cancelWorkflow(workflowID: string): Promise<void> {
-    return await this.systemDatabase.cancelWorkflow(workflowID);
+    await this.systemDatabase.cancelWorkflow(workflowID);
+  }
+
+  async resumeWorkflow(workflowID: string): Promise<WorkflowHandle<unknown>> {
+    await this.systemDatabase.resumeWorkflow(workflowID);
+    return await this.executeWorkflowUUID(workflowID, false);
   }
 
   /* BACKGROUND PROCESSES */

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -1964,6 +1964,10 @@ export class DBOSExecutor implements DBOSExecutorContext {
     return oc;
   }
 
+  async cancelWorkflow(workflowID: string): Promise<void> {
+    return await this.systemDatabase.cancelWorkflow(workflowID);
+  }
+
   /* BACKGROUND PROCESSES */
   /**
    * Periodically flush the workflow output buffer to the system database.

--- a/src/dbos-runtime/workflow_management.ts
+++ b/src/dbos-runtime/workflow_management.ts
@@ -77,7 +77,7 @@ export async function cancelWorkflow(config: DBOSConfig, workflowUUID: string) {
     createLogger() as unknown as GlobalLogger,
   );
   try {
-    await systemDatabase.setWorkflowStatus(workflowUUID, StatusString.CANCELLED, false);
+    await systemDatabase.cancelWorkflow(workflowUUID);
   } finally {
     await systemDatabase.destroy();
   }

--- a/src/dbos-runtime/workflow_management.ts
+++ b/src/dbos-runtime/workflow_management.ts
@@ -96,7 +96,7 @@ export async function reattemptWorkflow(
   try {
     await dbosExec.init();
     if (!startNewWorkflow) {
-      await dbosExec.systemDatabase.setWorkflowStatus(workflowUUID, StatusString.PENDING, true);
+      await dbosExec.systemDatabase.resumeWorkflow(workflowUUID);
     }
     const handle = await dbosExec.executeWorkflowUUID(workflowUUID, startNewWorkflow);
     const output = await handle.getResult();

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -227,7 +227,7 @@ export class DBOSHttpServer {
       const workflowId = koaCtxt.params.workflow_id;
       console.log(`Cancelling workflow with ID: ${workflowId}`);
       //eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      await dbosExec.systemDatabase.cancelWorkflow(workflowId);
+      await dbosExec.cancelWorkflow(workflowId);
       koaCtxt.status = 204;
     };
     router.post(workflowCancelUrl, workflowCancelHandler);

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -259,13 +259,9 @@ export class DBOSHttpServer {
   static registerRestartWorkflowEndpoint(dbosExec: DBOSExecutor, router: Router) {
     const workflowResumeUrl = '/workflows/:workflow_id/restart';
     const workflowResumeHandler = async (koaCtxt: Koa.Context) => {
-      // eslint-disable-next-line  @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      const workflowId = koaCtxt.params.workflow_id;
+      const workflowId = (koaCtxt.params as { workflow_id: string }).workflow_id;
       console.log(`Restarting workflow: ${workflowId} with a new id`);
-
-      // eslint-disable-next-line  @typescript-eslint/no-unsafe-argument
       await dbosExec.executeWorkflowUUID(workflowId, true);
-
       koaCtxt.status = 204;
     };
     router.post(workflowResumeUrl, workflowResumeHandler);

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -246,12 +246,8 @@ export class DBOSHttpServer {
       // eslint-disable-next-line  @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const workflowId = koaCtxt.params.workflow_id;
       console.log(`Resuming workflow with ID: ${workflowId}`);
-      //eslint-disable-next-line  @typescript-eslint/no-unsafe-argument
-      await dbosExec.systemDatabase.resumeWorkflow(workflowId);
-
       // eslint-disable-next-line  @typescript-eslint/no-unsafe-argument
-      await dbosExec.executeWorkflowUUID(workflowId, false);
-
+      await dbosExec.resumeWorkflow(workflowId);
       koaCtxt.status = 204;
     };
     router.post(workflowResumeUrl, workflowResumeHandler);

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -223,10 +223,8 @@ export class DBOSHttpServer {
   static registerCancelWorkflowEndpoint(dbosExec: DBOSExecutor, router: Router) {
     const workflowCancelUrl = '/workflows/:workflow_id/cancel';
     const workflowCancelHandler = async (koaCtxt: Koa.Context) => {
-      // eslint-disable-next-line  @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      const workflowId = koaCtxt.params.workflow_id;
+      const workflowId = (koaCtxt.params as { workflow_id: string }).workflow_id;
       console.log(`Cancelling workflow with ID: ${workflowId}`);
-      //eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       await dbosExec.cancelWorkflow(workflowId);
       koaCtxt.status = 204;
     };
@@ -243,10 +241,8 @@ export class DBOSHttpServer {
   static registerResumeWorkflowEndpoint(dbosExec: DBOSExecutor, router: Router) {
     const workflowResumeUrl = '/workflows/:workflow_id/resume';
     const workflowResumeHandler = async (koaCtxt: Koa.Context) => {
-      // eslint-disable-next-line  @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      const workflowId = koaCtxt.params.workflow_id;
+      const workflowId = (koaCtxt.params as { workflow_id: string }).workflow_id;
       console.log(`Resuming workflow with ID: ${workflowId}`);
-      // eslint-disable-next-line  @typescript-eslint/no-unsafe-argument
       await dbosExec.resumeWorkflow(workflowId);
       koaCtxt.status = 204;
     };

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -5,7 +5,7 @@ import cors from '@koa/cors';
 import { HandlerContextImpl, HandlerRegistrationBase } from './handler';
 import { ArgSources, APITypes } from './handlerTypes';
 import { Transaction } from '../transaction';
-import { Workflow, StatusString } from '../workflow';
+import { Workflow } from '../workflow';
 import { DBOSDataValidationError, DBOSError, DBOSResponseError, isClientError } from '../error';
 import { DBOSExecutor } from '../dbos-executor';
 import { GlobalLogger as Logger } from '../telemetry/logs';
@@ -247,7 +247,7 @@ export class DBOSHttpServer {
       const workflowId = koaCtxt.params.workflow_id;
       console.log(`Resuming workflow with ID: ${workflowId}`);
       //eslint-disable-next-line  @typescript-eslint/no-unsafe-argument
-      await dbosExec.systemDatabase.setWorkflowStatus(workflowId, StatusString.PENDING, true);
+      await dbosExec.systemDatabase.resumeWorkflow(workflowId);
 
       // eslint-disable-next-line  @typescript-eslint/no-unsafe-argument
       await dbosExec.executeWorkflowUUID(workflowId, false);

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -227,7 +227,7 @@ export class DBOSHttpServer {
       const workflowId = koaCtxt.params.workflow_id;
       console.log(`Cancelling workflow with ID: ${workflowId}`);
       //eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      await dbosExec.systemDatabase.setWorkflowStatus(workflowId, StatusString.CANCELLED, false);
+      await dbosExec.systemDatabase.cancelWorkflow(workflowId);
       koaCtxt.status = 204;
     };
     router.post(workflowCancelUrl, workflowCancelHandler);

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -63,6 +63,7 @@ export interface SystemDatabase {
     resetRecoveryAttempts: boolean,
   ): Promise<void>;
   cancelWorkflow(workflowID: string): Promise<void>;
+  resumeWorkflow(workflowID: string): Promise<void>;
 
   enqueueWorkflow(workflowId: string, queue: WorkflowQueue): Promise<void>;
   dequeueWorkflow(workflowId: string, queue: WorkflowQueue): Promise<void>;
@@ -929,6 +930,50 @@ export class PostgresSystemDatabase implements SystemDatabase {
          SET status = $1 
          WHERE workflow_uuid = $2`,
         [StatusString.CANCELLED, workflowUUID],
+      );
+
+      await client.query('COMMIT');
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async resumeWorkflow(workflowUUID: string): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      // Check workflow status. If it is complete, do nothing.
+      const statusResult = await client.query<workflow_status>(
+        `SELECT status FROM ${DBOSExecutor.systemDBSchemaName}.workflow_status 
+         WHERE workflow_uuid = $1`,
+        [workflowUUID],
+      );
+      if (
+        statusResult.rows.length === 0 ||
+        statusResult.rows[0].status === StatusString.SUCCESS ||
+        statusResult.rows[0].status === StatusString.ERROR
+      ) {
+        await client.query('COMMIT');
+        return;
+      }
+
+      // Remove the workflow from the queues table so resume can safely be called on an ENQUEUED workflow
+      await client.query(
+        `DELETE FROM ${DBOSExecutor.systemDBSchemaName}.workflow_queue 
+         WHERE workflow_uuid = $1`,
+        [workflowUUID],
+      );
+
+      // Update status to pending and reset recovery attempts
+      await client.query(
+        `UPDATE ${DBOSExecutor.systemDBSchemaName}.workflow_status 
+         SET status = $1, recovery_attempts = 0 
+         WHERE workflow_uuid = $2`,
+        [StatusString.PENDING, workflowUUID],
       );
 
       await client.query('COMMIT');

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -62,3 +62,28 @@ export interface TestKvTable {
   id?: number;
   value?: string;
 }
+
+// A helper class for testing concurrency. Behaves similarly to threading.Event in Python.
+// The class contains a promise and a resolution.
+// Await Event.wait() to await the promise.
+// Call event.set() to resolve the promise.
+export class Event {
+  private _resolve: (() => void) | null = null;
+  private _promise: Promise<void>;
+
+  constructor() {
+    this._promise = new Promise((resolve) => {
+      this._resolve = resolve;
+    });
+  }
+
+  set(): void {
+    if (this._resolve) {
+      this._resolve();
+    }
+  }
+
+  wait(): Promise<void> {
+    return this._promise;
+  }
+}

--- a/tests/httpServer/adminserver.test.ts
+++ b/tests/httpServer/adminserver.test.ts
@@ -32,7 +32,6 @@ describe('admin-server-tests', () => {
     // Test GET /dbos-healthz
     const healthzResponse = await fetch('http://localhost:3001/dbos-healthz', {
       method: 'GET',
-      signal: AbortSignal.timeout(5000),
     });
     expect(healthzResponse.status).toBe(200);
     expect(await healthzResponse.text()).toBe('healthy');
@@ -45,7 +44,6 @@ describe('admin-server-tests', () => {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(data),
-      signal: AbortSignal.timeout(5000),
     });
     expect(recoveryResponse.status).toBe(200);
     expect(await recoveryResponse.json()).toEqual([]);
@@ -53,14 +51,12 @@ describe('admin-server-tests', () => {
     // Test GET not found
     const getNotFoundResponse = await fetch('http://localhost:3001/stuff', {
       method: 'GET',
-      signal: AbortSignal.timeout(5000),
     });
     expect(getNotFoundResponse.status).toBe(404);
 
     // Test POST not found
     const postNotFoundResponse = await fetch('http://localhost:3001/stuff', {
       method: 'POST',
-      signal: AbortSignal.timeout(5000),
     });
     expect(postNotFoundResponse.status).toBe(404);
   });
@@ -91,8 +87,6 @@ describe('admin-server-tests', () => {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify([]),
-      signal: AbortSignal.timeout(5000),
     });
     expect(response.status).toBe(204);
     await expect(handle.getStatus()).resolves.toMatchObject({
@@ -105,8 +99,6 @@ describe('admin-server-tests', () => {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify([]),
-      signal: AbortSignal.timeout(5000),
     });
     expect(response.status).toBe(204);
     await DBOSExecutor.globalInstance?.flushWorkflowBuffers();
@@ -121,8 +113,6 @@ describe('admin-server-tests', () => {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify([]),
-      signal: AbortSignal.timeout(5000),
     });
     expect(response.status).toBe(204);
     await DBOSExecutor.globalInstance?.flushWorkflowBuffers();

--- a/tests/httpServer/adminserver.test.ts
+++ b/tests/httpServer/adminserver.test.ts
@@ -73,7 +73,7 @@ describe('admin-server-tests', () => {
       status: StatusString.SUCCESS,
     });
 
-    // Resume the workflow. Verify it does not run and statuc remains SUCCESS
+    // Resume the workflow. Verify it does not run and status remains SUCCESS
     response = await fetch(`http://localhost:3001/workflows/${handle.workflowID}/resume`, {
       method: 'POST',
       headers: {

--- a/tests/httpServer/adminserver.test.ts
+++ b/tests/httpServer/adminserver.test.ts
@@ -27,39 +27,6 @@ describe('admin-server-tests', () => {
     await DBOS.shutdown();
   }, 10000);
 
-  test('test-admin-endpoints', async () => {
-    // Test GET /dbos-healthz
-    const healthzResponse = await fetch('http://localhost:3001/dbos-healthz', {
-      method: 'GET',
-    });
-    expect(healthzResponse.status).toBe(200);
-    expect(await healthzResponse.text()).toBe('healthy');
-
-    // Test POST /dbos-workflow-recovery
-    const data = ['executor1', 'executor2'];
-    const recoveryResponse = await fetch('http://localhost:3001/dbos-workflow-recovery', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(data),
-    });
-    expect(recoveryResponse.status).toBe(200);
-    expect(await recoveryResponse.json()).toEqual([]);
-
-    // Test GET not found
-    const getNotFoundResponse = await fetch('http://localhost:3001/stuff', {
-      method: 'GET',
-    });
-    expect(getNotFoundResponse.status).toBe(404);
-
-    // Test POST not found
-    const postNotFoundResponse = await fetch('http://localhost:3001/stuff', {
-      method: 'POST',
-    });
-    expect(postNotFoundResponse.status).toBe(404);
-  });
-
   class testAdminWorkflow {
     static counter = 0;
 
@@ -130,5 +97,38 @@ describe('admin-server-tests', () => {
     expect(response.status).toBe(204);
     await DBOSExecutor.globalInstance?.flushWorkflowBuffers();
     expect(testAdminWorkflow.counter).toBe(3);
+  });
+
+  test('test-admin-endpoints', async () => {
+    // Test GET /dbos-healthz
+    const healthzResponse = await fetch('http://localhost:3001/dbos-healthz', {
+      method: 'GET',
+    });
+    expect(healthzResponse.status).toBe(200);
+    expect(await healthzResponse.text()).toBe('healthy');
+
+    // Test POST /dbos-workflow-recovery
+    const data = ['executor1', 'executor2'];
+    const recoveryResponse = await fetch('http://localhost:3001/dbos-workflow-recovery', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    });
+    expect(recoveryResponse.status).toBe(200);
+    expect(await recoveryResponse.json()).toEqual([]);
+
+    // Test GET not found
+    const getNotFoundResponse = await fetch('http://localhost:3001/stuff', {
+      method: 'GET',
+    });
+    expect(getNotFoundResponse.status).toBe(404);
+
+    // Test POST not found
+    const postNotFoundResponse = await fetch('http://localhost:3001/stuff', {
+      method: 'POST',
+    });
+    expect(postNotFoundResponse.status).toBe(404);
   });
 });

--- a/tests/httpServer/adminserver.test.ts
+++ b/tests/httpServer/adminserver.test.ts
@@ -1,6 +1,5 @@
 import { DBOS, DBOSRuntimeConfig, StatusString } from '../../src';
 import { DBOSConfig, DBOSExecutor } from '../../src/dbos-executor';
-import { sleepms } from '../../src/utils';
 import { generateDBOSTestConfig, setUpDBOSTestDb } from '../helpers';
 
 describe('admin-server-tests', () => {

--- a/tests/httpServer/adminserver.test.ts
+++ b/tests/httpServer/adminserver.test.ts
@@ -1,0 +1,66 @@
+import { DBOS, DBOSRuntimeConfig } from '../../src';
+import { DBOSConfig } from '../../src/dbos-executor';
+import { generateDBOSTestConfig, setUpDBOSTestDb } from '../helpers';
+
+describe('admin-server-tests', () => {
+  let config: DBOSConfig;
+
+  beforeAll(async () => {
+    config = generateDBOSTestConfig();
+    const runtimeConfig: DBOSRuntimeConfig = {
+      entrypoints: [],
+      port: 3000,
+      admin_port: 3001,
+      start: [],
+      setup: [],
+    };
+    await setUpDBOSTestDb(config);
+    DBOS.setConfig(config, runtimeConfig);
+  });
+
+  beforeEach(async () => {
+    await DBOS.launch();
+    await DBOS.launchAppHTTPServer();
+  });
+
+  afterEach(async () => {
+    await DBOS.shutdown();
+  }, 10000);
+
+  test('test-admin-endpoints', async () => {
+    // Test GET /dbos-healthz
+    const healthzResponse = await fetch('http://localhost:3001/dbos-healthz', {
+      method: 'GET',
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(healthzResponse.status).toBe(200);
+    expect(await healthzResponse.text()).toBe('healthy');
+
+    // Test POST /dbos-workflow-recovery
+    const data = ['executor1', 'executor2'];
+    const recoveryResponse = await fetch('http://localhost:3001/dbos-workflow-recovery', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(recoveryResponse.status).toBe(200);
+    expect(await recoveryResponse.json()).toEqual([]);
+
+    // Test GET not found
+    const getNotFoundResponse = await fetch('http://localhost:3001/stuff', {
+      method: 'GET',
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(getNotFoundResponse.status).toBe(404);
+
+    // Test POST not found
+    const postNotFoundResponse = await fetch('http://localhost:3001/stuff', {
+      method: 'POST',
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(postNotFoundResponse.status).toBe(404);
+  });
+});

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -526,8 +526,7 @@ describe('queued-wf-tests-simple', () => {
     });
 
     // Resume a regular workflow. Verify it completes.
-    await DBOSExecutor.globalInstance?.systemDatabase.resumeWorkflow(wfid);
-    await DBOSExecutor.globalInstance?.executeWorkflowUUID(wfid, false);
+    await DBOSExecutor.globalInstance?.resumeWorkflow(wfid);
     await expect(regularHandle.getResult()).resolves.toBeNull();
 
     // Complete the blocked workflow. Verify the second regular workflow also completes.

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -484,7 +484,7 @@ describe('queued-wf-tests-simple', () => {
     });
 
     // Cancel the blocked workflow. Verify the regular workflow runs.
-    await DBOSExecutor.globalInstance?.systemDatabase.cancelWorkflow(wfid);
+    await DBOSExecutor.globalInstance?.cancelWorkflow(wfid);
     await expect(blockedHandle.getStatus()).resolves.toMatchObject({
       status: StatusString.CANCELLED,
     });


### PR DESCRIPTION
- Cancelling a workflow removes it from any queue it is in. This way, cancelled workflows don't block queues.
- Resume sets status to `PENDING` and resets recovery attempts. It also removes the workflow from any queue it is in. This way, resume can safely start DLQ'ed, `CANCELLED`, and `ENQUEUED` workflows.
- Lots and lots of tests.