### PR TITLE
InitContext becomes optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
       "devDependencies": {
         "@eslint/js": "^9.22.0",
         "@fastify/express": "^4.0.1",
-        "@nestjs/common": "^10.4.7",
+        "@nestjs/common": "^11.0.12",
         "@prisma/client": "^5.3.1",
         "@types/co-body": "^6.1.3",
         "@types/dockerode": "^3.3.34",
@@ -3584,13 +3584,13 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "10.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.7.tgz",
-      "integrity": "sha512-gIOpjD3Mx8gfYGxYm/RHPcJzqdknNNFCyY+AxzBT3gc5Xvvik1Dn5OxaMGw5EbVfhZgJKVP0n83giUOAlZQe7w==",
+      "version": "11.0.12",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.0.12.tgz",
+      "integrity": "sha512-6PXxmDe2iYmb57xacnxzpW1NAxRZ7Gf+acMT7/hmRB/4KpZiFU/cNvLWwgbM2BL5QSzQulOwY6ny5bbKnPpB+A==",
       "dev": true,
       "dependencies": {
         "iterare": "1.2.1",
-        "tslib": "2.7.0",
+        "tslib": "2.8.1",
         "uid": "2.0.2"
       },
       "funding": {
@@ -13424,9 +13424,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -13853,9 +13853,9 @@
       }
     },
     "node_modules/vite-node/node_modules/vite": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.0.tgz",
-      "integrity": "sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
+      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -14036,9 +14036,9 @@
       }
     },
     "node_modules/vitest/node_modules/vite": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.0.tgz",
-      "integrity": "sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
+      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@eslint/js": "^9.22.0",
     "@fastify/express": "^4.0.1",
-    "@nestjs/common": "^10.4.7",
+    "@nestjs/common": "^11.0.12",
     "@prisma/client": "^5.3.1",
     "@types/co-body": "^6.1.3",
     "@types/dockerode": "^3.3.34",

--- a/packages/dbos-confluent-kafka/index.ts
+++ b/packages/dbos-confluent-kafka/index.ts
@@ -1,6 +1,5 @@
 import {
   DBOS,
-  InitContext,
   ConfiguredInstance,
   Error as DBOSError,
   DBOSEventReceiver,
@@ -233,7 +232,7 @@ export class KafkaProducer extends ConfiguredInstance {
     this.topic = topic;
   }
 
-  async initialize(_ctx: InitContext): Promise<void> {
+  override async initialize(): Promise<void> {
     const kafka = new KafkaJS.Kafka({});
     this.producer = kafka.producer({ kafkaJS: this.cfg });
     await this.producer.connect();

--- a/packages/dbos-kafkajs/index.ts
+++ b/packages/dbos-kafkajs/index.ts
@@ -11,15 +11,7 @@ import {
   logLevel,
   Partitioners,
 } from 'kafkajs';
-import {
-  DBOS,
-  Step,
-  StepContext,
-  ConfiguredInstance,
-  DBOSContext,
-  DBOSEventReceiver,
-  InitContext,
-} from '@dbos-inc/dbos-sdk';
+import { DBOS, Step, StepContext, ConfiguredInstance, DBOSContext, DBOSEventReceiver } from '@dbos-inc/dbos-sdk';
 import { associateClassWithEventReceiver, associateMethodWithEventReceiver } from '@dbos-inc/dbos-sdk';
 import { TransactionFunction } from '@dbos-inc/dbos-sdk';
 import { WorkflowFunction } from '@dbos-inc/dbos-sdk';
@@ -248,7 +240,7 @@ export class KafkaProduceStep extends ConfiguredInstance {
     this.topic = topic;
   }
 
-  async initialize(_ctx: InitContext): Promise<void> {
+  override async initialize(): Promise<void> {
     const kafka = new KafkaJS(this.cfg);
     this.producer = kafka.producer(this.pcfg);
     await this.producer.connect();

--- a/src/context.ts
+++ b/src/context.ts
@@ -3,8 +3,7 @@ import { GlobalLogger as Logger, Logger as DBOSLogger } from './telemetry/logs';
 import { get } from 'lodash';
 import { IncomingHttpHeaders } from 'http';
 import { ParsedUrlQuery } from 'querystring';
-import { UserDatabase, UserDatabaseClient } from './user_database';
-import { DBOSExecutor } from './dbos-executor';
+import { UserDatabaseClient } from './user_database';
 import { DBOSConfigKeyTypeError } from './error';
 import { AsyncLocalStorage } from 'async_hooks';
 import { WorkflowContext, WorkflowContextImpl } from './workflow';
@@ -273,52 +272,6 @@ export class DBOSContextImpl implements DBOSContext {
   getConfig<T>(key: string, defaultValue: T): T;
   getConfig<T>(key: string, defaultValue?: T): T | undefined {
     const value = get(this.applicationConfig, key, defaultValue);
-    // If the key is found and the default value is provided, check whether the value is of the same type.
-    if (value && defaultValue && typeof value !== typeof defaultValue) {
-      throw new DBOSConfigKeyTypeError(key, typeof defaultValue, typeof value);
-    }
-    return value;
-  }
-}
-
-/**
- * TODO : move logger and application, getConfig to a BaseContext which is at the root of all contexts
- */
-export class InitContext {
-  readonly logger: Logger;
-
-  // All private Not exposed
-  private userDatabase: UserDatabase;
-  private application?: object;
-
-  constructor(readonly dbosExec: DBOSExecutor) {
-    this.logger = dbosExec.logger;
-    this.userDatabase = dbosExec.userDatabase;
-    this.application = dbosExec.config.application;
-  }
-
-  createUserSchema(): Promise<void> {
-    this.logger.warn(
-      'Schema synchronization is deprecated and unsafe for production use. Please use migrations instead: https://typeorm.io/migrations',
-    );
-    return this.userDatabase.createSchema();
-  }
-
-  dropUserSchema(): Promise<void> {
-    this.logger.warn(
-      'Schema synchronization is deprecated and unsafe for production use. Please use migrations instead: https://typeorm.io/migrations',
-    );
-    return this.userDatabase.dropSchema();
-  }
-
-  queryUserDB<R>(sql: string, ...params: unknown[]): Promise<R[]> {
-    return this.userDatabase.query(sql, ...params);
-  }
-
-  getConfig<T>(key: string): T | undefined;
-  getConfig<T>(key: string, defaultValue: T): T;
-  getConfig<T>(key: string, defaultValue?: T): T | undefined {
-    const value = get(this.application, key, defaultValue);
     // If the key is found and the default value is provided, check whether the value is of the same type.
     if (value && defaultValue && typeof value !== typeof defaultValue) {
       throw new DBOSConfigKeyTypeError(key, typeof defaultValue, typeof value);

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -66,7 +66,6 @@ import { SpanStatusCode } from '@opentelemetry/api';
 import knex, { Knex } from 'knex';
 import {
   DBOSContextImpl,
-  InitContext,
   runWithWorkflowContext,
   runWithTransactionContext,
   runWithStepContext,
@@ -78,7 +77,7 @@ import { globalParams, DBOSJSON, sleepms } from './utils';
 import path from 'node:path';
 import { StoredProcedure, StoredProcedureConfig, StoredProcedureContextImpl } from './procedure';
 import { NoticeMessage } from 'pg-protocol/dist/messages';
-import { DBOSEventReceiver, DBOSExecutorContext, GetWorkflowsInput, GetWorkflowsOutput } from '.';
+import { DBOSEventReceiver, DBOSExecutorContext, GetWorkflowsInput, GetWorkflowsOutput, InitContext } from '.';
 
 import { get } from 'lodash';
 import { wfQueueRunner, WorkflowQueue } from './wfqueue';
@@ -527,7 +526,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
         // Init its configurations
         const creg = getOrCreateClassRegistration(cls as AnyConstructor);
         for (const [_cfgname, cfg] of creg.configuredInstances) {
-          await cfg.initialize(new InitContext(this));
+          await cfg.initialize(new InitContext());
         }
       }
 
@@ -535,7 +534,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
         const m = v as MethodRegistration<unknown, unknown[], unknown>;
         if (m.init === true) {
           this.logger.debug('Executing init method: ' + m.name);
-          await m.origFunction(new InitContext(this));
+          await m.origFunction(new InitContext());
         }
       }
 

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -837,9 +837,9 @@ export function DBOSInitializer() {
   function decorator<This, Args extends unknown[], Return>(
     target: object,
     propertyKey: string,
-    inDescriptor: TypedPropertyDescriptor<(this: This, ctx: InitContext, ...args: Args) => Promise<Return>>,
+    inDescriptor: TypedPropertyDescriptor<(this: This, ...args: Args) => Promise<Return>>,
   ) {
-    const { descriptor, registration } = registerAndWrapFunctionTakingContext(target, propertyKey, inDescriptor);
+    const { descriptor, registration } = registerAndWrapDBOSFunction(target, propertyKey, inDescriptor);
     registration.init = true;
     return descriptor;
   }

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -3,12 +3,13 @@ import 'reflect-metadata';
 import * as crypto from 'crypto';
 import { TransactionConfig, TransactionContext } from './transaction';
 import { WorkflowConfig, WorkflowContext } from './workflow';
-import { DBOSContext, DBOSContextImpl, getCurrentDBOSContext, InitContext } from './context';
+import { DBOSContext, DBOSContextImpl, getCurrentDBOSContext } from './context';
 import { StepConfig, StepContext } from './step';
 import { DBOSConflictingRegistrationError, DBOSNotAuthorizedError } from './error';
 import { validateMethodArgs } from './data_validation';
 import { StoredProcedureConfig, StoredProcedureContext } from './procedure';
 import { DBOSEventReceiver } from './eventreceiver';
+import { InitContext } from './dbos';
 
 /**
  * Any column type column can be.
@@ -839,7 +840,7 @@ export function DBOSInitializer() {
   return decorator;
 }
 
-// For future use with Deploy
+/** @deprecated */
 export function DBOSDeploy() {
   function decorator<This, Args extends unknown[], Return>(
     target: object,

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -285,7 +285,13 @@ export abstract class ConfiguredInstance {
     this.name = name;
     registerClassInstance(this, name);
   }
-  abstract initialize(ctx: InitContext): Promise<void>;
+  /**
+   * Override this method to perform async initialization.
+   * @param _ctx - @deprecated This parameter is unnecessary, use `DBOS` instead.
+   */
+  initialize(_ctx: InitContext): Promise<void> {
+    return Promise.resolve();
+  }
 }
 
 export class ClassRegistration<CT extends { new (...args: unknown[]): object }> implements RegistrationDefaults {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { createTestingRuntime, TestingRuntime } from './testing/testing_runtime';
 
-export { DBOSContext, InitContext } from './context';
+export { DBOSContext } from './context';
 
 export { DBOSClient } from './client';
 
@@ -124,4 +124,4 @@ export { DBOSConfig } from './dbos-executor';
 
 export { WorkflowQueue } from './wfqueue';
 
-export { DBOS } from './dbos';
+export { DBOS, InitContext } from './dbos';

--- a/tests/configuredinstances.test.ts
+++ b/tests/configuredinstances.test.ts
@@ -43,7 +43,7 @@ class DBOSTestConfiguredClass extends ConfiguredInstance {
     this.tracker = new ConfigTracker(name);
   }
 
-  initialize(_ctx: InitContext): Promise<void> {
+  override initialize(_ctx: InitContext): Promise<void> {
     const arg = this.tracker;
     if (!arg.name || DBOSTestConfiguredClass.configs.has(arg.name)) {
       throw new Error(`Invalid or duplicate config name: ${arg.name}`);

--- a/tests/contextfreeinst.test.ts
+++ b/tests/contextfreeinst.test.ts
@@ -6,7 +6,7 @@ class TestFunctions extends ConfiguredInstance {
     super(name);
   }
 
-  async initialize() {
+  override async initialize() {
     return Promise.resolve();
   }
 
@@ -80,10 +80,6 @@ const testTableName = 'dbos_test_kv';
 class TestSec extends ConfiguredInstance {
   constructor(name: string) {
     super(name);
-  }
-
-  async initialize() {
-    return Promise.resolve();
   }
 
   @DBOS.requiredRole([])

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -299,8 +299,10 @@ class DBOSTestClass {
   @DBOSInitializer()
   static async init(ctx: InitContext) {
     DBOSTestClass.initialized = true;
+    // ctx and DBOS should be interchangeable
     expect(ctx.getConfig('counter')).toBe(3);
-    await ctx.queryUserDB(`DROP TABLE IF EXISTS ${testTableName};`);
+    expect(DBOS.getConfig('counter')).toBe(3);
+    await DBOS.queryUserDB(`DROP TABLE IF EXISTS ${testTableName};`);
     await ctx.queryUserDB(`CREATE TABLE IF NOT EXISTS ${testTableName} (id SERIAL PRIMARY KEY, value TEXT);`);
     await ctx.queryUserDB(`CREATE OR REPLACE FUNCTION test_proc_raise() returns void as $$
     BEGIN

--- a/tests/failures.test.ts
+++ b/tests/failures.test.ts
@@ -8,7 +8,6 @@ import {
   ArgOptional,
   DBOS,
   ConfiguredInstance,
-  InitContext,
 } from '../src/';
 import { generateDBOSTestConfig, setUpDBOSTestDb, TestKvTable } from './helpers';
 import { DatabaseError, PoolClient } from 'pg';
@@ -231,7 +230,7 @@ describe('failures-tests', () => {
 });
 
 class FailureTestClass extends ConfiguredInstance {
-  initialize(_ctx: InitContext): Promise<void> {
+  initialize(): Promise<void> {
     return Promise.resolve();
   }
 

--- a/tests/proc-test/tsconfig.json
+++ b/tests/proc-test/tsconfig.json
@@ -13,6 +13,7 @@
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
     "strict": true /* Enable all strict type-checking options. */,
+    "resolveJsonModule": true /* Include modules imported with JSON extension in the compilation. */,
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
   "include": [/* Specifies an array of filenames or patterns to include in the program. */ "src"],

--- a/tests/recovery_configuredinst_v2.test.ts
+++ b/tests/recovery_configuredinst_v2.test.ts
@@ -1,4 +1,4 @@
-import { configureInstance, ConfiguredInstance, InitContext, DBOS } from '../src';
+import { configureInstance, ConfiguredInstance, DBOS } from '../src';
 
 import { generateDBOSTestConfig, setUpDBOSTestDb } from './helpers';
 import { DBOSConfig } from '../src/dbos-executor';
@@ -33,7 +33,7 @@ class CCRecovery extends ConfiguredInstance {
     super(name);
   }
 
-  initialize(_ctx: InitContext): Promise<void> {
+  initialize(): Promise<void> {
     return Promise.resolve();
   }
 

--- a/tests/steptxqueue.test.ts
+++ b/tests/steptxqueue.test.ts
@@ -1,4 +1,4 @@
-import { DBOS, ConfiguredInstance, InitContext, WorkflowHandle } from '../src';
+import { DBOS, ConfiguredInstance, WorkflowHandle } from '../src';
 import { DBOSConfig } from '../src/dbos-executor';
 import { generateDBOSTestConfig, queueEntriesAreCleanedUp, setUpDBOSTestDb, Event } from './helpers';
 import { WorkflowQueue } from '../src';
@@ -12,7 +12,7 @@ class InstanceStepTx extends ConfiguredInstance {
     super('Instance');
   }
 
-  initialize(_ctx: InitContext): Promise<void> {
+  initialize(): Promise<void> {
     return Promise.resolve();
   }
 
@@ -51,7 +51,7 @@ class StaticStepTx extends ConfiguredInstance {
     super('Instance');
   }
 
-  initialize(_ctx: InitContext): Promise<void> {
+  initialize(): Promise<void> {
     return Promise.resolve();
   }
 
@@ -355,7 +355,7 @@ class TestQueueRecoveryInst extends ConfiguredInstance {
   constructor() {
     super('single');
   }
-  initialize(_ctx: InitContext): Promise<void> {
+  initialize(): Promise<void> {
     return Promise.resolve();
   }
   static queuedSteps = 3;

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -1,4 +1,4 @@
-import { DBOSInitializer, InitContext, DBOS } from '../../src/';
+import { DBOSInitializer, DBOS } from '../../src/';
 import { generateDBOSTestConfig, setUpDBOSTestDb, TestKvTable } from '../helpers';
 import { v1 as uuidv1 } from 'uuid';
 import { DBOSConfigInternal, DBOSExecutor, DebugMode } from '../../src/dbos-executor';
@@ -44,9 +44,9 @@ describe('debugger-test', () => {
     static count: number = 0;
 
     @DBOSInitializer()
-    static async init(ctx: InitContext) {
-      await ctx.queryUserDB(`DROP TABLE IF EXISTS ${testTableName};`);
-      await ctx.queryUserDB(`CREATE TABLE IF NOT EXISTS ${testTableName} (id SERIAL PRIMARY KEY, value TEXT);`);
+    static async init() {
+      await DBOS.queryUserDB(`DROP TABLE IF EXISTS ${testTableName};`);
+      await DBOS.queryUserDB(`CREATE TABLE IF NOT EXISTS ${testTableName} (id SERIAL PRIMARY KEY, value TEXT);`);
     }
 
     @DBOS.transaction({ readOnly: true })

--- a/tests/testing/debugger_configuredinst.test.ts
+++ b/tests/testing/debugger_configuredinst.test.ts
@@ -1,4 +1,4 @@
-import { ConfiguredInstance, DBOS, InitContext } from '../../src/';
+import { ConfiguredInstance, DBOS } from '../../src/';
 import { generateDBOSTestConfig, setUpDBOSTestDb } from '../helpers';
 import { v1 as uuidv1 } from 'uuid';
 import { DBOSConfig, DebugMode } from '../../src/dbos-executor';
@@ -7,7 +7,7 @@ class DebuggerCCTest extends ConfiguredInstance {
   constructor(name: string) {
     super(name);
   }
-  initialize(_ctx: InitContext): Promise<void> {
+  override initialize(): Promise<void> {
     expect(this.name).toBe('configA');
     return Promise.resolve();
   }


### PR DESCRIPTION
`InitContext` is already "optional" in the sense that you can leave that argument off your initialize methods.  You can just ask `DBOS` for stuff at init time ... make `InitContext` behave that way to prove it.