### PR TITLE
Support sort order, offset, and workflow IDs in listWorkflows

### DIFF
--- a/src/dbos-runtime/workflow_management.ts
+++ b/src/dbos-runtime/workflow_management.ts
@@ -6,7 +6,11 @@ import { GetQueuedWorkflowsInput, WorkflowStatus } from '../workflow';
 import { HTTPRequest } from '../context';
 import axios from 'axios';
 
-export async function listWorkflows(config: DBOSConfig, input: GetWorkflowsInput, getRequest: boolean) {
+export async function listWorkflows(
+  config: DBOSConfig,
+  input: GetWorkflowsInput,
+  getRequest: boolean,
+): Promise<WorkflowInformation[]> {
   const systemDatabase = new PostgresSystemDatabase(
     config.poolConfig,
     config.system_database,
@@ -20,7 +24,11 @@ export async function listWorkflows(config: DBOSConfig, input: GetWorkflowsInput
   return workflowInfos;
 }
 
-export async function listQueuedWorkflows(config: DBOSConfig, input: GetQueuedWorkflowsInput, getRequest: boolean) {
+export async function listQueuedWorkflows(
+  config: DBOSConfig,
+  input: GetQueuedWorkflowsInput,
+  getRequest: boolean,
+): Promise<WorkflowInformation[]> {
   const systemDatabase = new PostgresSystemDatabase(
     config.poolConfig,
     config.system_database,
@@ -42,11 +50,15 @@ export type WorkflowInformation = Omit<WorkflowStatus, 'request'> & {
   request?: HTTPRequest;
 };
 
-async function getWorkflowInfo(systemDatabase: SystemDatabase, workflowUUID: string, getRequest: boolean) {
+async function getWorkflowInfo(
+  systemDatabase: SystemDatabase,
+  workflowUUID: string,
+  getRequest: boolean,
+): Promise<WorkflowInformation> {
   const info = (await systemDatabase.getWorkflowStatus(workflowUUID)) as WorkflowInformation;
   info.workflowUUID = workflowUUID;
   if (info === null) {
-    return {};
+    return Promise.resolve({} as WorkflowInformation);
   }
   const input = await systemDatabase.getWorkflowInputs(workflowUUID);
   if (input !== null) {

--- a/src/dbos-runtime/workflow_management.ts
+++ b/src/dbos-runtime/workflow_management.ts
@@ -12,7 +12,7 @@ export async function listWorkflows(config: DBOSConfig, input: GetWorkflowsInput
     config.system_database,
     createLogger() as unknown as GlobalLogger,
   );
-  const workflowUUIDs = (await systemDatabase.getWorkflows(input)).workflowUUIDs.reverse(); // Reverse so most recent entries are printed last
+  const workflowUUIDs = (await systemDatabase.getWorkflows(input)).workflowUUIDs;
   const workflowInfos = await Promise.all(
     workflowUUIDs.map(async (i) => await getWorkflowInfo(systemDatabase, i, getRequest)),
   );
@@ -26,7 +26,7 @@ export async function listQueuedWorkflows(config: DBOSConfig, input: GetQueuedWo
     config.system_database,
     createLogger() as unknown as GlobalLogger,
   );
-  const workflowUUIDs = (await systemDatabase.getQueuedWorkflows(input)).workflowUUIDs.reverse(); // Reverse so most recent entries are printed last
+  const workflowUUIDs = (await systemDatabase.getQueuedWorkflows(input)).workflowUUIDs;
   const workflowInfos = await Promise.all(
     workflowUUIDs.map(async (i) => await getWorkflowInfo(systemDatabase, i, getRequest)),
   );

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -67,6 +67,7 @@ export interface WorkflowStatus {
 }
 
 export interface GetWorkflowsInput {
+  workflowIDs?: string[]; // The workflow IDs to retrieve
   workflowName?: string; // The name of the workflow function
   authenticatedUser?: string; // The user who ran the workflow.
   startTime?: string; // Timestamp in ISO 8601 format
@@ -74,6 +75,8 @@ export interface GetWorkflowsInput {
   status?: 'PENDING' | 'SUCCESS' | 'ERROR' | 'RETRIES_EXCEEDED' | 'CANCELLED' | 'ENQUEUED'; // The status of the workflow.
   applicationVersion?: string; // The application version that ran this workflow.
   limit?: number; // Return up to this many workflows IDs. IDs are ordered by workflow creation time.
+  offset?: number; // Skip this many workflows IDs. IDs are ordered by workflow creation time.
+  sortDesc?: boolean; // Sort the workflows in descending order by creation time (default ascending order).
 }
 
 export interface GetQueuedWorkflowsInput {
@@ -83,6 +86,8 @@ export interface GetQueuedWorkflowsInput {
   status?: 'PENDING' | 'SUCCESS' | 'ERROR' | 'RETRIES_EXCEEDED' | 'CANCELLED' | 'ENQUEUED'; // The status of the workflow.
   limit?: number; // Return up to this many workflows IDs. IDs are ordered by workflow creation time.
   queueName?: string; // The queue
+  offset?: number; // Skip this many workflows IDs. IDs are ordered by workflow creation time.
+  sortDesc?: boolean; // Sort the workflows in descending order by creation time (default ascending order).
 }
 
 export interface GetWorkflowsOutput {

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -191,7 +191,7 @@ describe('workflow-management-tests', () => {
     expect(response.statusCode).toBe(200);
     workflowUUIDs = JSON.parse(response.text) as GetWorkflowsOutput;
     expect(workflowUUIDs.workflowUUIDs.length).toBe(10);
-    expect(workflowUUIDs.workflowUUIDs).not.toContain(firstUUID);
+    expect(workflowUUIDs.workflowUUIDs[0]).toBe(firstUUID); // First workflow should be the same
   });
 
   test('getworkflows-cli', async () => {

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -208,6 +208,28 @@ describe('workflow-management-tests', () => {
     for (let i = 0; i < 10; i++) {
       expect(workflowUUIDs.workflowUUIDs[i]).toBe(workflowIDs[10 - i]);
     }
+
+    // Test LIMIT 2 OFFSET 2 returns the third and fourth workflows
+    input.limit = 2;
+    input.offset = 2;
+    input.sortDesc = false;
+    response = await request(testRuntime.getHandlersCallback()).post('/getWorkflows').send({ input });
+    expect(response.statusCode).toBe(200);
+    workflowUUIDs = JSON.parse(response.text) as GetWorkflowsOutput;
+    expect(workflowUUIDs.workflowUUIDs.length).toBe(2);
+    for (let i = 0; i < workflowUUIDs.workflowUUIDs.length; i++) {
+      expect(workflowUUIDs.workflowUUIDs[i]).toBe(workflowIDs[i + 2]);
+    }
+
+    // Test OFFSET 10 returns the last workflow
+    input.offset = 10;
+    response = await request(testRuntime.getHandlersCallback()).post('/getWorkflows').send({ input });
+    expect(response.statusCode).toBe(200);
+    workflowUUIDs = JSON.parse(response.text) as GetWorkflowsOutput;
+    expect(workflowUUIDs.workflowUUIDs.length).toBe(1);
+    for (let i = 0; i < workflowUUIDs.workflowUUIDs.length; i++) {
+      expect(workflowUUIDs.workflowUUIDs[i]).toBe(workflowIDs[i + 10]);
+    }
   });
 
   test('getworkflows-cli', async () => {

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -257,7 +257,7 @@ describe('workflow-management-tests', () => {
     const input: GetWorkflowsInput = {};
     const infos = await listWorkflows(config, input, false);
     expect(infos.length).toBe(2);
-    let info = infos[0] as WorkflowInformation;
+    let info = infos[0];
     expect(info.authenticatedUser).toBe('alice');
     expect(info.workflowName).toBe('testWorkflow');
     expect(info.status).toBe(StatusString.SUCCESS);
@@ -268,7 +268,7 @@ describe('workflow-management-tests', () => {
     expect(info.output).toBe('alice');
     expect(info.input).toEqual(['alice']);
 
-    info = infos[1] as WorkflowInformation;
+    info = infos[1];
     expect(info.authenticatedUser).toBe('alice');
     expect(info.workflowName).toBe('failWorkflow');
     expect(info.status).toBe(StatusString.ERROR);
@@ -280,7 +280,7 @@ describe('workflow-management-tests', () => {
     expect(info.output).toBeUndefined();
     expect(info.input).toEqual(['alice']);
 
-    const getInfo = (await getWorkflow(config, info.workflowUUID, false)) as WorkflowInformation;
+    const getInfo = await getWorkflow(config, info.workflowUUID, false);
     expect(info).toEqual(getInfo);
   });
 


### PR DESCRIPTION
Make sure TS accepts the same set of limiters as Python.

For listWorkflows, added:
- workflowIDs
- offset
- sortDesc

For listQueuedWorkflows, added:
- offset
- sortDesc

Also updated tests to thoroughly test those new limiters.

Next step: make sure the workflow information output matches the ones in Python.