### PR TITLE
Fix q global concurrency

### DIFF
--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1395,7 +1395,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
           .whereNull('completed_at_epoch_ms')
           .andWhere('queue_name', queue.name)
           .andWhere(function () {
-            this.whereNull('executor_id').orWhere('executor_id', executorID);
+            void this.whereNull('executor_id').orWhere('executor_id', executorID);
           })
           .select()
           .orderBy('created_at_epoch_ms', 'asc')

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1396,9 +1396,9 @@ export class PostgresSystemDatabase implements SystemDatabase {
         let maxTasks = Infinity;
 
         if (queue.workerConcurrency !== undefined) {
-          if (queue.workerConcurrency < runningTasksForThisWorker) {
+          if (runningTasksForThisWorker > queue.workerConcurrency) {
             this.logger.warn(
-              `Worker concurrency limit ${queue.workerConcurrency} is less than the number of tasks running for this worker ${runningTasksForThisWorker}`,
+              `Number of tasks on this worker (${runningTasksForThisWorker}) exceeds the worker concurrency limit (${queue.workerConcurrency})`,
             );
           }
           maxTasks = Math.max(0, queue.workerConcurrency - runningTasksForThisWorker);
@@ -1406,9 +1406,9 @@ export class PostgresSystemDatabase implements SystemDatabase {
 
         if (queue.concurrency !== undefined) {
           const totalRunningTasks = Object.values(runningTasksResultDict).reduce((acc, val) => acc + val, 0);
-          if (queue.concurrency < totalRunningTasks) {
+          if (totalRunningTasks > queue.concurrency) {
             this.logger.warn(
-              `Queue global concurrency limit ${queue.concurrency} is less than the number of tasks running for this queue ${totalRunningTasks}`,
+              `Total running tasks (${totalRunningTasks}) exceeds the global concurrency limit (${queue.concurrency})`,
             );
           }
           const availableTasks = Math.max(0, queue.concurrency - totalRunningTasks);

--- a/src/wfqueue.ts
+++ b/src/wfqueue.ts
@@ -92,9 +92,11 @@ class WFQueueRunner {
           wfids = await exec.systemDatabase.findAndMarkStartableWorkflows(q, exec.executorID);
         } catch (e) {
           const err = e as Error;
-          exec.logger.warn(`Error getting startable workflows: ${err.message}`);
+          // Silence row lock acquisition errors
+          if ('code' in err && err.code !== '55P03') {
+            exec.logger.warn(`Error getting startable workflows: ${err.message}`);
+          }
           // On the premise that this was a transaction conflict error, just try again later.
-          // TODO: handle specific error codes
           wfids = [];
         }
 

--- a/src/wfqueue.ts
+++ b/src/wfqueue.ts
@@ -94,6 +94,7 @@ class WFQueueRunner {
           const err = e as Error;
           exec.logger.warn(`Error getting startable workflows: ${err.message}`);
           // On the premise that this was a transaction conflict error, just try again later.
+          // TODO: handle specific error codes
           wfids = [];
         }
 
@@ -106,7 +107,7 @@ class WFQueueRunner {
             const _wfh = await exec.executeWorkflowUUID(wfid);
           } catch (e) {
             exec.logger.warn(`Could not execute workflow with id ${wfid}`);
-            exec.logger.warn(e);
+            exec.logger.warn((e as Error).message);
           }
         }
       }
@@ -117,10 +118,14 @@ class WFQueueRunner {
     const logger = exec.logger;
     logger.info('Workflow queues:');
     for (const [qn, q] of this.wfQueuesByName) {
-        const conc = q.concurrency !== undefined ? `global concurrency limit: ${q.concurrency}` : 'No concurrency limit set';
-        logger.info(`    ${qn}: ${conc}`);
-        const workerconc = q.workerConcurrency !== undefined ? `worker concurrency limit: ${q.workerConcurrency}` : 'No worker concurrency limit set';
-        logger.info(`    ${qn}: ${workerconc}`);
+      const conc =
+        q.concurrency !== undefined ? `global concurrency limit: ${q.concurrency}` : 'No concurrency limit set';
+      logger.info(`    ${qn}: ${conc}`);
+      const workerconc =
+        q.workerConcurrency !== undefined
+          ? `worker concurrency limit: ${q.workerConcurrency}`
+          : 'No worker concurrency limit set';
+      logger.info(`    ${qn}: ${workerconc}`);
     }
   }
 }

--- a/src/wfqueue.ts
+++ b/src/wfqueue.ts
@@ -108,8 +108,7 @@ class WFQueueRunner {
           try {
             const _wfh = await exec.executeWorkflowUUID(wfid);
           } catch (e) {
-            exec.logger.warn(`Could not execute workflow with id ${wfid}`);
-            exec.logger.warn((e as Error).message);
+            exec.logger.warn(`Could not execute workflow with id ${wfid}: ${(e as Error).message}`);
           }
         }
       }

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -63,6 +63,7 @@ export interface WorkflowStatus {
   readonly assumedRole: string; // The role used to run this workflow.  Empty string if authorization is not required.
   readonly authenticatedRoles: string[]; // All roles the authenticated user has, if any.
   readonly request: HTTPRequest; // The parent request for this workflow, if any.
+  readonly executorId?: string; // The ID of the workflow executor
 }
 
 export interface GetWorkflowsInput {

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -184,7 +184,7 @@ describe('queued-wf-tests-simple', () => {
     // Verify that each "wave" of tasks started at the ~same time.
     for (let wave = 0; wave < numWaves; ++wave) {
       for (let i = wave * qlimit; i < (wave + 1) * qlimit - 1; ++i) {
-        expect(times[i + 1] - times[i]).toBeLessThan(100);
+        expect(times[i + 1] - times[i]).toBeLessThan(150);
       }
     }
 

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -677,57 +677,108 @@ const IPWQueue = new WorkflowQueue('IPWQueue', {
   rateLimit: { limitPerPeriod: 0, periodSec: 30 },
 });
 class InterProcessWorkflow {
-  static globalConcurrencyLimit = 3;
-  static nWorkers = InterProcessWorkflow.globalConcurrencyLimit * 2;
-  static nTasks = InterProcessWorkflow.globalConcurrencyLimit * 5;
+  static localConcurrencyLimit = 5;
+  static globalConcurrencyLimit = InterProcessWorkflow.localConcurrencyLimit * 2;
 
   @DBOS.workflow()
-  static async testGlobalConcurrency() {
-    // Enqueue a bunch of tasks
-    const handles = [];
-    for (let i = 0; i < InterProcessWorkflow.nTasks; ++i) {
+  static async testGlobalConcurrency(config: DBOSConfig) {
+    // First, start local concurrency limit tasks
+    let handles = [];
+    for (let i = 0; i < InterProcessWorkflow.localConcurrencyLimit; ++i) {
       handles.push(await DBOS.startWorkflow(InterProcessWorkflowTask, { queueName: IPWQueue.name }).task());
     }
-    // Start the processes and wait for the to notify us
-    const workerPromises = await InterProcessWorkflow.startWorkerProcesses();
-    try {
-      let num_dequeued = 0;
-      while (num_dequeued < InterProcessWorkflow.globalConcurrencyLimit) {
-        const msg = await DBOS.recv<string>('worker_dequeue', 1);
-        if (msg) {
-          num_dequeued++;
-          DBOS.logger.debug(`Dequeued ${num_dequeued} tasks`);
-        }
+    // Start two workers
+    const workerPromises = await InterProcessWorkflow.startWorkerProcesses(2);
+    // Check that a single worker was able to acquire all the tasks
+    let loop = true;
+    while (loop) {
+      const msg = await DBOS.recv<string>('worker_dequeue', 1);
+      if (msg === 'worker_dequeue') {
+        loop = false;
       }
-      // Check the concurrency limit is respected
-      let dequeuedWorkflows = 0;
-      let enqueuedWorkflows = 0;
-      for (const h of handles) {
-        const status = await h.getStatus();
-        expect(status).not.toBeNull();
-        if (status?.status === StatusString.ENQUEUED) {
-          enqueuedWorkflows++;
-        } else if (status?.status === StatusString.PENDING) {
-          dequeuedWorkflows++;
-        }
-      }
-      expect(dequeuedWorkflows).toBe(InterProcessWorkflow.globalConcurrencyLimit);
-      expect(enqueuedWorkflows).toBe(InterProcessWorkflow.nTasks - InterProcessWorkflow.globalConcurrencyLimit);
-
-      // Notify the workers they can resume
-      await DBOS.setEvent('worker_resume', true);
-    } catch (e) {
-      DBOS.logger.error(`Error: ${(e as Error).message}`);
-      throw e;
-    } finally {
-      await Promise.all(workerPromises);
     }
+    let executors = [];
+    for (const handle of handles) {
+      const status = await handle.getStatus();
+      expect(status).not.toBeNull();
+      expect(status?.status).toBe(StatusString.PENDING);
+      executors.push(status?.executorId);
+    }
+    expect(new Set(executors).size).toBe(1);
+
+    // Now enqueue less than the local concurrency limit. Check that the 2nd worker acquired them. We won't have a signal set from the worker so we need to sleep a little.
+    handles = [];
+    for (let i = 0; i < InterProcessWorkflow.localConcurrencyLimit - 1; ++i) {
+      handles.push(await DBOS.startWorkflow(InterProcessWorkflowTask, { queueName: IPWQueue.name }).task());
+    }
+    await sleepms(1000);
+
+    executors = [];
+    for (const handle of handles) {
+      const status = await handle.getStatus();
+      expect(status).not.toBeNull();
+      expect(status?.status).toBe(StatusString.PENDING);
+      executors.push(status?.executorId);
+    }
+    expect(new Set(executors).size).toBe(1);
+
+    // Now, enqueue two more tasks. This means qlen > local concurrency limit * 2 and qlen > global concurrency limit
+    // We should have 1 tasks PENDING and 1 ENQUEUED, thus meeting both local and global concurrency limits
+    handles = [];
+    for (let i = 0; i < 2; ++i) {
+      handles.push(await DBOS.startWorkflow(InterProcessWorkflowTask, { queueName: IPWQueue.name }).task());
+    }
+    // The first worker already sent a signal. Here we are waiting for the second worker.
+    loop = true;
+    while (loop) {
+      const msg = await DBOS.recv<string>('worker_dequeue', 1);
+      if (msg === 'worker_dequeue') {
+        loop = false;
+      }
+    }
+    executors = [];
+    let statuses = [];
+    for (const handle of handles) {
+      const status = await handle.getStatus();
+      expect(status).not.toBeNull();
+      statuses.push(status?.status);
+      executors.push(status?.executorId);
+    }
+    expect(statuses).toContain(StatusString.PENDING);
+    expect(statuses).toContain(StatusString.ENQUEUED);
+    expect(new Set(executors).size).toBe(2);
+    expect(executors).toContain('local');
+
+    // Now check the global concurrency is met
+    const systemDBClient = new Client({
+      user: config.poolConfig.user,
+      port: config.poolConfig.port,
+      host: config.poolConfig.host,
+      password: config.poolConfig.password,
+      database: config.system_database,
+    });
+    await systemDBClient.connect();
+    try {
+      const result = await systemDBClient.query<{ count: string }>(
+        'SELECT COUNT(*) FROM dbos.workflow_status WHERE status = $1 AND queue_name = $2',
+        [StatusString.PENDING, IPWQueue.name],
+      );
+      const count = Number(result.rows[0].count);
+      expect(count).toBe(InterProcessWorkflow.globalConcurrencyLimit);
+    } finally {
+      await systemDBClient.end();
+    }
+
+    // Notify the workers they can resume
+    await DBOS.setEvent('worker_resume', true);
+
+    expect(await queueEntriesAreCleanedUp()).toBe(true);
   }
 
   @DBOS.step()
-  static startWorkerProcesses(): Promise<Promise<void>[]> {
+  static startWorkerProcesses(nWorkers: number): Promise<Promise<void>[]> {
     const workerPromises: Promise<void>[] = [];
-    for (let i = 0; i < InterProcessWorkflow.nWorkers; i++) {
+    for (let i = 0; i < nWorkers; i++) {
       const workerId = `test-worker-${i}`;
       const workerPromise = new Promise<void>((resolve, reject) => {
         const child = spawn(
@@ -735,6 +786,7 @@ class InterProcessWorkflow {
           [
             'ts-node',
             './tests/wfqueueworker.ts',
+            `${InterProcessWorkflow.localConcurrencyLimit}`,
             `${InterProcessWorkflow.globalConcurrencyLimit}`,
             `${DBOS.workflowID}`,
             `${IPWQueue.name}`,
@@ -783,10 +835,10 @@ describe('queued-wf-tests-concurrent-workers', () => {
   });
 
   test('test_global_concurrency', async () => {
-    const wfh = await DBOS.startWorkflow(InterProcessWorkflow).testGlobalConcurrency();
+    const wfh = await DBOS.startWorkflow(InterProcessWorkflow).testGlobalConcurrency(config);
     await wfh.getResult();
     expect(await queueEntriesAreCleanedUp()).toBe(true);
-  }, 120000);
+  }, 60000);
 });
 
 class TestWFs {

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -693,7 +693,7 @@ class InterProcessWorkflow {
     try {
       let num_dequeued = 0;
       while (num_dequeued < InterProcessWorkflow.globalConcurrencyLimit) {
-        const msg = await DBOS.recv<String>('worker_dequeue', 1);
+        const msg = await DBOS.recv<string>('worker_dequeue', 1);
         if (msg) {
           num_dequeued++;
           DBOS.logger.debug(`Dequeued ${num_dequeued} tasks`);
@@ -715,7 +715,7 @@ class InterProcessWorkflow {
       expect(enqueuedWorkflows).toBe(InterProcessWorkflow.nTasks - InterProcessWorkflow.globalConcurrencyLimit);
 
       // Notify the workers they can resume
-      DBOS.setEvent('worker_resume', true);
+      await DBOS.setEvent('worker_resume', true);
     } catch (e) {
       DBOS.logger.error(`Error: ${(e as Error).message}`);
       throw e;
@@ -725,7 +725,7 @@ class InterProcessWorkflow {
   }
 
   @DBOS.step()
-  static async startWorkerProcesses(): Promise<Promise<void>[]> {
+  static startWorkerProcesses(): Promise<Promise<void>[]> {
     const workerPromises: Promise<void>[] = [];
     for (let i = 0; i < InterProcessWorkflow.nWorkers; i++) {
       const workerId = `test-worker-${i}`;

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -761,7 +761,7 @@ class InterProcessWorkflow {
       });
       workerPromises.push(workerPromise);
     }
-    return workerPromises;
+    return Promise.resolve(workerPromises);
   }
 }
 

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -677,7 +677,7 @@ const IPWQueue = new WorkflowQueue('IPWQueue', {
   rateLimit: { limitPerPeriod: 0, periodSec: 30 },
 });
 class InterProcessWorkflow {
-  static globalConcurrencyLimit = 4;
+  static globalConcurrencyLimit = 3;
   static nWorkers = InterProcessWorkflow.globalConcurrencyLimit * 2;
   static nTasks = InterProcessWorkflow.globalConcurrencyLimit * 5;
 
@@ -692,12 +692,11 @@ class InterProcessWorkflow {
     const workerPromises = await InterProcessWorkflow.startWorkerProcesses();
     try {
       let num_dequeued = 0;
-      // while (num_dequeued < InterProcessWorkflow.globalConcurrencyLimit) {
-      while (num_dequeued < InterProcessWorkflow.nWorkers) {
+      while (num_dequeued < InterProcessWorkflow.globalConcurrencyLimit) {
         const msg = await DBOS.recv<String>('worker_dequeue', 1);
         if (msg) {
           num_dequeued++;
-          DBOS.logger.info(`Dequeued ${num_dequeued} tasks`);
+          DBOS.logger.debug(`Dequeued ${num_dequeued} tasks`);
         }
       }
       // Check the concurrency limit is respected
@@ -783,7 +782,7 @@ describe('queued-wf-tests-concurrent-workers', () => {
     await DBOS.shutdown();
   });
 
-  test.only('test_global_concurrency', async () => {
+  test('test_global_concurrency', async () => {
     const wfh = await DBOS.startWorkflow(InterProcessWorkflow).testGlobalConcurrency();
     await wfh.getResult();
     expect(await queueEntriesAreCleanedUp()).toBe(true);

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -834,7 +834,7 @@ describe('queued-wf-tests-concurrent-workers', () => {
     await DBOS.shutdown();
   });
 
-  test('test_global_concurrency', async () => {
+  test('test_global_and_local_concurrency', async () => {
     const wfh = await DBOS.startWorkflow(InterProcessWorkflow).testGlobalConcurrency(config);
     await wfh.getResult();
     expect(await queueEntriesAreCleanedUp()).toBe(true);

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -737,7 +737,7 @@ class InterProcessWorkflow {
       }
     }
     executors = [];
-    let statuses = [];
+    const statuses = [];
     for (const handle of handles) {
       const status = await handle.getStatus();
       expect(status).not.toBeNull();
@@ -771,7 +771,7 @@ class InterProcessWorkflow {
 
     // Notify the workers they can resume
     await DBOS.setEvent('worker_resume', true);
-
+    await Promise.all(workerPromises);
     expect(await queueEntriesAreCleanedUp()).toBe(true);
   }
 

--- a/tests/wfqueueworker.ts
+++ b/tests/wfqueueworker.ts
@@ -58,7 +58,7 @@ async function main() {
   await DBOS.send<String>(parentWorkflowID, 'worker_dequeue', 'worker_dequeue', workerId.toString());
 
   // Wait for a resume signal from the main process
-  const can_resume = await DBOS.getEvent(parentWorkflowID, 'worker_resume', 10);
+  const can_resume = await DBOS.getEvent(parentWorkflowID, 'worker_resume');
   if (!can_resume) {
     console.error(`${workerId} did not receive resume signal`);
     process.exit(1);

--- a/tests/wfqueueworker.ts
+++ b/tests/wfqueueworker.ts
@@ -55,7 +55,7 @@ async function main() {
   await InterProcessWorkflowTask.start_event.wait();
 
   // Notify the main process this worker has dequeued a task
-  await DBOS.send<String>(parentWorkflowID, 'worker_dequeue', 'worker_dequeue', workerId.toString());
+  await DBOS.send<string>(parentWorkflowID, 'worker_dequeue', 'worker_dequeue', workerId.toString());
 
   // Wait for a resume signal from the main process
   const can_resume = await DBOS.getEvent(parentWorkflowID, 'worker_resume');

--- a/tests/wfqueueworker.ts
+++ b/tests/wfqueueworker.ts
@@ -1,32 +1,51 @@
 import { DBOS, WorkflowQueue } from '../src';
-import { generateDBOSTestConfig } from './helpers';
+import { generateDBOSTestConfig, Event } from '../tests/helpers';
 import { sleepms } from '../src/utils';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const workerConcurrencyQueue = new WorkflowQueue('workerQ', { workerConcurrency: 1 });
+// Extract worker arguments from command-line input
+const workerId = process.env.DBOS__VMID || process.pid;
+const globalConcurrencyLimit = parseInt(process.argv[2] || '1', 10);
+const parentWorkflowID = process.argv[3];
+if (!parentWorkflowID) {
+  console.error('Parent workflow ID not provided');
+  process.exit(1);
+}
+const queueName = process.argv[4];
+if (!queueName) {
+  console.error('Queue name not provided');
+  process.exit(1);
+}
+console.log(`Worker ID: ${workerId}, Global Concurrency Limit: ${globalConcurrencyLimit}`);
 
-// This declaration is just for registration in DBOS internal operations registry
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-class TestWFs {
+// Declare worker queue with controlled concurrency
+new WorkflowQueue(queueName, {
+  workerConcurrency: 1,
+  concurrency: globalConcurrencyLimit,
+});
+
+class InterProcessWorkflowTask {
+  static start_event = new Event();
+  static end_event = new Event();
+
   @DBOS.workflow()
-  static async noop() {
+  static async task() {
+    console.log(`${workerId} starting task`);
+    InterProcessWorkflowTask.start_event.set();
+    console.log(`${workerId} waiting to end`);
+    InterProcessWorkflowTask.end_event.wait();
     return Promise.resolve();
   }
 }
 
 async function queueEntriesAreCleanedUp() {
   let maxTries = 10;
-  let success = false;
   while (maxTries > 0) {
     const r = await DBOS.getWorkflowQueue({});
-    if (r.workflows.length === 0) {
-      success = true;
-      break;
-    }
+    if (r.workflows.length === 0) return true;
     await sleepms(1000);
     --maxTries;
   }
-  return success;
+  return false;
 }
 
 async function main() {
@@ -34,23 +53,40 @@ async function main() {
   DBOS.setConfig(config);
   await DBOS.launch();
 
+  // Wait for a task to be dequeued
+  await InterProcessWorkflowTask.start_event.wait();
+  // InterProcessWorkflowTask.start_event.clear();
+  console.log(`${workerId} dequeued task`);
+
+  // Notify the main process this worker has dequeued a task
+  await DBOS.send<String>(parentWorkflowID, 'worker_dequeue', 'worker_dequeue', workerId.toString());
+
+  // Wait for a resume signal from the main process
+  const can_resume = await DBOS.getEvent(parentWorkflowID, 'worker_resume', 10);
+  if (!can_resume) {
+    console.error(`${workerId} did not receive resume signal`);
+    process.exit(1);
+  }
+  console.log(`${workerId} received resume signal`);
+
+  // Complete the task
+  InterProcessWorkflowTask.end_event.set();
+
   const success = await queueEntriesAreCleanedUp();
   if (!success) {
-    throw new Error(`${process.env['DBOS__VMID']} worker detected unhandled workflow queue entries`);
+    console.error(`${workerId} detected unhandled workflow queue entries`);
+    process.exit(1);
   }
+  console.log(`${workerId} detected no unhandled workflow queue entries`);
 
   await DBOS.shutdown();
-
   process.exit(0);
 }
 
+// Run the worker if executed as a standalone script
 if (require.main === module) {
-  main()
-    .then(() => {
-      process.exit(0);
-    })
-    .catch((e) => {
-      console.error(e);
-      process.exit(1);
-    });
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 }

--- a/tests/wfqueueworker.ts
+++ b/tests/wfqueueworker.ts
@@ -29,10 +29,8 @@ class InterProcessWorkflowTask {
 
   @DBOS.workflow()
   static async task() {
-    console.log(`${workerId} starting task`);
     InterProcessWorkflowTask.start_event.set();
-    console.log(`${workerId} waiting to end`);
-    InterProcessWorkflowTask.end_event.wait();
+    await InterProcessWorkflowTask.end_event.wait();
     return Promise.resolve();
   }
 }
@@ -55,8 +53,6 @@ async function main() {
 
   // Wait for a task to be dequeued
   await InterProcessWorkflowTask.start_event.wait();
-  // InterProcessWorkflowTask.start_event.clear();
-  console.log(`${workerId} dequeued task`);
 
   // Notify the main process this worker has dequeued a task
   await DBOS.send<String>(parentWorkflowID, 'worker_dequeue', 'worker_dequeue', workerId.toString());
@@ -67,7 +63,6 @@ async function main() {
     console.error(`${workerId} did not receive resume signal`);
     process.exit(1);
   }
-  console.log(`${workerId} received resume signal`);
 
   // Complete the task
   InterProcessWorkflowTask.end_event.set();
@@ -77,7 +72,6 @@ async function main() {
     console.error(`${workerId} detected unhandled workflow queue entries`);
     process.exit(1);
   }
-  console.log(`${workerId} detected no unhandled workflow queue entries`);
 
   await DBOS.shutdown();
   process.exit(0);


### PR DESCRIPTION
- Correctly retrieve the total number of tasks executed across all workers to compute the local limit
- When doing this query, do a `FOR UPDATE NO WAIT` to lock the rows -- and fail early when failing to do so.
- Adjusted the test `queued-wf-tests-concurrent-workers` test to enforce global concurrency.