### PR TITLE
Handle empty database field in DBOS Config

### DIFF
--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -201,7 +201,7 @@ export async function deployAppCode(
     // Make sure the app database is the same.
     if (
       appRegistered.ApplicationDatabaseName &&
-      dbosConfig.database.app_db_name &&
+      dbosConfig.database?.app_db_name &&
       dbosConfig.database.app_db_name !== appRegistered.ApplicationDatabaseName
     ) {
       logger.error(

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -70,6 +70,9 @@ export function loadConfigFile(configFilePath: string): ConfigFile {
     const configFileContent = readFileSync(configFilePath);
     const interpolatedConfig = substituteEnvVars(configFileContent);
     const configFile = YAML.parse(interpolatedConfig) as ConfigFile;
+    if (!configFile.database) {
+      configFile.database = {}; // Create an empty database object if it doesn't exist
+    }
     return configFile;
   } catch (e) {
     if (e instanceof Error) {
@@ -227,10 +230,6 @@ export function parseConfigFile(cliOptions?: ParseOptions): [DBOSConfig, DBOSRun
   const configFile: ConfigFile | undefined = loadConfigFile(configFilePath);
   if (!configFile) {
     throw new DBOSInitializationError(`DBOS configuration file ${configFilePath} is empty`);
-  }
-
-  if (!configFile.database) {
-    configFile.database = {};
   }
 
   if (configFile.database.local_suffix === true && configFile.database.hostname === 'localhost') {


### PR DESCRIPTION
This PR fixes the issues when the database field of `dbos-config.yaml` file is empty:
- `dbos migrate` would fail when reading the non-exist `database` field: `Cannot read properties of undefined (reading 'hostname')`.
- `dbos-cloud app deploy` would fail when it tries to compare the `app_db_name` field with a previous deploy: `TypeError: Cannot read properties of undefined (reading 'app_db_name')`