### PR TITLE
No duplicate executor id column

### DIFF
--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1270,7 +1270,6 @@ export class PostgresSystemDatabase implements SystemDatabase {
       .join(`${DBOSExecutor.systemDBSchemaName}.workflow_status as ws`, 'wq.workflow_uuid', 'ws.workflow_uuid')
       .orderBy('wq.created_at_epoch_ms', 'desc');
 
-    // Apply filters
     if (input.queueName) {
       query = query.where('wq.queue_name', input.queueName);
     }
@@ -1284,7 +1283,6 @@ export class PostgresSystemDatabase implements SystemDatabase {
       query = query.limit(input.limit);
     }
 
-    // Select specific columns with aliases that match the workflow_queue interface
     const rows = await query
       .select({
         workflow_uuid: 'wq.workflow_uuid',
@@ -1296,7 +1294,6 @@ export class PostgresSystemDatabase implements SystemDatabase {
       })
       .then((rows) => rows as workflow_queue[]);
 
-    // Map the results to the output format
     const workflows = rows.map((row) => {
       return {
         workflowID: row.workflow_uuid,

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1436,7 +1436,8 @@ export class PostgresSystemDatabase implements SystemDatabase {
 
         // Lookup tasks
         let query = trx<workflow_queue>(`${DBOSExecutor.systemDBSchemaName}.workflow_queue`)
-          .whereNull('completed_at_epoch_ms') // not started
+          .whereNull('completed_at_epoch_ms') // not completed
+          .whereNull('started_at_epoch_ms') // not started
           .andWhere('queue_name', queue.name)
           .orderBy('created_at_epoch_ms', 'asc')
           .forUpdate()

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1304,7 +1304,6 @@ export class PostgresSystemDatabase implements SystemDatabase {
         completedAt: row.completed_at_epoch_ms,
       };
     });
-
     return { workflows };
   }
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -45,11 +45,23 @@ export async function setUpDBOSTestDb(config: DBOSConfig) {
     password: config.poolConfig.password,
     database: 'postgres',
   });
-  await pgSystemClient.connect();
-  await pgSystemClient.query(`DROP DATABASE IF EXISTS ${config.poolConfig.database};`);
-  await pgSystemClient.query(`CREATE DATABASE ${config.poolConfig.database};`);
-  await pgSystemClient.query(`DROP DATABASE IF EXISTS ${config.system_database};`);
-  await pgSystemClient.end();
+  try {
+    await pgSystemClient.connect();
+    await pgSystemClient.query(`DROP DATABASE IF EXISTS ${config.poolConfig.database};`);
+    await pgSystemClient.query(`CREATE DATABASE ${config.poolConfig.database};`);
+    await pgSystemClient.query(`DROP DATABASE IF EXISTS ${config.system_database};`);
+    await pgSystemClient.end();
+  } catch (e) {
+    if (e instanceof AggregateError) {
+      console.error(`Test database setup failed: AggregateError containing ${e.errors.length} errors:`);
+      e.errors.forEach((err, index) => {
+        console.error(`  Error ${index + 1}:`, err);
+      });
+    } else {
+      console.error(`Test database setup failed:`, e);
+    }
+    throw e;
+  }
 }
 
 /* Common test types */

--- a/tests/scheduler/scheduler_contextfree.test.ts
+++ b/tests/scheduler/scheduler_contextfree.test.ts
@@ -64,7 +64,7 @@ class DBOSSchedTestClass {
   @DBOS.workflow()
   static async scheduledDefault(schedTime: Date, startTime: Date) {
     await DBOSSchedTestClass.scheduledTxn();
-    if (schedTime.getTime() > startTime.getTime() + 0.002) {
+    if (schedTime.getTime() > startTime.getTime() + 2) {
       // Floating point, sleep, etc., is a little imprecise
       console.log(
         `Scheduled 'scheduledDefault' function running early: ${DBOS.workflowID}; at ${startTime.toISOString()} vs ${schedTime.toISOString()}`,

--- a/tests/scheduler/scheduler_contextfree.test.ts
+++ b/tests/scheduler/scheduler_contextfree.test.ts
@@ -66,7 +66,7 @@ class DBOSSchedTestClass {
     await DBOSSchedTestClass.scheduledTxn();
     if (schedTime.getTime() > startTime.getTime() + 0.002) {
       // Floating point, sleep, etc., is a little imprecise
-      DBOS.logger.warn(
+      console.log(
         `Scheduled 'scheduledDefault' function running early: ${DBOS.workflowID}; at ${startTime.toISOString()} vs ${schedTime.toISOString()}`,
       );
       DBOSSchedTestClass.nTooEarly++;

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -492,15 +492,21 @@ describe('queued-wf-tests-simple', () => {
 
     const workflows = await DBOS.getWorkflowQueue({ queueName: recoveryQueue.name });
     expect(workflows.workflows.length).toBe(3);
+
     expect(workflows.workflows[2].workflowID).toBe(wfid1);
-    expect(workflows.workflows[2].executorID).toBe('local');
-    expect((await wfh1.getStatus())?.status).toBe(StatusString.PENDING);
+    const wf1Status = await wfh1.getStatus();
+    expect(wf1Status?.status).toBe(StatusString.PENDING);
+    expect(wf1Status?.executorId).toBe('local');
+
     expect(workflows.workflows[1].workflowID).toBe(wfid2);
-    expect(workflows.workflows[1].executorID).toBe('local');
-    expect((await wfh2.getStatus())?.status).toBe(StatusString.PENDING);
+    const wf2Status = await wfh2.getStatus();
+    expect(wf2Status?.status).toBe(StatusString.PENDING);
+    expect(wf2Status?.executorId).toBe('local');
+
     expect(workflows.workflows[0].workflowID).toBe(wfid3);
-    expect(workflows.workflows[0].executorID).toBe(null);
-    expect((await wfh3.getStatus())?.status).toBe(StatusString.ENQUEUED);
+    const wf3Status = await wfh3.getStatus();
+    expect(wf3Status?.status).toBe(StatusString.ENQUEUED);
+    expect(wf3Status?.executorId).toBe('local');
 
     // Manually update the database to pretend wf3 is PENDING and comes from a different executor
     const systemDBClient = new Client({

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -492,21 +492,15 @@ describe('queued-wf-tests-simple', () => {
 
     const workflows = await DBOS.getWorkflowQueue({ queueName: recoveryQueue.name });
     expect(workflows.workflows.length).toBe(3);
-
     expect(workflows.workflows[2].workflowID).toBe(wfid1);
-    const wf1Status = await wfh1.getStatus();
-    expect(wf1Status?.status).toBe(StatusString.PENDING);
-    expect(wf1Status?.executorId).toBe('local');
-
+    expect(workflows.workflows[2].executorID).toBe('local');
+    expect((await wfh1.getStatus())?.status).toBe(StatusString.PENDING);
     expect(workflows.workflows[1].workflowID).toBe(wfid2);
-    const wf2Status = await wfh2.getStatus();
-    expect(wf2Status?.status).toBe(StatusString.PENDING);
-    expect(wf2Status?.executorId).toBe('local');
-
+    expect(workflows.workflows[1].executorID).toBe('local');
+    expect((await wfh2.getStatus())?.status).toBe(StatusString.PENDING);
     expect(workflows.workflows[0].workflowID).toBe(wfid3);
-    const wf3Status = await wfh3.getStatus();
-    expect(wf3Status?.status).toBe(StatusString.ENQUEUED);
-    expect(wf3Status?.executorId).toBe('local');
+    expect(workflows.workflows[0].executorID).toBe('local');
+    expect((await wfh3.getStatus())?.status).toBe(StatusString.ENQUEUED);
 
     // Manually update the database to pretend wf3 is PENDING and comes from a different executor
     const systemDBClient = new Client({


### PR DESCRIPTION
Only use the `dbos.workflow_status.executor_id` column to represent queue assignments.


Also properly catch and display errors during test DB setup. See the difference:

![Screenshot 2025-03-10 at 08 42 21](https://github.com/user-attachments/assets/0cb784c5-1b39-488d-8eef-ebf738bce0e2)


Also relax the timing test for scheduled workflows (allow 2ms vs 2microseconds)