### PR TITLE
handle chooseAppDBServer errors and return a 1 exit code if it threw

### DIFF
--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -180,7 +180,12 @@ export async function deployAppCode(
   const dbosConfig = YAML.parse(interpolatedConfig) as ConfigFile;
 
   if (appRegistered === undefined) {
-    userDBName = await chooseAppDBServer(logger, host, userCredentials, userDBName);
+    try {
+      userDBName = await chooseAppDBServer(logger, host, userCredentials, userDBName);
+    } catch (e) {
+      logger.error(`Failed to choose database instance: ${(e as Error).message}`);
+      return 1;
+    }
     if (userDBName === '') {
       return 1;
     }


### PR DESCRIPTION
When not handling explicitly errors thrown by inquirer, we don't have a chance to return a failure exit code. (GHA seems to force a 0.)

Without the fix:

<img width="1698" alt="Screenshot 2025-03-11 at 16 02 24" src="https://github.com/user-attachments/assets/ab598915-05e0-4d68-85c5-7228a56b6fef" />


With the fix

<img width="1704" alt="Screenshot 2025-03-11 at 16 03 09" src="https://github.com/user-attachments/assets/1e20a3a6-ad33-43e3-901e-16c3e216cdda" />

