### PR TITLE
Error if steps are still running at WF exit

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -10,6 +10,7 @@ import {
   DBOSFailedSqlTransactionError,
   DBOSMaxStepRetriesError,
   DBOSWorkflowCancelledError,
+  DBOSOperationInProgressError,
 } from './error';
 import {
   InvokedHandle,
@@ -744,6 +745,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
 
     const runWorkflow = async () => {
       let result: R;
+      let stepsInProgressAtWFExit = false;
 
       // Execute the workflow.
       try {
@@ -825,6 +827,9 @@ export class DBOSExecutor implements DBOSExecutorContext {
         }
       } finally {
         this.tracer.endSpan(wCtxt.span);
+        if (wCtxt.functionsOutstanding > 0) {
+          stepsInProgressAtWFExit = true;
+        }
         if (
           wCtxt.tempWfOperationType === TempWorkflowType.transaction ||
           wCtxt.tempWfOperationType === TempWorkflowType.procedure
@@ -840,6 +845,13 @@ export class DBOSExecutor implements DBOSExecutorContext {
       if (wCtxt.resultBuffer.size > 0) {
         this.workflowResultBuffer.set(wCtxt.workflowUUID, wCtxt.resultBuffer);
       }
+
+      // This is not able to catch all promise misuses / accidents, but it can catch some.
+      //  (A better solution is lint, but that only works if you use it.)
+      if (stepsInProgressAtWFExit) {
+        throw new DBOSOperationInProgressError(wf.name);
+      }
+
       return result;
     };
 
@@ -1094,159 +1106,165 @@ export class DBOSExecutor implements DBOSExecutorContext {
     let retryWaitMillis = 1;
     const backoffFactor = 1.5;
     const maxRetryWaitMs = 2000; // Maximum wait 2 seconds.
-    const funcId = wfCtx.functionIDGetIncrement();
-    const span: Span = this.tracer.startSpan(
-      txn.name,
-      {
-        operationUUID: wfCtx.workflowUUID,
-        operationType: OperationType.TRANSACTION,
-        authenticatedUser: wfCtx.authenticatedUser,
-        assumedRole: wfCtx.assumedRole,
-        authenticatedRoles: wfCtx.authenticatedRoles,
-        readOnly: readOnly,
-        isolationLevel: txnInfo.config.isolationLevel,
-      },
-      wfCtx.span,
-    );
+    const funcId = wfCtx.beginWorkflowFunction();
+    try {
+      const span: Span = this.tracer.startSpan(
+        txn.name,
+        {
+          operationUUID: wfCtx.workflowUUID,
+          operationType: OperationType.TRANSACTION,
+          authenticatedUser: wfCtx.authenticatedUser,
+          assumedRole: wfCtx.assumedRole,
+          authenticatedRoles: wfCtx.authenticatedRoles,
+          readOnly: readOnly,
+          isolationLevel: txnInfo.config.isolationLevel,
+        },
+        wfCtx.span,
+      );
 
-    while (true) {
-      if (this.workflowCancellationMap.get(wfCtx.workflowUUID) === true) {
-        throw new DBOSWorkflowCancelledError(wfCtx.workflowUUID);
-      }
-
-      let txn_snapshot = 'invalid';
-      const workflowUUID = wfCtx.workflowUUID;
-      const wrappedTransaction = async (client: UserDatabaseClient): Promise<R> => {
-        const tCtxt = new TransactionContextImpl(
-          this.userDatabase.getName(),
-          client,
-          wfCtx,
-          span,
-          this.logger,
-          funcId,
-          txn.name,
-        );
-
-        // If the UUID is preset, it is possible this execution previously happened. Check, and return its original result if it did.
-        // Note: It is possible to retrieve a generated ID from a workflow handle, run a concurrent execution, and cause trouble for yourself. We recommend against this.
-        if (wfCtx.presetUUID) {
-          const func = <T>(sql: string, args: unknown[]) => this.userDatabase.queryWithClient<T>(client, sql, ...args);
-          const check: BufferedResult = await this.#checkExecution<R>(func, workflowUUID, funcId);
-          txn_snapshot = check.txn_snapshot;
-          if (check.output !== dbosNull) {
-            tCtxt.span.setAttribute('cached', true);
-            tCtxt.span.setStatus({ code: SpanStatusCode.OK });
-            this.tracer.endSpan(tCtxt.span);
-            return check.output as R;
-          }
-        } else {
-          // Collect snapshot information for read-only transactions and non-preset UUID transactions, if not already collected above
-          const func = <T>(sql: string, args: unknown[]) => this.userDatabase.queryWithClient<T>(client, sql, ...args);
-          txn_snapshot = await DBOSExecutor.#retrieveSnapshot(func);
+      while (true) {
+        if (this.workflowCancellationMap.get(wfCtx.workflowUUID) === true) {
+          throw new DBOSWorkflowCancelledError(wfCtx.workflowUUID);
         }
 
-        if (this.debugMode) {
-          throw new DBOSDebuggerError(
-            `Failed to find the recorded output for the transaction: workflow UUID ${workflowUUID}, step number ${funcId}`,
+        let txn_snapshot = 'invalid';
+        const workflowUUID = wfCtx.workflowUUID;
+        const wrappedTransaction = async (client: UserDatabaseClient): Promise<R> => {
+          const tCtxt = new TransactionContextImpl(
+            this.userDatabase.getName(),
+            client,
+            wfCtx,
+            span,
+            this.logger,
+            funcId,
+            txn.name,
           );
-        }
 
-        // For non-read-only transactions, flush the result buffer.
-        if (!readOnly) {
-          await this.flushResultBuffer(client, wfCtx.resultBuffer, wfCtx.workflowUUID);
-        }
-
-        // Execute the user's transaction.
-        let cresult: R | undefined;
-        if (txnInfo.registration.passContext) {
-          await runWithTransactionContext(tCtxt, async () => {
-            cresult = await txn.call(clsinst, tCtxt, ...args);
-          });
-        } else {
-          await runWithTransactionContext(tCtxt, async () => {
-            const tf = txn as unknown as (...args: T) => Promise<R>;
-            cresult = await tf.call(clsinst, ...args);
-          });
-        }
-        const result = cresult!;
-
-        // Record the execution, commit, and return.
-        if (readOnly) {
-          // Buffer the output of read-only transactions instead of synchronously writing it.
-          const readOutput: BufferedResult = {
-            output: result,
-            txn_snapshot: txn_snapshot,
-            created_at: Date.now(),
-          };
-          wfCtx.resultBuffer.set(funcId, readOutput);
-        } else {
-          try {
-            // Synchronously record the output of write transactions and obtain the transaction ID.
+          // If the UUID is preset, it is possible this execution previously happened. Check, and return its original result if it did.
+          // Note: It is possible to retrieve a generated ID from a workflow handle, run a concurrent execution, and cause trouble for yourself. We recommend against this.
+          if (wfCtx.presetUUID) {
             const func = <T>(sql: string, args: unknown[]) =>
               this.userDatabase.queryWithClient<T>(client, sql, ...args);
-            const pg_txn_id = await this.#recordOutput(
-              func,
-              wfCtx.workflowUUID,
-              funcId,
-              txn_snapshot,
-              result,
-              (error) => this.userDatabase.isKeyConflictError(error),
+            const check: BufferedResult = await this.#checkExecution<R>(func, workflowUUID, funcId);
+            txn_snapshot = check.txn_snapshot;
+            if (check.output !== dbosNull) {
+              tCtxt.span.setAttribute('cached', true);
+              tCtxt.span.setStatus({ code: SpanStatusCode.OK });
+              this.tracer.endSpan(tCtxt.span);
+              return check.output as R;
+            }
+          } else {
+            // Collect snapshot information for read-only transactions and non-preset UUID transactions, if not already collected above
+            const func = <T>(sql: string, args: unknown[]) =>
+              this.userDatabase.queryWithClient<T>(client, sql, ...args);
+            txn_snapshot = await DBOSExecutor.#retrieveSnapshot(func);
+          }
+
+          if (this.debugMode) {
+            throw new DBOSDebuggerError(
+              `Failed to find the recorded output for the transaction: workflow UUID ${workflowUUID}, step number ${funcId}`,
             );
-            tCtxt.span.setAttribute('pg_txn_id', pg_txn_id);
-            wfCtx.resultBuffer.clear();
-          } catch (error) {
-            if (this.userDatabase.isFailedSqlTransactionError(error)) {
-              this.logger.error(
-                `Postgres aborted the ${txn.name} @Transaction of Workflow ${workflowUUID}, but the function did not raise an exception.  Please ensure that the @Transaction method raises an exception if the database transaction is aborted.`,
+          }
+
+          // For non-read-only transactions, flush the result buffer.
+          if (!readOnly) {
+            await this.flushResultBuffer(client, wfCtx.resultBuffer, wfCtx.workflowUUID);
+          }
+
+          // Execute the user's transaction.
+          let cresult: R | undefined;
+          if (txnInfo.registration.passContext) {
+            await runWithTransactionContext(tCtxt, async () => {
+              cresult = await txn.call(clsinst, tCtxt, ...args);
+            });
+          } else {
+            await runWithTransactionContext(tCtxt, async () => {
+              const tf = txn as unknown as (...args: T) => Promise<R>;
+              cresult = await tf.call(clsinst, ...args);
+            });
+          }
+          const result = cresult!;
+
+          // Record the execution, commit, and return.
+          if (readOnly) {
+            // Buffer the output of read-only transactions instead of synchronously writing it.
+            const readOutput: BufferedResult = {
+              output: result,
+              txn_snapshot: txn_snapshot,
+              created_at: Date.now(),
+            };
+            wfCtx.resultBuffer.set(funcId, readOutput);
+          } else {
+            try {
+              // Synchronously record the output of write transactions and obtain the transaction ID.
+              const func = <T>(sql: string, args: unknown[]) =>
+                this.userDatabase.queryWithClient<T>(client, sql, ...args);
+              const pg_txn_id = await this.#recordOutput(
+                func,
+                wfCtx.workflowUUID,
+                funcId,
+                txn_snapshot,
+                result,
+                (error) => this.userDatabase.isKeyConflictError(error),
               );
-              throw new DBOSFailedSqlTransactionError(workflowUUID, txn.name);
-            } else {
-              throw error;
+              tCtxt.span.setAttribute('pg_txn_id', pg_txn_id);
+              wfCtx.resultBuffer.clear();
+            } catch (error) {
+              if (this.userDatabase.isFailedSqlTransactionError(error)) {
+                this.logger.error(
+                  `Postgres aborted the ${txn.name} @Transaction of Workflow ${workflowUUID}, but the function did not raise an exception.  Please ensure that the @Transaction method raises an exception if the database transaction is aborted.`,
+                );
+                throw new DBOSFailedSqlTransactionError(workflowUUID, txn.name);
+              } else {
+                throw error;
+              }
             }
           }
-        }
 
-        return result;
-      };
+          return result;
+        };
 
-      try {
-        const result = await this.userDatabase.transaction(wrappedTransaction, txnInfo.config);
-        span.setStatus({ code: SpanStatusCode.OK });
-        this.tracer.endSpan(span);
-        return result;
-      } catch (err) {
-        if (this.debugMode) {
+        try {
+          const result = await this.userDatabase.transaction(wrappedTransaction, txnInfo.config);
+          span.setStatus({ code: SpanStatusCode.OK });
+          this.tracer.endSpan(span);
+          return result;
+        } catch (err) {
+          if (this.debugMode) {
+            throw err;
+          }
+
+          if (this.userDatabase.isRetriableTransactionError(err)) {
+            // serialization_failure in PostgreSQL
+            span.addEvent('TXN SERIALIZATION FAILURE', { retryWaitMillis: retryWaitMillis }, performance.now());
+            // Retry serialization failures.
+            await sleepms(retryWaitMillis);
+            retryWaitMillis *= backoffFactor;
+            retryWaitMillis = retryWaitMillis < maxRetryWaitMs ? retryWaitMillis : maxRetryWaitMs;
+            continue;
+          }
+
+          // Record and throw other errors.
+          const e: Error = err as Error;
+          await this.userDatabase.transaction(
+            async (client: UserDatabaseClient) => {
+              await this.flushResultBuffer(client, wfCtx.resultBuffer, wfCtx.workflowUUID);
+              const func = <T>(sql: string, args: unknown[]) =>
+                this.userDatabase.queryWithClient<T>(client, sql, ...args);
+              await this.#recordError(func, wfCtx.workflowUUID, funcId, txn_snapshot, e, (error) =>
+                this.userDatabase.isKeyConflictError(error),
+              );
+            },
+            { isolationLevel: IsolationLevel.ReadCommitted },
+          );
+          wfCtx.resultBuffer.clear();
+          span.setStatus({ code: SpanStatusCode.ERROR, message: e.message });
+          this.tracer.endSpan(span);
           throw err;
         }
-
-        if (this.userDatabase.isRetriableTransactionError(err)) {
-          // serialization_failure in PostgreSQL
-          span.addEvent('TXN SERIALIZATION FAILURE', { retryWaitMillis: retryWaitMillis }, performance.now());
-          // Retry serialization failures.
-          await sleepms(retryWaitMillis);
-          retryWaitMillis *= backoffFactor;
-          retryWaitMillis = retryWaitMillis < maxRetryWaitMs ? retryWaitMillis : maxRetryWaitMs;
-          continue;
-        }
-
-        // Record and throw other errors.
-        const e: Error = err as Error;
-        await this.userDatabase.transaction(
-          async (client: UserDatabaseClient) => {
-            await this.flushResultBuffer(client, wfCtx.resultBuffer, wfCtx.workflowUUID);
-            const func = <T>(sql: string, args: unknown[]) =>
-              this.userDatabase.queryWithClient<T>(client, sql, ...args);
-            await this.#recordError(func, wfCtx.workflowUUID, funcId, txn_snapshot, e, (error) =>
-              this.userDatabase.isKeyConflictError(error),
-            );
-          },
-          { isolationLevel: IsolationLevel.ReadCommitted },
-        );
-        wfCtx.resultBuffer.clear();
-        span.setStatus({ code: SpanStatusCode.ERROR, message: e.message });
-        this.tracer.endSpan(span);
-        throw err;
       }
+    } finally {
+      wfCtx.endWorkflowFunction();
     }
   }
 
@@ -1285,7 +1303,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
     }
 
     const executeLocally = this.debugMode || (procInfo.config.executeLocally ?? false);
-    const funcId = wfCtx.functionIDGetIncrement();
+    const funcId = wfCtx.beginWorkflowFunction();
     const span: Span = this.tracer.startSpan(
       proc.name,
       {
@@ -1313,6 +1331,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
       throw e;
     } finally {
       this.tracer.endSpan(span);
+      wfCtx.endWorkflowFunction();
     }
   }
 
@@ -1614,69 +1633,107 @@ export class DBOSExecutor implements DBOSExecutorContext {
       throw new DBOSWorkflowCancelledError(wfCtx.workflowUUID);
     }
 
-    const funcID = wfCtx.functionIDGetIncrement();
-    const maxRetryIntervalSec = 3600; // Maximum retry interval: 1 hour
+    const funcID = wfCtx.beginWorkflowFunction();
+    try {
+      const maxRetryIntervalSec = 3600; // Maximum retry interval: 1 hour
 
-    const span: Span = this.tracer.startSpan(
-      stepFn.name,
-      {
-        operationUUID: wfCtx.workflowUUID,
-        operationType: OperationType.COMMUNICATOR,
-        authenticatedUser: wfCtx.authenticatedUser,
-        assumedRole: wfCtx.assumedRole,
-        authenticatedRoles: wfCtx.authenticatedRoles,
-        retriesAllowed: commInfo.config.retriesAllowed,
-        intervalSeconds: commInfo.config.intervalSeconds,
-        maxAttempts: commInfo.config.maxAttempts,
-        backoffRate: commInfo.config.backoffRate,
-      },
-      wfCtx.span,
-    );
-
-    const ctxt: StepContextImpl = new StepContextImpl(wfCtx, funcID, span, this.logger, commInfo.config, stepFn.name);
-
-    await this.userDatabase.transaction(
-      async (client: UserDatabaseClient) => {
-        await this.flushResultBuffer(client, wfCtx.resultBuffer, wfCtx.workflowUUID);
-      },
-      { isolationLevel: IsolationLevel.ReadCommitted },
-    );
-    wfCtx.resultBuffer.clear();
-
-    // Check if this execution previously happened, returning its original result if it did.
-    const check: R | DBOSNull = await this.systemDatabase.checkOperationOutput<R>(wfCtx.workflowUUID, ctxt.functionID);
-    if (check !== dbosNull) {
-      ctxt.span.setAttribute('cached', true);
-      ctxt.span.setStatus({ code: SpanStatusCode.OK });
-      this.tracer.endSpan(ctxt.span);
-      return check as R;
-    }
-
-    if (this.debugMode) {
-      throw new DBOSDebuggerError(
-        `Failed to find the recorded output for the step: workflow UUID: ${wfCtx.workflowUUID}, step number: ${funcID}`,
+      const span: Span = this.tracer.startSpan(
+        stepFn.name,
+        {
+          operationUUID: wfCtx.workflowUUID,
+          operationType: OperationType.COMMUNICATOR,
+          authenticatedUser: wfCtx.authenticatedUser,
+          assumedRole: wfCtx.assumedRole,
+          authenticatedRoles: wfCtx.authenticatedRoles,
+          retriesAllowed: commInfo.config.retriesAllowed,
+          intervalSeconds: commInfo.config.intervalSeconds,
+          maxAttempts: commInfo.config.maxAttempts,
+          backoffRate: commInfo.config.backoffRate,
+        },
+        wfCtx.span,
       );
-    }
 
-    // Execute the step function.  If it throws an exception, retry with exponential backoff.
-    // After reaching the maximum number of retries, throw an DBOSError.
-    let result: R | DBOSNull = dbosNull;
-    let err: Error | DBOSNull = dbosNull;
-    const errors: Error[] = [];
-    if (ctxt.retriesAllowed) {
-      let numAttempts = 0;
-      let intervalSeconds: number = ctxt.intervalSeconds;
-      if (intervalSeconds > maxRetryIntervalSec) {
-        this.logger.warn(
-          `Step config interval exceeds maximum allowed interval, capped to ${maxRetryIntervalSec} seconds!`,
+      const ctxt: StepContextImpl = new StepContextImpl(wfCtx, funcID, span, this.logger, commInfo.config, stepFn.name);
+
+      await this.userDatabase.transaction(
+        async (client: UserDatabaseClient) => {
+          await this.flushResultBuffer(client, wfCtx.resultBuffer, wfCtx.workflowUUID);
+        },
+        { isolationLevel: IsolationLevel.ReadCommitted },
+      );
+      wfCtx.resultBuffer.clear();
+
+      // Check if this execution previously happened, returning its original result if it did.
+      const check: R | DBOSNull = await this.systemDatabase.checkOperationOutput<R>(
+        wfCtx.workflowUUID,
+        ctxt.functionID,
+      );
+      if (check !== dbosNull) {
+        ctxt.span.setAttribute('cached', true);
+        ctxt.span.setStatus({ code: SpanStatusCode.OK });
+        this.tracer.endSpan(ctxt.span);
+        return check as R;
+      }
+
+      if (this.debugMode) {
+        throw new DBOSDebuggerError(
+          `Failed to find the recorded output for the step: workflow UUID: ${wfCtx.workflowUUID}, step number: ${funcID}`,
         );
       }
-      while (result === dbosNull && numAttempts++ < ctxt.maxAttempts) {
-        try {
-          if (this.workflowCancellationMap.get(wfCtx.workflowUUID) === true) {
-            throw new DBOSWorkflowCancelledError(wfCtx.workflowUUID);
-          }
 
+      // Execute the step function.  If it throws an exception, retry with exponential backoff.
+      // After reaching the maximum number of retries, throw an DBOSError.
+      let result: R | DBOSNull = dbosNull;
+      let err: Error | DBOSNull = dbosNull;
+      const errors: Error[] = [];
+      if (ctxt.retriesAllowed) {
+        let numAttempts = 0;
+        let intervalSeconds: number = ctxt.intervalSeconds;
+        if (intervalSeconds > maxRetryIntervalSec) {
+          this.logger.warn(
+            `Step config interval exceeds maximum allowed interval, capped to ${maxRetryIntervalSec} seconds!`,
+          );
+        }
+        while (result === dbosNull && numAttempts++ < ctxt.maxAttempts) {
+          try {
+            if (this.workflowCancellationMap.get(wfCtx.workflowUUID) === true) {
+              throw new DBOSWorkflowCancelledError(wfCtx.workflowUUID);
+            }
+
+            let cresult: R | undefined;
+            if (commInfo.registration.passContext) {
+              await runWithStepContext(ctxt, async () => {
+                cresult = await stepFn.call(clsInst, ctxt, ...args);
+              });
+            } else {
+              await runWithStepContext(ctxt, async () => {
+                const sf = stepFn as unknown as (...args: T) => Promise<R>;
+                cresult = await sf.call(clsInst, ...args);
+              });
+            }
+            result = cresult!;
+          } catch (error) {
+            const e = error as Error;
+            errors.push(e);
+            this.logger.warn(
+              `Error in step being automatically retried. Attempt ${numAttempts} of ${ctxt.maxAttempts}. ${e.stack}`,
+            );
+            span.addEvent(
+              `Step attempt ${numAttempts + 1} failed`,
+              { retryIntervalSeconds: intervalSeconds, error: (error as Error).message },
+              performance.now(),
+            );
+            if (numAttempts < ctxt.maxAttempts) {
+              // Sleep for an interval, then increase the interval by backoffRate.
+              // Cap at the maximum allowed retry interval.
+              await sleepms(intervalSeconds * 1000);
+              intervalSeconds *= ctxt.backoffRate;
+              intervalSeconds = intervalSeconds < maxRetryIntervalSec ? intervalSeconds : maxRetryIntervalSec;
+            }
+          }
+        }
+      } else {
+        try {
           let cresult: R | undefined;
           if (commInfo.registration.passContext) {
             await runWithStepContext(ctxt, async () => {
@@ -1690,58 +1747,27 @@ export class DBOSExecutor implements DBOSExecutorContext {
           }
           result = cresult!;
         } catch (error) {
-          const e = error as Error;
-          errors.push(e);
-          this.logger.warn(
-            `Error in step being automatically retried. Attempt ${numAttempts} of ${ctxt.maxAttempts}. ${e.stack}`,
-          );
-          span.addEvent(
-            `Step attempt ${numAttempts + 1} failed`,
-            { retryIntervalSeconds: intervalSeconds, error: (error as Error).message },
-            performance.now(),
-          );
-          if (numAttempts < ctxt.maxAttempts) {
-            // Sleep for an interval, then increase the interval by backoffRate.
-            // Cap at the maximum allowed retry interval.
-            await sleepms(intervalSeconds * 1000);
-            intervalSeconds *= ctxt.backoffRate;
-            intervalSeconds = intervalSeconds < maxRetryIntervalSec ? intervalSeconds : maxRetryIntervalSec;
-          }
+          err = error as Error;
         }
       }
-    } else {
-      try {
-        let cresult: R | undefined;
-        if (commInfo.registration.passContext) {
-          await runWithStepContext(ctxt, async () => {
-            cresult = await stepFn.call(clsInst, ctxt, ...args);
-          });
-        } else {
-          await runWithStepContext(ctxt, async () => {
-            const sf = stepFn as unknown as (...args: T) => Promise<R>;
-            cresult = await sf.call(clsInst, ...args);
-          });
-        }
-        result = cresult!;
-      } catch (error) {
-        err = error as Error;
-      }
-    }
 
-    // `result` can only be dbosNull when the step timed out
-    if (result === dbosNull) {
-      // Record the error, then throw it.
-      err = err === dbosNull ? new DBOSMaxStepRetriesError(stepFn.name, ctxt.maxAttempts, errors) : err;
-      await this.systemDatabase.recordOperationError(wfCtx.workflowUUID, ctxt.functionID, err as Error);
-      ctxt.span.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
-      this.tracer.endSpan(ctxt.span);
-      throw err as Error;
-    } else {
-      // Record the execution and return.
-      await this.systemDatabase.recordOperationOutput<R>(wfCtx.workflowUUID, ctxt.functionID, result as R);
-      ctxt.span.setStatus({ code: SpanStatusCode.OK });
-      this.tracer.endSpan(ctxt.span);
-      return result as R;
+      // `result` can only be dbosNull when the step timed out
+      if (result === dbosNull) {
+        // Record the error, then throw it.
+        err = err === dbosNull ? new DBOSMaxStepRetriesError(stepFn.name, ctxt.maxAttempts, errors) : err;
+        await this.systemDatabase.recordOperationError(wfCtx.workflowUUID, ctxt.functionID, err as Error);
+        ctxt.span.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
+        this.tracer.endSpan(ctxt.span);
+        throw err as Error;
+      } else {
+        // Record the execution and return.
+        await this.systemDatabase.recordOperationOutput<R>(wfCtx.workflowUUID, ctxt.functionID, result as R);
+        ctxt.span.setStatus({ code: SpanStatusCode.OK });
+        this.tracer.endSpan(ctxt.span);
+        return result as R;
+      }
+    } finally {
+      wfCtx.endWorkflowFunction();
     }
   }
 

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -576,7 +576,8 @@ export class DBOS {
 
       const wfctx = assertCurrentWorkflowContext();
 
-      const funcId = wfctx.functionIDGetIncrement();
+      const funcId = wfctx.getFuncIDForChildWorkflow();
+
       wfId = wfId || wfctx.workflowUUID + '-' + funcId;
       const wfParams: WorkflowParams = {
         workflowUUID: wfId,
@@ -866,7 +867,7 @@ export class DBOS {
 
           const wfctx = assertCurrentWorkflowContext();
 
-          const funcId = wfctx.functionIDGetIncrement();
+          const funcId = wfctx.getFuncIDForChildWorkflow();
           wfId = wfId || wfctx.workflowUUID + '-' + funcId;
           const params: WorkflowParams = {
             workflowUUID: wfId,

--- a/src/error.ts
+++ b/src/error.ts
@@ -251,3 +251,11 @@ export class DBOSConflictingRegistrationError extends DBOSError {
     super(msg, ConflictingRegistrationError);
   }
 }
+
+const OperationInProgressError = 25;
+export class DBOSOperationInProgressError extends DBOSError {
+  constructor(name: string) {
+    const msg = `Workflow ${name} completed with operations still in progress.  (Is an 'await' missing?)`;
+    super(msg, OperationInProgressError);
+  }
+}

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -416,7 +416,9 @@ export class PostgresSystemDatabase implements SystemDatabase {
         sqlStmt +=
           ' ON CONFLICT (workflow_uuid) DO UPDATE SET status=EXCLUDED.status, output=EXCLUDED.output, updated_at=EXCLUDED.updated_at;';
 
-        await this.pool.query(sqlStmt, values);
+        if (values.length > 0) {
+          await this.pool.query(sqlStmt, values);
+        }
 
         // Clean up after each batch succeeds
         batchUUIDs.forEach((value) => {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -9,7 +9,6 @@ import { ConfiguredInstance, getRegisteredOperations } from './decorators';
 import { StoredProcedure, StoredProcedureContext } from './procedure';
 import { InvokeFuncsInst } from './httpServer/handler';
 import { WorkflowQueue } from './wfqueue';
-import { DBOSOperationInProgressError } from './error';
 
 export type Workflow<T extends unknown[], R> = (ctxt: WorkflowContext, ...args: T) => Promise<R>;
 export type WorkflowFunction<T extends unknown[], R> = Workflow<T, R>;


### PR DESCRIPTION
So the other week someone forgot to await a promise and it caused a system database error.

This should fix the system database error.  And detect some of the cases where promises are dropped, based on runtime behavior.  (It's not going to get them all, whereas a linter would.  So, part of the exercise is to determine if the added code is worth it... we don't have to commit this.)

If you are reviewing, turn off whitespace sensitivity.  (Trust prettier on that).  Large blocks got indented into try/finally...