### PR TITLE
remove obsolete debug proxy config field

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -103,7 +103,6 @@ export interface DBOSConfig {
   readonly system_database: string;
   readonly env?: Record<string, string>;
   readonly application?: object;
-  readonly debugProxy?: string;
   readonly debugMode?: boolean;
   readonly appVersion?: string;
   readonly http?: {
@@ -1133,7 +1132,9 @@ export class DBOSExecutor implements DBOSExecutorContext {
         }
 
         if (this.debugMode) {
-          throw new DBOSDebuggerError(`Failed to find the recorded output for the transaction: workflow UUID ${workflowUUID}, step number ${funcId}`);
+          throw new DBOSDebuggerError(
+            `Failed to find the recorded output for the transaction: workflow UUID ${workflowUUID}, step number ${funcId}`,
+          );
         }
 
         // For non-read-only transactions, flush the result buffer.
@@ -1342,7 +1343,9 @@ export class DBOSExecutor implements DBOSExecutorContext {
         }
 
         if (this.debugMode) {
-          throw new DBOSDebuggerError(`Failed to find the recorded output for the procedure: workflow UUID ${wfCtx.workflowUUID}, step number ${funcId}`);
+          throw new DBOSDebuggerError(
+            `Failed to find the recorded output for the procedure: workflow UUID ${wfCtx.workflowUUID}, step number ${funcId}`,
+          );
         }
 
         // For non-read-only transactions, flush the result buffer.
@@ -1636,7 +1639,9 @@ export class DBOSExecutor implements DBOSExecutorContext {
     }
 
     if (this.debugMode) {
-      throw new DBOSDebuggerError(`Failed to find the recorded output for the step: workflow UUID: ${wfCtx.workflowUUID}, step number: ${funcID}`);
+      throw new DBOSDebuggerError(
+        `Failed to find the recorded output for the step: workflow UUID: ${wfCtx.workflowUUID}, step number: ${funcID}`,
+      );
     }
 
     // Execute the step function.  If it throws an exception, retry with exponential backoff.

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -45,7 +45,7 @@ export interface DBOSConfigureOptions {
 
 interface DBOSDebugOptions {
   uuid: string; // Workflow UUID
-  proxy: string;
+  proxy?: string; // deprecated
   loglevel?: string;
   configfile?: string;
   appVersion?: string | boolean;

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -174,18 +174,17 @@ export class DBOS {
 
     const debugWorkflowId = process.env.DBOS_DEBUG_WORKFLOW_ID;
     const debugMode = debugWorkflowId !== undefined;
-    const debugProxy = process.env.DBOS_DEBUG_PROXY;
 
     // Initialize the DBOS executor
     if (!DBOS.dbosConfig) {
       const [dbosConfig, runtimeConfig] = parseConfigFile({ forceConsole: debugMode });
-      if (!debugProxy) {
+      if (!debugMode) {
         dbosConfig.poolConfig = await db_wizard(dbosConfig.poolConfig);
       }
-      DBOS.dbosConfig = { ...dbosConfig, debugMode, debugProxy };
+      DBOS.dbosConfig = { ...dbosConfig, debugMode };
       DBOS.runtimeConfig = runtimeConfig;
     } else {
-      DBOS.dbosConfig = { ...DBOS.dbosConfig, debugMode, debugProxy };
+      DBOS.dbosConfig = { ...DBOS.dbosConfig, debugMode };
     }
 
     DBOSExecutor.globalInstance = new DBOSExecutor(DBOS.dbosConfig);

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -3,11 +3,7 @@ import { Client } from 'pg';
 import { UserDatabaseName } from '../src/user_database';
 
 /* DB management helpers */
-export function generateDBOSTestConfig(
-  dbClient?: UserDatabaseName,
-  debugMode?: boolean,
-  debugProxy?: string,
-): DBOSConfig {
+export function generateDBOSTestConfig(dbClient?: UserDatabaseName, debugMode?: boolean): DBOSConfig {
   const dbPassword: string | undefined = process.env.DB_PASSWORD || process.env.PGPASSWORD;
   if (!dbPassword) {
     throw new Error('DB_PASSWORD or PGPASSWORD environment variable not set');
@@ -35,7 +31,6 @@ export function generateDBOSTestConfig(
     },
     system_database: 'dbostest_dbos_sys',
     userDbclient: dbClient || UserDatabaseName.PGNODE,
-    debugProxy: debugProxy,
     debugMode: debugMode,
   };
 

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -30,7 +30,7 @@ describe('debugger-test', () => {
   beforeAll(async () => {
     config = generateDBOSTestConfig();
     debugConfig = generateDBOSTestConfig(undefined, true);
-    debugProxyConfig = generateDBOSTestConfig(undefined, true, 'postgresql://localhost:5432');
+    debugProxyConfig = generateDBOSTestConfig(undefined, true);
     username = config.poolConfig.user || 'postgres';
     await setUpDBOSTestDb(config);
   });

--- a/tests/testing/debugger_configuredinst.test.ts
+++ b/tests/testing/debugger_configuredinst.test.ts
@@ -70,7 +70,7 @@ describe('debugger-test', () => {
   beforeAll(async () => {
     config = generateDBOSTestConfig();
     debugConfig = generateDBOSTestConfig(undefined, true);
-    debugProxyConfig = generateDBOSTestConfig(undefined, true, 'localhost:5432');
+    debugProxyConfig = generateDBOSTestConfig(undefined, true);
     await setUpDBOSTestDb(config);
   });
 


### PR DESCRIPTION
With the latest changes to parseConfigFile that uses env vars to override database connection info, the `DBOSConfig.debugProxy` field is no longer used. This PR removes it 