### PR TITLE
Relax reflect-metadata requirement

### DIFF
--- a/src/data_validation.ts
+++ b/src/data_validation.ts
@@ -83,6 +83,9 @@ export function validateMethodArgs<Args extends unknown[]>(methReg: MethodRegist
       args[idx] = argValue;
     }
 
+    // Argument validation - below - if we have any info about it
+    if (!argDescriptor.dataType) return;
+
     // Maybe look into https://www.npmjs.com/package/validator
     //  We could support emails and other validations too with something like that...
     if (argDescriptor.dataType.dataType === 'text' || argDescriptor.dataType.dataType === 'varchar') {

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -50,7 +50,9 @@ export class DBOSDataType {
 
   /** Take type from reflect metadata */
   // eslint-disable-next-line @typescript-eslint/ban-types
-  static fromArg(arg: Function) {
+  static fromArg(arg?: Function): DBOSDataType | undefined {
+    if (!arg) return undefined;
+
     const dt = new DBOSDataType();
 
     if (arg === String) {
@@ -83,8 +85,6 @@ export class DBOSDataType {
     return rv;
   }
 }
-
-const paramMetadataKey = Symbol.for('dbos:parameter');
 
 /* Arguments parsing heuristic:
  * - Convert the function to a string
@@ -120,12 +120,12 @@ export class MethodParameter {
   logMask: LogMasks = LogMasks.NONE;
 
   // eslint-disable-next-line @typescript-eslint/ban-types
-  argType: Function = String;
-  dataType: DBOSDataType;
+  argType?: Function = undefined; // This comes from reflect-metadata, if we have it
+  dataType?: DBOSDataType;
   index: number = -1;
 
   // eslint-disable-next-line @typescript-eslint/ban-types
-  constructor(idx: number, at: Function) {
+  constructor(idx: number, at?: Function) {
     this.index = idx;
     this.argType = at;
     this.dataType = DBOSDataType.fromArg(at);
@@ -328,20 +328,31 @@ export function getConfiguredInstance(clsname: string, cfgname: string): Configu
 // initialization time.
 ////////////////////////////////////////////////////////////////////////////////
 
+const methodArgsByFunction: Map<string, MethodParameter[]> = new Map();
+
 export function getOrCreateMethodArgsRegistration(target: object, propertyKey: string | symbol): MethodParameter[] {
   let regtarget = target;
   if (typeof regtarget !== 'function') {
     regtarget = regtarget.constructor;
   }
-  let mParameters: MethodParameter[] =
-    (Reflect.getOwnMetadata(paramMetadataKey, regtarget, propertyKey) as MethodParameter[]) || [];
 
-  if (!mParameters.length) {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  const mkey = (regtarget as Function).name + '|' + propertyKey.toString();
+
+  let mParameters: MethodParameter[] | undefined = methodArgsByFunction.get(mkey);
+  if (mParameters === undefined) {
     // eslint-disable-next-line @typescript-eslint/ban-types
-    const designParamTypes = Reflect.getMetadata('design:paramtypes', target, propertyKey) as Function[];
-    mParameters = designParamTypes.map((value, index) => new MethodParameter(index, value));
+    const designParamTypes = Reflect.getMetadata('design:paramtypes', target, propertyKey) as Function[] | undefined;
+    if (designParamTypes) {
+      mParameters = designParamTypes.map((value, index) => new MethodParameter(index, value));
+    } else {
+      const descriptor = Object.getOwnPropertyDescriptor(regtarget, propertyKey);
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      const argnames = getArgNames(descriptor?.value as Function);
+      mParameters = argnames.map((_value, index) => new MethodParameter(index));
+    }
 
-    Reflect.defineMetadata(paramMetadataKey, mParameters, regtarget, propertyKey);
+    methodArgsByFunction.set(mkey, mParameters);
   }
 
   return mParameters;
@@ -462,7 +473,7 @@ function getOrCreateMethodRegistration<This, Args extends unknown[], Return>(
         } else {
           if (methReg.args[idx].logMask !== LogMasks.NONE) {
             // For now this means hash
-            if (methReg.args[idx].dataType.dataType === 'json') {
+            if (methReg.args[idx].dataType?.dataType === 'json') {
               loggedArgValue = generateSaltedHash(JSON.stringify(argValue), 'JSONSALT');
             } else {
               // Yes, we are doing the same as above for now.
@@ -616,6 +627,7 @@ export function ArgDate() {
     const existingParameters = getOrCreateMethodArgsRegistration(target, propertyKey);
 
     const curParam = existingParameters[parameterIndex];
+    if (!curParam.dataType) curParam.dataType = new DBOSDataType();
     curParam.dataType.dataType = 'timestamp';
   };
 }

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -97,7 +97,9 @@ export class DBOSDataType {
 function getArgNames(func: Function): string[] {
   let fn = func.toString();
   fn = fn.replace(/\s/g, '');
+  fn = fn.replace(/\/\*[\s\S]*?\*\//g, '');
   fn = fn.substring(fn.indexOf('(') + 1, fn.indexOf(')'));
+  if (!fn.length) return [];
   return fn.split(',');
 }
 
@@ -346,7 +348,7 @@ export function getOrCreateMethodArgsRegistration(target: object, propertyKey: s
     if (designParamTypes) {
       mParameters = designParamTypes.map((value, index) => new MethodParameter(index, value));
     } else {
-      const descriptor = Object.getOwnPropertyDescriptor(regtarget, propertyKey);
+      const descriptor = Object.getOwnPropertyDescriptor(target, propertyKey);
       // eslint-disable-next-line @typescript-eslint/ban-types
       const argnames = getArgNames(descriptor?.value as Function);
       mParameters = argnames.map((_value, index) => new MethodParameter(index));

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -48,7 +48,7 @@ describe('dbos-logging', () => {
           return;
         }
         // NB not all types here may match the SQL string
-        let ctype = element.dataType.formatAsString();
+        let ctype = element.dataType!.formatAsString();
         if (element.logMask === LogMasks.HASH) {
           ctype = 'VARCHAR(64)';
         }


### PR DESCRIPTION
Phase 1 - relax reflect metadata requirement

Test pass.  With `emitDecoratorMetadata` turned off in tsconfig.json, the following tests fail (which is what we expect):

validation.test.ts - This test uses the metadata to do argument validation (in the rudimentary way we'd like to replace with something better in later phases of the project)
debug_typeorm.test.ts - TypeORM needs this setting
typeorm.test.ts - TypeORM needs this setting
