### PR TITLE
Make configureInstance optional

### DIFF
--- a/packages/communicator-email-ses/README.md
+++ b/packages/communicator-email-ses/README.md
@@ -40,7 +40,7 @@ For more information about configuring AWS services, see [AWS Configuration](htt
 
 ## Selecting A Configuration
 
-An instance of `DBOS_SES` takes configuration information. This means that the configuration (or config file key name) must be provided when a class instance is created. One instance per configuration should be created wwhen the application code starts. For example:
+An instance of `DBOS_SES` takes configuration information. This means that the configuration (or config file key name) must be provided when a class instance is created. One instance per configuration should be created when the application code starts. For example:
 
 ```typescript
 import { DBOS } from '@dbos-inc/dbos-sdk';

--- a/packages/communicator-email-ses/README.md
+++ b/packages/communicator-email-ses/README.md
@@ -40,15 +40,15 @@ For more information about configuring AWS services, see [AWS Configuration](htt
 
 ## Selecting A Configuration
 
-`DBOS_SES` is a configured class. This means that the configuration (or config file key name) must be provided when a class instance is created. One instance per configuration should be created with `DBOS.configureInstance` when the application code starts. For example:
+An instance of `DBOS_SES` takes configuration information. This means that the configuration (or config file key name) must be provided when a class instance is created. One instance per configuration should be created wwhen the application code starts. For example:
 
 ```typescript
 import { DBOS } from '@dbos-inc/dbos-sdk';
 
 // This will use the dbos-config.yaml section named by `aws_ses_configuration` if it is specified, or `aws_config` if not
-const defaultSES = DBOS.configureInstance(DBOS_SES, 'default');
+const defaultSES = new DBOS_SES('default');
 // This will use the section named `aws_config_marketing`
-const marketingSES = DBOS.configureInstance(DBOS_SES, 'marketing', { awscfgname: 'aws_config_marketing' });
+const marketingSES = new DBOS_SES('marketing', { awscfgname: 'aws_config_marketing' });
 ```
 
 ## Sending Messages

--- a/packages/communicator-email-ses/ses.test.ts
+++ b/packages/communicator-email-ses/ses.test.ts
@@ -14,7 +14,7 @@ describe('ses-tests', () => {
       // This would normally be a global or static or something
       const [config, rtConfig] = parseConfigFile({ configfile: 'ses-test-dbos-config.yaml' });
       DBOS.setConfig(config, rtConfig);
-      sesCfg = DBOS.configureInstance(DBOS_SES, 'default', { awscfgname: 'aws_config' });
+      sesCfg = new DBOS_SES('default', { awscfgname: 'aws_config' });
     }
   });
 

--- a/packages/component-aws-s3/README.md
+++ b/packages/component-aws-s3/README.md
@@ -44,7 +44,7 @@ The application will need at least one s3 bucket. This can be placed in the `app
 `DBOS_S3` is a configured class. The AWS configuration (or config file key name) and bucket name must be provided when a class instance is created, for example:
 
 ```typescript
-const defaultS3 = configureInstance(DBOS_S3, 'myS3Bucket', {awscfgname: 'aws_config', bucket: 'my-s3-bucket', ...});
+const defaultS3 = new DBOS_S3 ('myS3Bucket', {awscfgname: 'aws_config', bucket: 'my-s3-bucket', ...});
 ```
 
 ## Simple Operation Wrappers

--- a/packages/component-aws-s3/README.md
+++ b/packages/component-aws-s3/README.md
@@ -44,7 +44,7 @@ The application will need at least one s3 bucket. This can be placed in the `app
 `DBOS_S3` is a configured class. The AWS configuration (or config file key name) and bucket name must be provided when a class instance is created, for example:
 
 ```typescript
-const defaultS3 = new DBOS_S3 ('myS3Bucket', {awscfgname: 'aws_config', bucket: 'my-s3-bucket', ...});
+const defaultS3 = new DBOS_S3('myS3Bucket', {awscfgname: 'aws_config', bucket: 'my-s3-bucket', ...});
 ```
 
 ## Simple Operation Wrappers

--- a/packages/component-aws-s3/src/s3_utils.test.ts
+++ b/packages/component-aws-s3/src/s3_utils.test.ts
@@ -133,7 +133,7 @@ describe('ses-tests', () => {
         'S3 Test is not configured.  To run, set AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and S3_BUCKET',
       );
     } else {
-      s3Cfg = DBOS.configureInstance(DBOS_S3, 'default', {
+      s3Cfg = new DBOS_S3('default', {
         awscfgname: 'aws_config',
         bucket: '',
         s3Callbacks: {

--- a/packages/dbos-confluent-kafka/README.md
+++ b/packages/dbos-confluent-kafka/README.md
@@ -40,7 +40,7 @@ const kafkaConfig: KafkaConfig = {
   logLevel: logLevel.INFO, // FOR TESTING
 };
 
-kafkaCfg = DBOS.configureInstance(KafkaProducer, 'defKafka', kafkaConfig, kafkaTopic);
+kafkaCfg = new KafkaProducer('defKafka', kafkaConfig, kafkaTopic);
 ```
 
 ### Sending

--- a/packages/dbos-confluent-kafka/confluent-kafka.test.ts
+++ b/packages/dbos-confluent-kafka/confluent-kafka.test.ts
@@ -113,8 +113,8 @@ describe('kafka-tests', () => {
     DBOS.setConfig(cfg, rtCfg);
 
     // This would normally be a global or static or something
-    wfKafkaCfg = DBOS.configureInstance(KafkaProducer, 'wfKafka', kafkaConfig, wf1Topic);
-    wf2KafkaCfg = DBOS.configureInstance(KafkaProducer, 'wf2Kafka', kafkaConfig, wf2Topic);
+    wfKafkaCfg = new KafkaProducer('wfKafka', kafkaConfig, wf1Topic);
+    wf2KafkaCfg = new KafkaProducer('wf2Kafka', kafkaConfig, wf2Topic);
     await DBOS.launch();
   }, 30000);
 

--- a/packages/dbos-kafkajs/README.md
+++ b/packages/dbos-kafkajs/README.md
@@ -40,7 +40,7 @@ const kafkaConfig: KafkaConfig = {
   logLevel: logLevel.NOTHING, // FOR TESTING
 };
 
-kafkaCfg = DBOS.configureInstance(KafkaProduceStep, 'defKafka', kafkaConfig, defTopic, {
+kafkaCfg = new KafkaProduceStep('defKafka', kafkaConfig, defTopic, {
   createPartitioner: Partitioners.DefaultPartitioner,
 });
 ```

--- a/packages/dbos-kafkajs/kafkajs.test.ts
+++ b/packages/dbos-kafkajs/kafkajs.test.ts
@@ -6,7 +6,6 @@ import {
   Workflow,
   WorkflowContext,
   WorkflowQueue,
-  configureInstance,
   createTestingRuntime,
 } from '@dbos-inc/dbos-sdk';
 
@@ -87,10 +86,10 @@ describe('kafka-tests', () => {
   beforeEach(async () => {
     if (kafkaIsAvailable) {
       // This would normally be a global or static or something
-      wfKafkaCfg = configureInstance(KafkaProduceStep, 'wfKafka', kafkaConfig, wfTopic, {
+      wfKafkaCfg = new KafkaProduceStep('wfKafka', kafkaConfig, wfTopic, {
         createPartitioner: Partitioners.DefaultPartitioner,
       });
-      txKafkaCfg = configureInstance(KafkaProduceStep, 'txKafka', kafkaConfig, txnTopic, {
+      txKafkaCfg = new KafkaProduceStep('txKafka', kafkaConfig, txnTopic, {
         createPartitioner: Partitioners.DefaultPartitioner,
       });
       testRuntime = await createTestingRuntime(undefined, 'kafkajs-test-dbos-config.yaml');

--- a/packages/dbos-sqs/README.md
+++ b/packages/dbos-sqs/README.md
@@ -44,7 +44,7 @@ import { DBOS_SQS } from '@dbos-inc/dbos-sqs';
 `DBOS_SQS` is a configured class. This means that the configuration (or config file key name) must be provided when a class instance is created, for example:
 
 ```typescript
-const sqsCfg = configureInstance(DBOS_SQS, 'default', { awscfgname: 'aws_config' });
+const sqsCfg = new DBOS_SQS('default', { awscfgname: 'aws_config' });
 ```
 
 ### Sending With Standard Queues

--- a/packages/dbos-sqs/sqs.test.ts
+++ b/packages/dbos-sqs/sqs.test.ts
@@ -34,7 +34,7 @@ describe('sqs-tests', () => {
       // This would normally be a global or static or something
       const [cfg, rtCfg] = parseConfigFile({ configfile: 'sqs-test-dbos-config.yaml' });
       DBOS.setConfig(cfg, rtCfg);
-      sqsCfg = DBOS.configureInstance(DBOS_SQS, 'default', {
+      sqsCfg = new DBOS_SQS('default', {
         awscfgname: 'aws_config',
         queueUrl: process.env['SQS_QUEUE_URL'],
       });

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1249,6 +1249,7 @@ export class DBOS {
   /////
   // Registration, etc
   /////
+  /** Calling this is no longer necessary */
   static configureInstance<R extends ConfiguredInstance, T extends unknown[]>(
     cls: new (name: string, ...args: T) => R,
     name: string,

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1249,7 +1249,10 @@ export class DBOS {
   /////
   // Registration, etc
   /////
-  /** Calling this is no longer necessary */
+  /**
+   * Construct and register an object.
+   * Calling this is not necessary; calling the constructor of any `ConfiguredInstance` subclass is sufficient
+   */
   static configureInstance<R extends ConfiguredInstance, T extends unknown[]>(
     cls: new (name: string, ...args: T) => R,
     name: string,

--- a/tests/configuredinstances.test.ts
+++ b/tests/configuredinstances.test.ts
@@ -130,8 +130,8 @@ class DBOSTestConfiguredClass extends ConfiguredInstance {
   }
 }
 
-const config1 = configureInstance(DBOSTestConfiguredClass, 'config1', 1);
-const configA = configureInstance(DBOSTestConfiguredClass, 'configA', 2);
+const config1 = new DBOSTestConfiguredClass('config1', 1); // The new way
+const configA = configureInstance(DBOSTestConfiguredClass, 'configA', 2); // The old way
 
 describe('dbos-configclass-tests', () => {
   let config: DBOSConfig;

--- a/tests/contextfreeinst.test.ts
+++ b/tests/contextfreeinst.test.ts
@@ -124,8 +124,8 @@ class TestSec2 extends ConfiguredInstance {
   }
 }
 
-const instA = configureInstance(TestFunctions, 'A');
-const instB = configureInstance(TestFunctions, 'B');
+const instA = new TestFunctions('A'); // New way
+const instB = configureInstance(TestFunctions, 'B'); // Old way
 
 async function main() {
   // First hurdle - configuration.
@@ -281,7 +281,7 @@ async function main6() {
 
 async function main7() {
   const testSecInst = DBOS.configureInstance(TestSec, 'Sec1');
-  const testSec2Inst = DBOS.configureInstance(TestSec2, 'Sec2');
+  const testSec2Inst = new TestSec2('Sec2');
 
   const config = generateDBOSTestConfig();
   await setUpDBOSTestDb(config);

--- a/tests/recovery_configuredinst.test.ts
+++ b/tests/recovery_configuredinst.test.ts
@@ -51,8 +51,8 @@ class CCRecovery extends ConfiguredInstance {
   }
 }
 
-const configA = configureInstance(CCRecovery, 'configA', new CCRConfig());
-const configB = configureInstance(CCRecovery, 'configB', new CCRConfig());
+const configA = configureInstance(CCRecovery, 'configA', new CCRConfig()); // Old way
+const configB = new CCRecovery('configB', new CCRConfig()); // New way
 
 describe('recovery-cc-tests', () => {
   let config: DBOSConfig;

--- a/tests/testing/debugger_configuredinst.test.ts
+++ b/tests/testing/debugger_configuredinst.test.ts
@@ -2,7 +2,6 @@ import {
   Step,
   StepContext,
   ConfiguredInstance,
-  configureInstance,
   InitContext,
   Transaction,
   TransactionContext,
@@ -57,7 +56,7 @@ class DebuggerCCTest extends ConfiguredInstance {
   }
 }
 
-const configR = configureInstance(DebuggerCCTest, 'configA');
+const configR = new DebuggerCCTest('configA');
 
 describe('debugger-test', () => {
   let config: DBOSConfig;

--- a/tests/v2v1apimix.test.ts
+++ b/tests/v2v1apimix.test.ts
@@ -1,4 +1,4 @@
-import { ConfiguredInstance, configureInstance, DBOS, StepContext, TransactionContext, WorkflowContext } from '../src';
+import { ConfiguredInstance, DBOS, StepContext, TransactionContext, WorkflowContext } from '../src';
 import { Step, Transaction, Workflow } from '../src';
 import { PoolClient } from 'pg';
 import { generateDBOSTestConfig, setUpDBOSTestDb } from './helpers';
@@ -227,7 +227,7 @@ class ChildWorkflowsV1 {
   }
 }
 
-const inst = configureInstance(TestFunctionsInst, 'i');
+const inst = new TestFunctionsInst('i');
 
 async function mainInst() {
   const config = generateDBOSTestConfig();

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -377,7 +377,7 @@ describe('queued-wf-tests-simple', () => {
     await expect(handle2.getResult()).resolves.toBe('abc');
 
     // Call the same function in a different configured class is not allowed.
-    const myObj = DBOS.configureInstance(TestDuplicateIDins, 'myname');
+    const myObj = new TestDuplicateIDins('myname');
     await expect(DBOS.startWorkflow(myObj, { workflowID: wfid }).testWorkflow('abc')).rejects.toThrow(
       DBOSConflictingWorkflowError,
     );


### PR DESCRIPTION
Constructor works fine, world gets simpler.

Old code, and mixing with `configureInstance` is still fine, as configureInstance simply calls the constructor.