### PR TITLE
Only clear queue assignment if wf is still in the queue

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -1858,8 +1858,12 @@ export class DBOSExecutor implements DBOSExecutorContext {
         try {
           // If the workflow is member of a queue, re-enqueue it.
           if (pendingWorkflow.queueName) {
-            await this.systemDatabase.clearQueueAssignment(pendingWorkflow.workflowUUID);
-            handlerArray.push(this.retrieveWorkflow(pendingWorkflow.workflowUUID));
+            const cleared = await this.systemDatabase.clearQueueAssignment(pendingWorkflow.workflowUUID);
+            if (cleared) {
+              handlerArray.push(this.retrieveWorkflow(pendingWorkflow.workflowUUID));
+            } else {
+              handlerArray.push(await this.executeWorkflowUUID(pendingWorkflow.workflowUUID));
+            }
           } else {
             handlerArray.push(await this.executeWorkflowUUID(pendingWorkflow.workflowUUID));
           }


### PR DESCRIPTION
This fixes a race condition where 
1. A workflow might have been removed from the queue and its result still be in the results buffer
2. The recovery code finds this workflow still pending (because the results buffer has not been flushed), re-enqueue the task and skips it