### PR TITLE
handle spaces in app name when building app db name

### DIFF
--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -166,7 +166,7 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
     globalParams.appName = appName;
   }
   if (databaseName === undefined) {
-    databaseName = appName.toLowerCase().replaceAll('-', '_');
+    databaseName = appName.toLowerCase().replaceAll('-', '_').replaceAll(' ', '_');
     if (databaseName.match(/^\d/)) {
       databaseName = '_' + databaseName; // Append an underscore if the name starts with a digit
     }
@@ -270,7 +270,7 @@ export function parseConfigFile(cliOptions?: ParseOptions): [DBOSConfigInternal,
 
   if (!isValidDBname(poolConfig.database!)) {
     throw new DBOSInitializationError(
-      `${configFilePath} specifies invalid app_db_name ${configFile.database.app_db_name}. Must be between 3 and 31 characters long and contain only lowercase letters, underscores, and digits (cannot begin with a digit).`,
+      `${configFilePath} specifies invalid app_db_name ${poolConfig.database}. Must be between 3 and 31 characters long and contain only lowercase letters, underscores, and digits (cannot begin with a digit).`,
     );
   }
 

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -273,6 +273,18 @@ describe('dbos-config', () => {
       expect(poolConfig.port).toBe(5432);
       await expect(db_wizard(poolConfig)).rejects.toThrow(DBOSInitializationError);
     });
+
+    test('constructPoolConfig correctly handles app names with spaces', () => {
+      const mockDBOSConfigYamlString = `
+        name: 'some app with spaces'
+        `;
+
+      jest.spyOn(utils, 'readFileSync').mockReturnValueOnce(mockDBOSConfigYamlString);
+
+      const [dbosConfig, _]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(mockCLIOptions);
+      const poolConfig: PoolConfig = dbosConfig.poolConfig!;
+      expect(poolConfig.database).toBe('some_app_with_spaces');
+    });
   });
 
   describe('context getConfig()', () => {


### PR DESCRIPTION
Handle the case where `constructPoolConfig` has to derive an app DB name using the provided Config.

+ improve the log entry to use the problematic name