### PR TITLE
Catch Exceptions During System Database Migration

### DIFF
--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -108,7 +108,7 @@ async function createDBOSTables(configFile: ConfigFile, userPoolConfig: PoolConf
   await pgSystemClient.connect();
 
   try {
-    await migrateSystemDatabase(systemPoolConfig);
+    await migrateSystemDatabase(systemPoolConfig, logger);
   } catch (e) {
     const tableExists = await pgSystemClient.query<ExistenceCheck>(
       `SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = 'dbos' AND table_name = 'operation_outputs')`,


### PR DESCRIPTION
This allows an older version of DBOS to start using a system database created by a later version, assuming all changes are backwards-compatible (as they should be).