### PR TITLE
cancellable sleepms

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,6 +16,31 @@ export const globalParams = {
 };
 export const sleepms = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+/*
+A cancellable sleep function that returns a promise and a callback
+The promis can be awaited for and will automatically resolve after the given time
+When cancel is called, not only it clears the timeout, but also resolves the promise
+So any waiters on the cancelable sleep will be resolved
+*/
+export const cancellableSleep = (ms: number) => {
+  let timeoutId: ReturnType<typeof setTimeout>;
+  let resolvePromise: () => void;
+
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+    timeoutId = setTimeout(resolve, ms);
+  });
+
+  const cancel = () => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      resolvePromise();
+    }
+  };
+
+  return { promise, cancel };
+};
+
 export type ValuesOf<T> = T[keyof T];
 
 // Adapated and translated from from: https://github.com/junosuarez/find-root


### PR DESCRIPTION
Fix a bug where timeout promises were never cancelled correctly after `recv()` or `getEvent()` completed.