### PR TITLE
Remove TestingRuntime from debugger tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         env:
-          KAFKA_CFG_PROCESS_ROLES: broker
+          KAFKA_CFG_PROCESS_ROLES: broker,controller
           KAFKA_CFG_NODE_ID: 1
           KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
           ALLOW_PLAINTEXT_LISTENER: yes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,8 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         env:
+          KAFKA_CFG_PROCESS_ROLES: broker
+          KAFKA_CFG_NODE_ID: 1
           KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
           ALLOW_PLAINTEXT_LISTENER: yes
           KAFKA_CFG_LISTENERS: PLAINTEXT://:9092

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           --health-retries 5
       # Kafka service container
       kafka:
-        image: bitnami/kafka
+        image: bitnami/kafka:3.9.0
         ports:
           - 9092:9092
         options: >-
@@ -50,8 +50,6 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         env:
-          KAFKA_CFG_PROCESS_ROLES: broker,controller
-          KAFKA_CFG_NODE_ID: 1
           KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
           ALLOW_PLAINTEXT_LISTENER: yes
           KAFKA_CFG_LISTENERS: PLAINTEXT://:9092

--- a/packages/dbos-kafkajs/kafkajs.test.ts
+++ b/packages/dbos-kafkajs/kafkajs.test.ts
@@ -6,7 +6,7 @@ import {
   Workflow,
   WorkflowContext,
   WorkflowQueue,
-  createTestingRuntime,
+  createTestingRuntime, // This test intentionally tests v1 and v2
   parseConfigFile,
 } from '@dbos-inc/dbos-sdk';
 

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -87,6 +87,7 @@ export interface DBOSLaunchOptions {
   // For DBOS Conductor
   conductorURL?: string;
   conductorKey?: string;
+  debugMode?: DebugMode;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -257,7 +258,10 @@ export class DBOS {
       DBOS.runtimeConfig = runtimeConfig;
     }
 
-    DBOSExecutor.globalInstance = new DBOSExecutor(DBOS.dbosConfig, { debugMode });
+    DBOSExecutor.globalInstance = new DBOSExecutor(DBOS.dbosConfig, {
+      debugMode: options?.debugMode ?? debugMode,
+    });
+
     const executor: DBOSExecutor = DBOSExecutor.globalInstance;
     DBOS.globalLogger = executor.logger;
     await executor.init();

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -200,7 +200,7 @@ export class DBOS {
   static appServer: Server | undefined = undefined;
   static conductor: Conductor | undefined = undefined;
 
-  static getDebugMode(): DebugMode {
+  private static getDebugModeFromEnv(): DebugMode {
     const debugWorkflowId = process.env.DBOS_DEBUG_WORKFLOW_ID;
     const isDebugging = debugWorkflowId !== undefined;
     return isDebugging
@@ -218,7 +218,7 @@ export class DBOS {
 
   private static translateConfig() {
     if (DBOS.dbosConfig && !isDeprecatedDBOSConfig(DBOS.dbosConfig)) {
-      const isDebugging = DBOS.getDebugMode() !== DebugMode.DISABLED;
+      const isDebugging = DBOS.getDebugModeFromEnv() !== DebugMode.DISABLED;
       [DBOS.dbosConfig, DBOS.runtimeConfig] = translatePublicDBOSconfig(DBOS.dbosConfig, isDebugging);
       if (process.env.DBOS__CLOUD === 'true') {
         [DBOS.dbosConfig, DBOS.runtimeConfig] = overwrite_config(DBOS.dbosConfig, DBOS.runtimeConfig);
@@ -237,7 +237,7 @@ export class DBOS {
     if (!DBOS.dbosConfig) {
       DBOS.dbosConfig = parseConfigFile()[0];
     }
-    this.translateConfig();
+    DBOS.translateConfig();
     return PostgresSystemDatabase.dropSystemDB(DBOS.dbosConfig);
   }
 
@@ -260,7 +260,7 @@ export class DBOS {
     // Do nothing is DBOS is already initialized
     if (DBOSExecutor.globalInstance) return;
 
-    const debugMode = this.getDebugMode();
+    const debugMode = options?.debugMode ?? DBOS.getDebugModeFromEnv();
     const isDebugging = debugMode !== DebugMode.DISABLED;
 
     if (options?.conductorKey) {
@@ -288,7 +288,7 @@ export class DBOS {
     }
 
     DBOSExecutor.globalInstance = new DBOSExecutor(DBOS.dbosConfig, {
-      debugMode: options?.debugMode ?? debugMode,
+      debugMode,
     });
 
     const executor: DBOSExecutor = DBOSExecutor.globalInstance;
@@ -324,7 +324,7 @@ export class DBOS {
       await DBOSHttpServer.checkPortAvailabilityIPv4Ipv6(DBOS.runtimeConfig.admin_port, logger as GlobalLogger);
 
       DBOS.adminServer = adminApp.listen(DBOS.runtimeConfig.admin_port, () => {
-        this.logger.info(`DBOS Admin Server is running at http://localhost:${DBOS.runtimeConfig?.admin_port}`);
+        DBOS.logger.info(`DBOS Admin Server is running at http://localhost:${DBOS.runtimeConfig?.admin_port}`);
       });
     }
 
@@ -431,7 +431,7 @@ export class DBOS {
   }
 
   static async launchAppHTTPServer() {
-    const server = this.setUpHandlerCallback();
+    const server = DBOS.setUpHandlerCallback();
     if (DBOS.runtimeConfig) {
       // This will not listen if there's no decorated endpoint
       DBOS.appServer = await server.appListen(DBOS.runtimeConfig.port);
@@ -649,10 +649,10 @@ export class DBOS {
     await sleepms(durationMS);
   }
   static async sleepSeconds(durationSec: number): Promise<void> {
-    return this.sleepms(durationSec * 1000);
+    return DBOS.sleepms(durationSec * 1000);
   }
   static async sleep(durationMS: number): Promise<void> {
-    return this.sleepms(durationMS);
+    return DBOS.sleepms(durationMS);
   }
 
   static async withNextWorkflowID<R>(wfid: string, callback: () => Promise<R>): Promise<R> {

--- a/tests/proc-test/src/operations.test.ts
+++ b/tests/proc-test/src/operations.test.ts
@@ -1,13 +1,13 @@
-import { DBOS, TestingRuntime, parseConfigFile } from '@dbos-inc/dbos-sdk';
+import { DBOS, parseConfigFile } from '@dbos-inc/dbos-sdk';
 import { StoredProcTest } from './operations';
 import { v1 as uuidv1 } from 'uuid';
 
 import { workflow_status } from '@dbos-inc/dbos-sdk/schemas/system_db_schema';
 import { transaction_outputs } from '@dbos-inc/dbos-sdk/schemas/user_db_schema';
-import { TestingRuntimeImpl, createInternalTestRuntime } from '@dbos-inc/dbos-sdk/dist/src/testing/testing_runtime';
 import { DBOSConfig } from '@dbos-inc/dbos-sdk';
 import { Client, ClientConfig } from 'pg';
 import { runWithTopContext } from '../../../dist/src/context';
+import { DebugMode } from '../../../src/dbos-executor';
 
 async function runSql<T>(config: ClientConfig, func: (client: Client) => Promise<T>) {
   const client = new Client(config);
@@ -19,14 +19,14 @@ async function runSql<T>(config: ClientConfig, func: (client: Client) => Promise
   }
 }
 
-async function dropLocalProcs(testRuntime: TestingRuntime) {
+async function dropLocalProcs() {
   const localProcs = ['getGreetCountLocal', 'helloProcedureLocal', 'helloProcedure_v2_local'];
   const sqlDropLocalProcs = localProcs
     .map(
       (proc) => `DROP ROUTINE IF EXISTS "StoredProcTest_${proc}_p"; DROP ROUTINE IF EXISTS "StoredProcTest_${proc}_f";`,
     )
     .join('\n');
-  await testRuntime.queryUserDB(sqlDropLocalProcs);
+  await DBOS.queryUserDB(sqlDropLocalProcs);
 }
 
 describe('stored-proc-v2-test', () => {
@@ -34,11 +34,12 @@ describe('stored-proc-v2-test', () => {
 
   beforeAll(async () => {
     [config] = parseConfigFile();
-    const testRuntime = await createInternalTestRuntime([StoredProcTest], config);
+    DBOS.setConfig(config);
+    await DBOS.launch();
     try {
-      await dropLocalProcs(testRuntime);
+      await dropLocalProcs();
     } finally {
-      await testRuntime.destroy();
+      await DBOS.shutdown();
     }
   });
 
@@ -127,28 +128,30 @@ describe('stored-proc-v2-test', () => {
 
 describe('stored-proc-test', () => {
   let config: DBOSConfig;
-  let testRuntime: TestingRuntime;
 
   beforeAll(async () => {
     [config] = parseConfigFile();
-    testRuntime = await createInternalTestRuntime([StoredProcTest], config);
-    await dropLocalProcs(testRuntime);
+    DBOS.setConfig(config);
+    await DBOS.launch();
+    await dropLocalProcs();
   });
 
   afterAll(async () => {
-    await testRuntime?.destroy();
+    await DBOS.shutdown();
   });
 
   test('test-procReplay', async () => {
     const now = Date.now();
     const user = `procReplay-${now}`;
-    const res = await testRuntime.invoke(StoredProcTest).helloProcedure(user);
+    const res = await StoredProcTest.helloProcedure(user);
     expect(res).toMatch(`Hello, ${user}! You have been greeted 1 times.`);
 
     const wfUUID = `procReplay-wfid-${now}`;
-    expect(await testRuntime.invoke(StoredProcTest, wfUUID).getGreetCount(user)).toBe(1);
+    await DBOS.withNextWorkflowID(wfUUID, async () => {
+      expect(await StoredProcTest.getGreetCount(user)).toBe(1);
+    });
 
-    await testRuntime.retrieveWorkflow(wfUUID).getResult();
+    await DBOS.retrieveWorkflow(wfUUID).getResult();
 
     const statuses = await runSql({ ...config.poolConfig, database: config.system_database }, async (client) => {
       const { rows } = await client.query<workflow_status>(
@@ -163,11 +166,13 @@ describe('stored-proc-test', () => {
     expect(statuses[0].output).toBe(JSON.stringify(1));
     expectNullResult(statuses[0].error);
 
-    expect(await testRuntime.invoke(StoredProcTest, wfUUID).getGreetCount(user)).toBe(1);
+    await DBOS.withNextWorkflowID(wfUUID, async () => {
+      expect(await StoredProcTest.getGreetCount(user)).toBe(1);
+    });
 
-    const txRows = await testRuntime.queryUserDB<transaction_outputs>(
+    const txRows = await DBOS.queryUserDB<transaction_outputs>(
       'SELECT * FROM dbos.transaction_outputs WHERE workflow_uuid=$1',
-      wfUUID,
+      [wfUUID],
     );
     expect(txRows.length).toBe(1);
     expect(txRows[0].function_id).toBe(0);
@@ -178,66 +183,73 @@ describe('stored-proc-test', () => {
   test('test-procGreetingWorkflow', async () => {
     const wfUUID = uuidv1();
     const user = `procWF_${Date.now()}`;
-    const res = await testRuntime.invokeWorkflow(StoredProcTest, wfUUID).procGreetingWorkflow(user);
-    expect(res.count).toBe(0);
-    expect(res.greeting).toMatch(`Hello, ${user}! You have been greeted 1 times.`);
-    expect(res.rowCount).toBeGreaterThan(0);
+    await DBOS.withNextWorkflowID(wfUUID, async () => {
+      const res = await StoredProcTest.procGreetingWorkflow(user);
+      expect(res.count).toBe(0);
+      expect(res.greeting).toMatch(`Hello, ${user}! You have been greeted 1 times.`);
+      expect(res.rowCount).toBeGreaterThan(0);
 
-    const txRows = await testRuntime.queryUserDB<transaction_outputs>(
-      'SELECT * FROM dbos.transaction_outputs WHERE workflow_uuid=$1',
-      wfUUID,
-    );
-    expect(txRows.length).toBe(3);
-    expect(txRows[0].function_id).toBe(0);
-    expect(txRows[0].output).toBe('0');
-    expectNullResult(txRows[0].error);
+      const txRows = await DBOS.queryUserDB<transaction_outputs>(
+        'SELECT * FROM dbos.transaction_outputs WHERE workflow_uuid=$1',
+        [wfUUID],
+      );
+      expect(txRows.length).toBe(3);
+      expect(txRows[0].function_id).toBe(0);
+      expect(txRows[0].output).toBe('0');
+      expectNullResult(txRows[0].error);
 
-    expect(txRows[1].function_id).toBe(1);
-    expect(txRows[1].output).toMatch(`Hello, ${user}! You have been greeted 1 times.`);
-    expectNullResult(txRows[1].error);
+      expect(txRows[1].function_id).toBe(1);
+      expect(txRows[1].output).toMatch(`Hello, ${user}! You have been greeted 1 times.`);
+      expectNullResult(txRows[1].error);
 
-    expect(txRows[2].function_id).toBe(2);
-    expect(txRows[2].output).toEqual(`${res.rowCount}`);
-    expectNullResult(txRows[1].error);
+      expect(txRows[2].function_id).toBe(2);
+      expect(txRows[2].output).toEqual(`${res.rowCount}`);
+      expectNullResult(txRows[1].error);
+    });
   });
 
   test('test-debug-procGreetingWorkflow', async () => {
     const wfUUID = uuidv1();
     const user = `debugProcWF_${Date.now()}`;
-    const res = await testRuntime.invokeWorkflow(StoredProcTest, wfUUID).procGreetingWorkflow(user);
-    expect(res.count).toBe(0);
-    expect(res.greeting).toMatch(`Hello, ${user}! You have been greeted 1 times.`);
-    expect(res.rowCount).toBeGreaterThan(0);
+    let res: { count: number; greeting: string; rowCount: number } | undefined = undefined;
+    await DBOS.withNextWorkflowID(wfUUID, async () => {
+      res = await StoredProcTest.procGreetingWorkflow(user);
+      expect(res.count).toBe(0);
+      expect(res.greeting).toMatch(`Hello, ${user}! You have been greeted 1 times.`);
+      expect(res.rowCount).toBeGreaterThan(0);
+    });
+    await DBOS.shutdown();
 
+    // Temporarily use debug
     const debugConfig = { ...config, debugMode: true };
-    const debugRuntime = await createInternalTestRuntime([StoredProcTest], debugConfig);
+    DBOS.setConfig(debugConfig);
+    await DBOS.launch({ debugMode: DebugMode.ENABLED });
     try {
-      expect(debugRuntime).toBeDefined();
-      await expect(debugRuntime.invokeWorkflow(StoredProcTest, wfUUID).procGreetingWorkflow(user)).resolves.toEqual(
-        res,
-      );
-      await expect(
-        (debugRuntime as TestingRuntimeImpl)
-          .getDBOSExec()
-          .executeWorkflowUUID(wfUUID)
-          .then((x) => x.getResult()),
-      ).resolves.toEqual(res);
+      await DBOS.withNextWorkflowID(wfUUID, async () => {
+        await expect(StoredProcTest.procGreetingWorkflow(user)).resolves.toEqual(res);
+      });
+      await expect(DBOS.executeWorkflowById(wfUUID).then((x) => x.getResult())).resolves.toEqual(res);
     } finally {
-      await debugRuntime.destroy();
+      await DBOS.shutdown();
     }
+
+    DBOS.setConfig(config);
+    await DBOS.launch();
   });
 
   test('test-txGreetingWorkflow', async () => {
     const wfUUID = uuidv1();
 
     const user = `txWF_${Date.now()}`;
-    const res = await testRuntime.invokeWorkflow(StoredProcTest, wfUUID).txAndProcGreetingWorkflow(user);
-    expect(res.count).toBe(0);
-    expect(res.greeting).toMatch(`Hello, ${user}! You have been greeted 1 times.`);
+    await DBOS.withNextWorkflowID(wfUUID, async () => {
+      const res = await StoredProcTest.txAndProcGreetingWorkflow(user);
+      expect(res.count).toBe(0);
+      expect(res.greeting).toMatch(`Hello, ${user}! You have been greeted 1 times.`);
+    });
 
-    const txRows = await testRuntime.queryUserDB<transaction_outputs>(
+    const txRows = await DBOS.queryUserDB<transaction_outputs>(
       'SELECT * FROM dbos.transaction_outputs WHERE workflow_uuid=$1',
-      wfUUID,
+      [wfUUID],
     );
     expect(txRows.length).toBe(2);
     expect(txRows[0].function_id).toBe(0);
@@ -252,39 +264,43 @@ describe('stored-proc-test', () => {
   test('test-procLocalGreetingWorkflow', async () => {
     const wfUUID = uuidv1();
     const user = `procLocalWF_${Date.now()}`;
-    const res = await testRuntime.invokeWorkflow(StoredProcTest, wfUUID).procLocalGreetingWorkflow(user);
-    expect(res.count).toBe(0);
-    expect(res.greeting).toMatch(`Hello, ${user}! You have been greeted 1 times.`);
-    expect(res.rowCount).toBeGreaterThan(0);
+    await DBOS.withNextWorkflowID(wfUUID, async () => {
+      const res = await StoredProcTest.procLocalGreetingWorkflow(user);
+      expect(res.count).toBe(0);
+      expect(res.greeting).toMatch(`Hello, ${user}! You have been greeted 1 times.`);
+      expect(res.rowCount).toBeGreaterThan(0);
 
-    const txRows = await testRuntime.queryUserDB<transaction_outputs>(
-      'SELECT * FROM dbos.transaction_outputs WHERE workflow_uuid=$1',
-      wfUUID,
-    );
-    expect(txRows.length).toBe(3);
-    expect(txRows[0].function_id).toBe(0);
-    expect(txRows[0].output).toBe('0');
-    expectNullResult(txRows[0].error);
+      const txRows = await DBOS.queryUserDB<transaction_outputs>(
+        'SELECT * FROM dbos.transaction_outputs WHERE workflow_uuid=$1',
+        [wfUUID],
+      );
+      expect(txRows.length).toBe(3);
+      expect(txRows[0].function_id).toBe(0);
+      expect(txRows[0].output).toBe('0');
+      expectNullResult(txRows[0].error);
 
-    expect(txRows[1].function_id).toBe(1);
-    expect(txRows[1].output).toMatch(`Hello, ${user}! You have been greeted 1 times.`);
-    expectNullResult(txRows[1].error);
+      expect(txRows[1].function_id).toBe(1);
+      expect(txRows[1].output).toMatch(`Hello, ${user}! You have been greeted 1 times.`);
+      expectNullResult(txRows[1].error);
 
-    expect(txRows[2].function_id).toBe(2);
-    expect(txRows[2].output).toEqual(`${res.rowCount}`);
-    expectNullResult(txRows[1].error);
+      expect(txRows[2].function_id).toBe(2);
+      expect(txRows[2].output).toEqual(`${res.rowCount}`);
+      expectNullResult(txRows[1].error);
+    });
   });
 
   test('test-txAndProcGreetingWorkflow', async () => {
     const wfUUID = uuidv1();
     const user = `txAndProcWF_${Date.now()}`;
-    const res = await testRuntime.invokeWorkflow(StoredProcTest, wfUUID).txAndProcGreetingWorkflow(user);
-    expect(res.count).toBe(0);
-    expect(res.greeting).toMatch(`Hello, ${user}! You have been greeted 1 times.`);
+    await DBOS.withNextWorkflowID(wfUUID, async () => {
+      const res = await StoredProcTest.txAndProcGreetingWorkflow(user);
+      expect(res.count).toBe(0);
+      expect(res.greeting).toMatch(`Hello, ${user}! You have been greeted 1 times.`);
+    });
 
-    const txRows = await testRuntime.queryUserDB<transaction_outputs>(
+    const txRows = await DBOS.queryUserDB<transaction_outputs>(
       'SELECT * FROM dbos.transaction_outputs WHERE workflow_uuid=$1',
-      wfUUID,
+      [wfUUID],
     );
     expect(txRows.length).toBe(2);
     expect(txRows[0].function_id).toBe(0);
@@ -299,13 +315,14 @@ describe('stored-proc-test', () => {
   test('test-procErrorWorkflow', async () => {
     const wfid = uuidv1();
     const user = `procErrorWF_${Date.now()}`;
-    await expect(testRuntime.invokeWorkflow(StoredProcTest, wfid).procErrorWorkflow(user)).rejects.toThrow(
-      'This is a test error',
-    );
 
-    const txRows = await testRuntime.queryUserDB<transaction_outputs>(
+    await DBOS.withNextWorkflowID(wfid, async () => {
+      await expect(StoredProcTest.procErrorWorkflow(user)).rejects.toThrow('This is a test error');
+    });
+
+    const txRows = await DBOS.queryUserDB<transaction_outputs>(
       'SELECT * FROM dbos.transaction_outputs WHERE workflow_uuid=$1',
-      wfid,
+      [wfid],
     );
 
     expect(txRows.length).toBe(3);

--- a/tests/proc-test/src/operations.ts
+++ b/tests/proc-test/src/operations.ts
@@ -1,13 +1,4 @@
-import {
-  DBOS,
-  StoredProcedure,
-  StoredProcedureContext,
-  Transaction,
-  TransactionContext,
-  Workflow,
-  WorkflowContext,
-} from '@dbos-inc/dbos-sdk';
-import { Knex } from 'knex';
+import { DBOS } from '@dbos-inc/dbos-sdk';
 
 // The schema of the database table used in this example.
 export interface dbos_hello {
@@ -16,119 +7,110 @@ export interface dbos_hello {
 }
 
 export class StoredProcTest {
-  @StoredProcedure({ readOnly: true })
-  static async getGreetCount(ctxt: StoredProcedureContext, user: string): Promise<number> {
+  @DBOS.storedProcedure({ readOnly: true })
+  static async getGreetCount(user: string): Promise<number> {
     const query = 'SELECT greet_count FROM dbos_hello WHERE name = $1;';
-    const { rows } = await ctxt.query<dbos_hello>(query, [user]);
+    const { rows } = await DBOS.pgClient.query<dbos_hello>(query, [user]);
     return rows.length === 0 ? 0 : rows[0].greet_count;
   }
 
-  @StoredProcedure() // not marking this read only so the tx output table write is not buffered
-  static async getHelloRowCount(ctxt: StoredProcedureContext): Promise<number> {
+  @DBOS.storedProcedure() // not marking this read only so the tx output table write is not buffered
+  static async getHelloRowCount(): Promise<number> {
     const query = 'SELECT COUNT(*) FROM dbos_hello;';
-    const { rows } = await ctxt.query<{ count: string }>(query);
+    const { rows } = await DBOS.pgClient.query<{ count: string }>(query);
     return parseInt(rows[0].count);
   }
 
-  @StoredProcedure() // Run this function as a database transaction
-  static async helloProcedure(ctxt: StoredProcedureContext, user: string): Promise<string> {
+  @DBOS.storedProcedure() // Run this function as a database transaction
+  static async helloProcedure(user: string): Promise<string> {
     const query =
       'INSERT INTO dbos_hello (name, greet_count) VALUES ($1, 1) ON CONFLICT (name) DO UPDATE SET greet_count = dbos_hello.greet_count + 1 RETURNING greet_count;';
-    const { rows } = await ctxt.query<dbos_hello>(query, [user]);
+    const { rows } = await DBOS.pgClient.query<dbos_hello>(query, [user]);
     const greet_count = rows[0].greet_count;
     return `Hello, ${user}! You have been greeted ${greet_count} times.\n`;
   }
 
-  @Workflow()
-  static async procGreetingWorkflow(
-    ctxt: WorkflowContext,
-    user: string,
-  ): Promise<{ count: number; greeting: string; rowCount: number }> {
-    const count = await ctxt.invoke(StoredProcTest).getGreetCount(user);
-    const greeting = await ctxt.invoke(StoredProcTest).helloProcedure(user);
-    const rowCount = await ctxt.invoke(StoredProcTest).getHelloRowCount();
+  @DBOS.workflow()
+  static async procGreetingWorkflow(user: string): Promise<{ count: number; greeting: string; rowCount: number }> {
+    const count = await StoredProcTest.getGreetCount(user);
+    const greeting = await StoredProcTest.helloProcedure(user);
+    const rowCount = await StoredProcTest.getHelloRowCount();
     return { count, greeting, rowCount };
   }
 
-  @StoredProcedure()
-  static async procError(_ctxt: StoredProcedureContext): Promise<void> {
+  @DBOS.storedProcedure()
+  static async procError(): Promise<void> {
     await Promise.resolve();
     throw new Error('This is a test error');
   }
 
-  @Workflow()
-  static async procErrorWorkflow(ctxt: WorkflowContext, user: string): Promise<string> {
-    const greeting = await ctxt.invoke(StoredProcTest).helloProcedure(user);
-    const _count = await ctxt.invoke(StoredProcTest).getGreetCount(user);
-    await ctxt.invoke(StoredProcTest).procError();
+  @DBOS.workflow()
+  static async procErrorWorkflow(user: string): Promise<string> {
+    const greeting = await StoredProcTest.helloProcedure(user);
+    const _count = await StoredProcTest.getGreetCount(user);
+    await StoredProcTest.procError();
     return greeting;
   }
 
-  @StoredProcedure({ readOnly: true, executeLocally: true })
-  static async getGreetCountLocal(ctxt: StoredProcedureContext, user: string): Promise<number> {
+  @DBOS.storedProcedure({ readOnly: true, executeLocally: true })
+  static async getGreetCountLocal(user: string): Promise<number> {
     const query = 'SELECT greet_count FROM dbos_hello WHERE name = $1;';
-    const { rows } = await ctxt.query<dbos_hello>(query, [user]);
+    const { rows } = await DBOS.pgClient.query<dbos_hello>(query, [user]);
     return rows.length === 0 ? 0 : rows[0].greet_count;
   }
 
-  @StoredProcedure({ executeLocally: true }) // Run this function as a database transaction
-  static async helloProcedureLocal(ctxt: StoredProcedureContext, user: string): Promise<string> {
+  @DBOS.storedProcedure({ executeLocally: true }) // Run this function as a database transaction
+  static async helloProcedureLocal(user: string): Promise<string> {
     // Retrieve and increment the number of times this user has been greeted.
     const query =
       'INSERT INTO dbos_hello (name, greet_count) VALUES ($1, 1) ON CONFLICT (name) DO UPDATE SET greet_count = dbos_hello.greet_count + 1 RETURNING greet_count;';
-    const { rows } = await ctxt.query<dbos_hello>(query, [user]);
+    const { rows } = await DBOS.pgClient.query<dbos_hello>(query, [user]);
     const greet_count = rows[0].greet_count;
     return `Hello, ${user}! You have been greeted ${greet_count} times.\n`;
   }
 
-  @StoredProcedure({ executeLocally: true }) // like getHelloRowCount, not marked as read only so the tx output does not get buffered
-  static async getHelloRowCountLocal(ctxt: StoredProcedureContext): Promise<number> {
+  @DBOS.storedProcedure({ executeLocally: true }) // like getHelloRowCount, not marked as read only so the tx output does not get buffered
+  static async getHelloRowCountLocal(): Promise<number> {
     const query = 'SELECT COUNT(*) FROM dbos_hello;';
-    const { rows } = await ctxt.query<{ count: string }>(query);
+    const { rows } = await DBOS.pgClient.query<{ count: string }>(query);
     return parseInt(rows[0].count);
   }
 
-  @Workflow()
-  static async procLocalGreetingWorkflow(
-    ctxt: WorkflowContext,
-    user: string,
-  ): Promise<{ count: number; greeting: string; rowCount: number }> {
-    const count = await ctxt.invoke(StoredProcTest).getGreetCountLocal(user);
-    const greeting = await ctxt.invoke(StoredProcTest).helloProcedureLocal(user);
-    const rowCount = await ctxt.invoke(StoredProcTest).getHelloRowCountLocal();
+  @DBOS.workflow()
+  static async procLocalGreetingWorkflow(user: string): Promise<{ count: number; greeting: string; rowCount: number }> {
+    const count = await StoredProcTest.getGreetCountLocal(user);
+    const greeting = await StoredProcTest.helloProcedureLocal(user);
+    const rowCount = await StoredProcTest.getHelloRowCountLocal();
     return { count, greeting, rowCount };
   }
 
-  @Transaction({ readOnly: true })
-  static async getGreetCountTx(ctxt: TransactionContext<Knex>, user: string): Promise<number> {
+  @DBOS.transaction({ readOnly: true })
+  static async getGreetCountTx(user: string): Promise<number> {
     const query = 'SELECT greet_count FROM dbos_hello WHERE name = ?;';
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    const result = (await ctxt.client.raw(query, user)) as { rows: dbos_hello[] } | undefined;
+    const result = (await DBOS.knexClient.raw(query, user)) as { rows: dbos_hello[] } | undefined;
     if (result && result.rows.length > 0) {
       return result.rows[0].greet_count;
     }
     return 0;
   }
 
-  @Transaction() // Run this function as a database transaction
-  static async helloTransaction(ctxt: TransactionContext<Knex>, user: string) {
+  @DBOS.transaction() // Run this function as a database transaction
+  static async helloTransaction(user: string) {
     // Retrieve and increment the number of times this user has been greeted.
     const query =
       'INSERT INTO dbos_hello (name, greet_count) VALUES (?, 1) ON CONFLICT (name) DO UPDATE SET greet_count = dbos_hello.greet_count + 1 RETURNING greet_count;';
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    const { rows } = (await ctxt.client.raw(query, [user])) as { rows: dbos_hello[] };
+    const { rows } = (await DBOS.knexClient.raw(query, [user])) as { rows: dbos_hello[] };
     const greet_count = rows[0].greet_count;
     return `Hello, ${user}! You have been greeted ${greet_count} times.\n`;
   }
 
-  @Workflow()
-  static async txAndProcGreetingWorkflow(
-    ctxt: WorkflowContext,
-    user: string,
-  ): Promise<{ count: number; greeting: string }> {
+  @DBOS.workflow()
+  static async txAndProcGreetingWorkflow(user: string): Promise<{ count: number; greeting: string }> {
     // Retrieve the number of times this user has been greeted.
-    const count = await ctxt.invoke(StoredProcTest).getGreetCountTx(user);
-    const greeting = await ctxt.invoke(StoredProcTest).helloProcedure(user);
+    const count = await StoredProcTest.getGreetCountTx(user);
+    const greeting = await StoredProcTest.helloProcedure(user);
 
     return { count, greeting };
   }

--- a/tests/testing/debug_typeorm.test.ts
+++ b/tests/testing/debug_typeorm.test.ts
@@ -1,18 +1,13 @@
-import { TransactionContext, Transaction, OrmEntities } from '../../src/';
+import { DBOS, OrmEntities } from '../../src/';
 import { generateDBOSTestConfig, setUpDBOSTestDb } from '../helpers';
 import { v1 as uuidv1 } from 'uuid';
 import { DBOSConfig, DebugMode } from '../../src/dbos-executor';
-import { TestingRuntime, TestingRuntimeImpl, createInternalTestRuntime } from '../../src/testing/testing_runtime';
 import { Column, Entity, EntityManager, PrimaryColumn } from 'typeorm';
 import { UserDatabaseName } from '../../src/user_database';
-
-type TestTransactionContext = TransactionContext<EntityManager>;
 
 describe('typeorm-debugger-test', () => {
   let config: DBOSConfig;
   let debugConfig: DBOSConfig;
-  let testRuntime: TestingRuntime;
-  let debugRuntime: TestingRuntime;
 
   beforeAll(async () => {
     config = generateDBOSTestConfig(UserDatabaseName.TYPEORM);
@@ -22,15 +17,11 @@ describe('typeorm-debugger-test', () => {
 
   beforeEach(async () => {
     // TODO: connect to the real proxy.
-    debugRuntime = await createInternalTestRuntime(undefined, debugConfig, { debugMode: DebugMode.ENABLED });
-    testRuntime = await createInternalTestRuntime(undefined, config);
-    await testRuntime.dropUserSchema();
-    await testRuntime.createUserSchema();
-  });
-
-  afterEach(async () => {
-    await debugRuntime.destroy();
-    await testRuntime.destroy();
+    DBOS.setConfig(config);
+    await DBOS.launch();
+    await DBOS.dropUserSchema();
+    await DBOS.createUserSchema();
+    await DBOS.shutdown();
   });
 
   // Test TypeORM
@@ -45,12 +36,12 @@ describe('typeorm-debugger-test', () => {
 
   @OrmEntities([KV])
   class KVController {
-    @Transaction()
-    static async testTxn(txnCtxt: TestTransactionContext, id: string, value: string) {
+    @DBOS.transaction()
+    static async testTxn(id: string, value: string) {
       const kv: KV = new KV();
       kv.id = id;
       kv.value = value;
-      const res = await txnCtxt.client.save(kv);
+      const res = await (DBOS.typeORMClient as EntityManager).save(kv);
       return res.id;
     }
   }
@@ -58,18 +49,22 @@ describe('typeorm-debugger-test', () => {
   test('debug-typeorm-transaction', async () => {
     const wfUUID = uuidv1();
     // Execute the workflow and destroy the runtime
-    await expect(testRuntime.invoke(KVController, wfUUID).testTxn('test', 'value')).resolves.toBe('test');
-    await testRuntime.destroy();
+    DBOS.setConfig(config);
+    await DBOS.launch();
+    await DBOS.withNextWorkflowID(wfUUID, async () => {
+      await expect(KVController.testTxn('test', 'value')).resolves.toBe('test');
+    });
+    await DBOS.shutdown();
 
     // Execute again in debug mode.
-    await expect(debugRuntime.invoke(KVController, wfUUID).testTxn('test', 'value')).resolves.toBe('test');
+    DBOS.setConfig(debugConfig);
+    await DBOS.launch({ debugMode: DebugMode.ENABLED });
+    await DBOS.withNextWorkflowID(wfUUID, async () => {
+      await expect(KVController.testTxn('test', 'value')).resolves.toBe('test');
+    });
 
     // Execute again with the provided UUID.
-    await expect(
-      (debugRuntime as TestingRuntimeImpl)
-        .getDBOSExec()
-        .executeWorkflowUUID(wfUUID)
-        .then((x) => x.getResult()),
-    ).resolves.toBe('test');
+    await expect(DBOS.executeWorkflowById(wfUUID).then((x) => x.getResult())).resolves.toBe('test');
+    await DBOS.shutdown();
   });
 });

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -446,38 +446,61 @@ describe('debugger-test', () => {
     expect(result.rows[0].status).toBe('SUCCESS');
   });
 
-  /*
   test('debug-workflow-notifications', async () => {
     const recvUUID = uuidv1();
     const sendUUID = uuidv1();
+
     // Execute the workflow and destroy the runtime
-    const handle = await testRuntime.invoke(DebuggerTest, recvUUID).receiveWorkflow();
-    await expect(testRuntime.invokeWorkflow(DebuggerTest, sendUUID).sendWorkflow(recvUUID)).resolves.toBeFalsy(); // return void.
+    DBOS.setConfig(config);
+    await DBOS.launch();
+    const handle = await DBOS.startWorkflow(DebuggerTest, { workflowID: recvUUID }).receiveWorkflow();
+    await DBOS.withNextWorkflowID(sendUUID, async () => {
+      await expect(DebuggerTest.sendWorkflow(recvUUID)).resolves.toBeFalsy(); // return void.
+    });
     expect(await handle.getResult()).toBe(true);
-    await testRuntime.destroy();
+    await DBOS.shutdown();
 
     // Execute again in debug mode.
-    await expect(debugRuntime.invokeWorkflow(DebuggerTest, recvUUID).receiveWorkflow()).resolves.toBe(true);
-    await expect(debugRuntime.invokeWorkflow(DebuggerTest, sendUUID).sendWorkflow(recvUUID)).resolves.toBeFalsy();
+    /*
+    DBOS.setConfig(debugConfig);
+    await DBOS.launch({debugMode: DebugMode.ENABLED});
+    await DBOS.withNextWorkflowID(recvUUID, async () => {
+      await expect(DebuggerTest.receiveWorkflow()).resolves.toBeFalsy(); // return void.
+    });
+    await DBOS.withNextWorkflowID(sendUUID, async () => {
+      await expect(DebuggerTest.sendWorkflow(recvUUID)).resolves.toBeFalsy(); // return void.
+    });
+    await DBOS.shutdown();
+    */
   });
 
   test('debug-workflow-events', async () => {
     const getUUID = uuidv1();
     const setUUID = uuidv1();
     // Execute the workflow and destroy the runtime
-    await expect(testRuntime.invokeWorkflow(DebuggerTest, setUUID).setEventWorkflow()).resolves.toBe(0);
-    await expect(testRuntime.invokeWorkflow(DebuggerTest, getUUID).getEventWorkflow(setUUID)).resolves.toBe(
-      'value1-value2',
-    );
-    await testRuntime.destroy();
+    DBOS.setConfig(config);
+    await DBOS.launch();
+    await DBOS.withNextWorkflowID(setUUID, async () => {
+      await expect(DebuggerTest.setEventWorkflow()).resolves.toBe(0);
+    });
+    await DBOS.withNextWorkflowID(getUUID, async () => {
+      await expect(DebuggerTest.getEventWorkflow(setUUID)).resolves.toBe('value1-value2');
+    });
+    await DBOS.shutdown();
 
     // Execute again in debug mode.
-    await expect(debugRuntime.invokeWorkflow(DebuggerTest, setUUID).setEventWorkflow()).resolves.toBe(0);
-    await expect(debugRuntime.invokeWorkflow(DebuggerTest, getUUID).getEventWorkflow(setUUID)).resolves.toBe(
-      'value1-value2',
-    );
+    DBOS.setConfig(debugConfig);
+    await DBOS.launch({ debugMode: DebugMode.ENABLED });
+    await DBOS.withNextWorkflowID(setUUID, async () => {
+      await expect(DebuggerTest.setEventWorkflow()).resolves.toBe(0);
+    });
+    await DBOS.withNextWorkflowID(getUUID, async () => {
+      await expect(DebuggerTest.getEventWorkflow(setUUID)).resolves.toBe('value1-value2');
+    });
+    await DBOS.shutdown();
   });
 
+  /*
   test('debug-workflow-input-output', async () => {
     const wfUUID = uuidv1();
     // Execute the workflow and destroy the runtime

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -201,26 +201,41 @@ describe('debugger-test', () => {
     await DBOS.shutdown();
   });
 
-  /*
   test('tt-debug-workflow', async () => {
     DebuggerTest.debugCount = 0;
     const wfUUID = uuidv1();
-    // Execute the workflow and destroy the runtime
-    const res = await testRuntime.invokeWorkflow(DebuggerTest, wfUUID).debugWF(100);
-    expect(res).toBe(1000);
-    expect(DebuggerTest.debugCount).toBe(1);
-    await testRuntime.destroy();
+    DBOS.setConfig(config);
+    await DBOS.launch();
+    await DBOS.withNextWorkflowID(wfUUID, async () => {
+      // Execute the workflow and destroy the runtime
+      const res = await DebuggerTest.debugWF(100);
+      expect(res).toBe(1000);
+      expect(DebuggerTest.debugCount).toBe(1);
+    });
+    await DBOS.shutdown();
 
     // Execute again in debug mode.
-    const debugRes = await debugRuntime.invokeWorkflow(DebuggerTest, wfUUID).debugWF(100);
-    expect(DebuggerTest.debugCount).toBe(1);
-    expect(debugRes).toBe(1000);
+    DBOS.setConfig(debugConfig);
+    await DBOS.launch({ debugMode: DebugMode.ENABLED });
+    await DBOS.withNextWorkflowID(wfUUID, async () => {
+      const debugRes = await DebuggerTest.debugWF(100);
+      expect(DebuggerTest.debugCount).toBe(1);
+      expect(debugRes).toBe(1000);
+    });
+    await DBOS.shutdown();
 
-    const ttdbgRes = await timeTravelRuntime.invokeWorkflow(DebuggerTest, wfUUID).debugWF(100);
-    expect(DebuggerTest.debugCount).toBe(2);
-    expect(ttdbgRes).toBe(1000);
+    // And as time travel
+    DBOS.setConfig(debugProxyConfig);
+    await DBOS.launch({ debugMode: DebugMode.TIME_TRAVEL });
+    await DBOS.withNextWorkflowID(wfUUID, async () => {
+      const ttdbgRes = await DebuggerTest.debugWF(100);
+      expect(DebuggerTest.debugCount).toBe(2);
+      expect(ttdbgRes).toBe(1000);
+    });
+    await DBOS.shutdown();
   });
 
+  /*
   test('debug-sleep-workflow', async () => {
     const wfUUID = uuidv1();
     // Execute the workflow and destroy the runtime

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -461,17 +461,15 @@ describe('debugger-test', () => {
     await DBOS.shutdown();
 
     // Execute again in debug mode.
-    /*
     DBOS.setConfig(debugConfig);
-    await DBOS.launch({debugMode: DebugMode.ENABLED});
+    await DBOS.launch({ debugMode: DebugMode.ENABLED });
     await DBOS.withNextWorkflowID(recvUUID, async () => {
-      await expect(DebuggerTest.receiveWorkflow()).resolves.toBeFalsy(); // return void.
+      await expect(DebuggerTest.receiveWorkflow()).resolves.toBeTruthy();
     });
     await DBOS.withNextWorkflowID(sendUUID, async () => {
-      await expect(DebuggerTest.sendWorkflow(recvUUID)).resolves.toBeFalsy(); // return void.
+      await expect(DebuggerTest.sendWorkflow(recvUUID)).resolves.toBeFalsy();
     });
     await DBOS.shutdown();
-    */
   });
 
   test('debug-workflow-events', async () => {

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -498,27 +498,29 @@ describe('debugger-test', () => {
     await DBOS.shutdown();
   });
 
-  /*
   test('debug-workflow-input-output', async () => {
     const wfUUID = uuidv1();
     // Execute the workflow and destroy the runtime
-    const res = await testRuntime.invokeWorkflow(DebuggerTest, wfUUID).diffWorkflow(1);
-    expect(res).toBe(1);
-    await testRuntime.destroy();
+    DBOS.setConfig(config);
+    await DBOS.launch();
+    await DBOS.withNextWorkflowID(wfUUID, async () => {
+      const res = await DebuggerTest.diffWorkflow(1);
+      expect(res).toBe(1);
+    });
+    await DBOS.shutdown();
 
     // Execute again with the provided UUID, should still get the same output.
-    await expect(
-      (debugRuntime as TestingRuntimeImpl)
-        .getDBOSExec()
-        .executeWorkflowUUID(wfUUID)
-        .then((x) => x.getResult()),
-    ).resolves.toBe(1);
+    DBOS.setConfig(debugConfig);
+    await DBOS.launch({ debugMode: DebugMode.ENABLED });
+    await expect(DBOS.executeWorkflowById(wfUUID).then((x) => x.getResult())).resolves.toBe(1);
     expect(DebuggerTest.count).toBe(2);
 
     // Execute again with different input, should still get the same output.
-    await expect(debugRuntime.invoke(DebuggerTest, wfUUID).diffWorkflow(2)).rejects.toThrow(
-      /DEBUGGER: Detected different inputs for workflow UUID [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}.\s*Received: \[2\]\s*Original: \[1\]/gm,
-    );
+    await DBOS.withNextWorkflowID(wfUUID, async () => {
+      await expect(DebuggerTest.diffWorkflow(2)).rejects.toThrow(
+        /DEBUGGER: Detected different inputs for workflow UUID [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}.\s*Received: \[2\]\s*Original: \[1\]/gm,
+      );
+    });
+    await DBOS.shutdown();
   });
-  */
 });

--- a/tests/testing/debugger_configuredinst.test.ts
+++ b/tests/testing/debugger_configuredinst.test.ts
@@ -1,20 +1,7 @@
-import {
-  Step,
-  StepContext,
-  ConfiguredInstance,
-  InitContext,
-  Transaction,
-  TransactionContext,
-  Workflow,
-  WorkflowContext,
-} from '../../src/';
+import { ConfiguredInstance, DBOS, InitContext } from '../../src/';
 import { generateDBOSTestConfig, setUpDBOSTestDb } from '../helpers';
 import { v1 as uuidv1 } from 'uuid';
 import { DBOSConfig, DebugMode } from '../../src/dbos-executor';
-import { PoolClient } from 'pg';
-import { TestingRuntime, TestingRuntimeImpl, createInternalTestRuntime } from '../../src/testing/testing_runtime';
-
-type TestTransactionContext = TransactionContext<PoolClient>;
 
 class DebuggerCCTest extends ConfiguredInstance {
   constructor(name: string) {
@@ -25,33 +12,33 @@ class DebuggerCCTest extends ConfiguredInstance {
     return Promise.resolve();
   }
 
-  @Transaction({ readOnly: true })
-  async testReadOnlyFunction(_txnCtxt: TestTransactionContext, number: number) {
+  @DBOS.transaction({ readOnly: true })
+  async testReadOnlyFunction(number: number) {
     expect(this.name).toBe('configA');
     return Promise.resolve(number);
   }
 
-  @Workflow()
-  async testWorkflow(ctxt: WorkflowContext, name: string) {
+  @DBOS.workflow()
+  async testWorkflow(name: string) {
     expect(this.name).toBe('configA');
-    const funcResult = await ctxt.invoke(this).testReadOnlyFunction(5);
+    const funcResult = await this.testReadOnlyFunction(5);
     return `${name}${funcResult}`;
   }
 
-  @Step()
-  async testStep(_ctxt: StepContext, inp: string) {
+  @DBOS.step()
+  async testStep(inp: string) {
     expect(this.name).toBe('configA');
     return Promise.resolve(inp);
   }
 
   // Workflow that sleep, call comm, call tx, call child WF
-  @Workflow()
-  async mixedWorkflow(ctxt: WorkflowContext, num: number) {
+  @DBOS.workflow()
+  async mixedWorkflow(num: number) {
     expect(this.name).toBe('configA');
-    await ctxt.sleep(1);
-    const txResult = await ctxt.invoke(this).testReadOnlyFunction(num);
-    const cResult = await ctxt.invoke(this).testStep('comm');
-    const wfResult = await ctxt.invokeWorkflow(this).testWorkflow('cwf');
+    await DBOS.sleepSeconds(1);
+    const txResult = await this.testReadOnlyFunction(num);
+    const cResult = await this.testStep('comm');
+    const wfResult = await this.testWorkflow('cwf');
     return `${this.name}${txResult}${cResult}${wfResult}-${num}`;
   }
 }
@@ -62,9 +49,6 @@ describe('debugger-test', () => {
   let config: DBOSConfig;
   let debugConfig: DBOSConfig;
   let debugProxyConfig: DBOSConfig;
-  let testRuntime: TestingRuntime;
-  let debugRuntime: TestingRuntime;
-  let debugProxyRuntime: TestingRuntime;
 
   beforeAll(async () => {
     config = generateDBOSTestConfig();
@@ -73,44 +57,33 @@ describe('debugger-test', () => {
     await setUpDBOSTestDb(config);
   });
 
-  beforeEach(async () => {
-    testRuntime = await createInternalTestRuntime(undefined, config);
-    debugRuntime = await createInternalTestRuntime(undefined, debugConfig, { debugMode: DebugMode.ENABLED });
-    debugProxyRuntime = await createInternalTestRuntime(undefined, debugProxyConfig, {
-      debugMode: DebugMode.TIME_TRAVEL,
-    }); // TODO: connect to the real proxy.
-  });
-
-  afterEach(async () => {
-    await debugRuntime.destroy();
-    await testRuntime.destroy();
-    await debugProxyRuntime.destroy();
-  });
-
   test('debug-workflow', async () => {
     const wfUUID = uuidv1();
     // Execute the workflow and destroy the runtime
-    const res = await testRuntime.invokeWorkflow(configR, wfUUID).mixedWorkflow(23);
-    expect(res).toBe('configA23commcwf5-23');
-    await testRuntime.destroy();
+    DBOS.setConfig(config);
+    await DBOS.launch();
+    await DBOS.withNextWorkflowID(wfUUID, async () => {
+      const res = await configR.mixedWorkflow(23);
+      expect(res).toBe('configA23commcwf5-23');
+    });
+    await DBOS.shutdown();
 
     // Execute again in debug mode.
-    const debugRes = await debugRuntime.invokeWorkflow(configR, wfUUID).mixedWorkflow(23);
-    expect(debugRes).toBe('configA23commcwf5-23');
+    DBOS.setConfig(debugConfig);
+    await DBOS.launch({ debugMode: DebugMode.ENABLED });
+    await DBOS.withNextWorkflowID(wfUUID, async () => {
+      const res = await configR.mixedWorkflow(23);
+      expect(res).toBe('configA23commcwf5-23');
+    });
 
     // Execute again with the provided UUID.
-    await expect(
-      (debugRuntime as TestingRuntimeImpl)
-        .getDBOSExec()
-        .executeWorkflowUUID(wfUUID)
-        .then((x) => x.getResult()),
-    ).resolves.toBe('configA23commcwf5-23');
+    await expect(DBOS.executeWorkflowById(wfUUID).then((x) => x.getResult())).resolves.toBe('configA23commcwf5-23');
+    await DBOS.shutdown();
 
-    await expect(
-      (debugProxyRuntime as TestingRuntimeImpl)
-        .getDBOSExec()
-        .executeWorkflowUUID(wfUUID)
-        .then((x) => x.getResult()),
-    ).resolves.toBe('configA23commcwf5-23');
+    // TT Mode
+    DBOS.setConfig(debugProxyConfig);
+    await DBOS.launch({ debugMode: DebugMode.TIME_TRAVEL });
+    await expect(DBOS.executeWorkflowById(wfUUID).then((x) => x.getResult())).resolves.toBe('configA23commcwf5-23');
+    await DBOS.shutdown();
   });
 });


### PR DESCRIPTION
This relies on only one DBOS running at a time (in the right mode for the situation), but otherwise the same.