### PR TITLE
Record get_result as a step

### DIFF
--- a/schemas/system_db_schema.ts
+++ b/schemas/system_db_schema.ts
@@ -67,7 +67,7 @@ export interface workflow_queue {
 
 export interface step_info {
   function_id: number;
-  function_name: string | null;
+  function_name: string;
   output: unknown;
   error: Error | null;
   child_workflow_id: string | null;

--- a/schemas/system_db_schema.ts
+++ b/schemas/system_db_schema.ts
@@ -67,8 +67,8 @@ export interface workflow_queue {
 
 export interface step_info {
   function_id: number;
-  function_name: string;
-  output: string;
-  error: string;
-  child_workflow_id: string;
+  function_name: string | null;
+  output: unknown;
+  error: Error | null;
+  child_workflow_id: string | null;
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -27,7 +27,6 @@ export interface DBOSLocalCtx {
   idAssignedForNextWorkflow?: string;
   queueAssignedForWorkflows?: string;
   workflowId?: string;
-  functionId?: number;
   inRecovery?: boolean;
   curStepFunctionId?: number; // If currently in a step, its function ID
   stepStatus?: StepStatus; // If currently in a step, its public status object
@@ -43,24 +42,24 @@ export interface DBOSLocalCtx {
   operationCaller?: string; // This is made to pass through the operationName to DBOS contexts, and potentially the caller span name.
 }
 
-function isWithinWorkflowCtx(ctx: DBOSLocalCtx) {
+export function isWithinWorkflowCtx(ctx: DBOSLocalCtx) {
   if (ctx.workflowId === undefined) return false;
   return true;
 }
 
-function isInStepCtx(ctx: DBOSLocalCtx) {
+export function isInStepCtx(ctx: DBOSLocalCtx) {
   if (ctx.workflowId === undefined) return false;
   if (ctx.curStepFunctionId) return true;
   return false;
 }
 
-function isInTxnCtx(ctx: DBOSLocalCtx) {
+export function isInTxnCtx(ctx: DBOSLocalCtx) {
   if (ctx.workflowId === undefined) return false;
   if (ctx.curTxFunctionId) return true;
   return false;
 }
 
-function isInWorkflowCtx(ctx: DBOSLocalCtx) {
+export function isInWorkflowCtx(ctx: DBOSLocalCtx) {
   if (!isWithinWorkflowCtx(ctx)) return false;
   if (isInStepCtx(ctx)) return false;
   if (isInTxnCtx(ctx)) return false;

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -190,7 +190,7 @@ export const OperationType = {
 export const TempWorkflowType = {
   transaction: 'transaction',
   procedure: 'procedure',
-  external: 'external',
+  step: 'step',
   send: 'send',
 } as const;
 
@@ -825,7 +825,12 @@ export class DBOSExecutor implements DBOSExecutorContext {
         const ires = await this.systemDatabase.initWorkflowStatus(internalStatus, args);
 
         if (callerFunctionID !== undefined && callerUUID !== undefined) {
-          await this.systemDatabase.recordChildWorkflow(callerUUID, workflowUUID, callerFunctionID, wf.name);
+          await this.systemDatabase.recordChildWorkflow(
+            callerUUID,
+            workflowUUID,
+            callerFunctionID,
+            internalStatus.workflowName,
+          );
         }
 
         args = ires.args;
@@ -1762,7 +1767,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
       temp_workflow,
       {
         ...params,
-        tempWfType: TempWorkflowType.external,
+        tempWfType: TempWorkflowType.step,
         tempWfName: getRegisteredMethodName(stepFn),
         tempWfClass: getRegisteredMethodClassName(stepFn),
       },
@@ -2166,7 +2171,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         ...inputs,
       );
-    } else if (nameArr[1] === TempWorkflowType.external) {
+    } else if (nameArr[1] === TempWorkflowType.step) {
       const { commInfo, clsInst } = this.getStepInfoByNames(
         wfStatus.workflowClassName,
         nameArr[2],

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -620,8 +620,8 @@ export class PostgresSystemDatabase implements SystemDatabase {
     );
 
     for (const row of rows) {
-      row.output = row !== null ? DBOSJSON.parse(row.output as string) : null;
-      row.error = row !== null ? deserializeError(DBOSJSON.parse(row.error as unknown as string)) : null;
+      row.output = row.output !== null ? DBOSJSON.parse(row.output as string) : null;
+      row.error = row.error !== null ? deserializeError(DBOSJSON.parse(row.error as unknown as string)) : null;
     }
 
     return rows;

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -619,6 +619,11 @@ export class PostgresSystemDatabase implements SystemDatabase {
       [workflowUUID],
     );
 
+    for (const row of rows) {
+      row.output = row !== null ? DBOSJSON.parse(row.output as string) : null;
+      row.error = row !== null ? deserializeError(DBOSJSON.parse(row.error as unknown as string)) : null;
+    }
+
     return rows;
   }
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -647,7 +647,6 @@ export class PostgresSystemDatabase implements SystemDatabase {
 
   async recordGetResult(resultWorkflowID: string, output: string | null, error: string | null): Promise<void> {
     const ctx = getCurrentContextStore();
-    console.log(ctx);
     // Only record getResult called in workflow functions
     if (ctx === undefined || !isInWorkflowCtx(ctx)) {
       return;

--- a/tests/oaoo.test.ts
+++ b/tests/oaoo.test.ts
@@ -318,6 +318,8 @@ describe('oaoo-tests', () => {
 
       // Set the child workflow UUID to targetUUID.
       const invokedHandle = await DBOS.startWorkflow(EventStatusOAOO, { workflowID: targetUUID }).setEventWorkflow();
+      const ires = await invokedHandle.getStatus();
+      res += '-' + ires?.status;
       try {
         if (EventStatusOAOO.wfCnt > 2) {
           await invokedHandle.getResult();
@@ -327,8 +329,6 @@ describe('oaoo-tests', () => {
         DBOS.logger.error(e);
       }
 
-      const ires = await invokedHandle.getStatus();
-      res += '-' + ires?.status;
       return res;
     }
   }

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -625,14 +625,12 @@ describe('test-list-steps', () => {
     }
 
     @DBOS.step()
-    // eslint-disable-next-line @typescript-eslint/require-await
     static async stepOne() {
-      console.log('executed stepOne');
+      return Promise.resolve(DBOS.workflowID);
     }
     @DBOS.step()
-    // eslint-disable-next-line @typescript-eslint/require-await
     static async stepTwo() {
-      console.log('executed stepTwo');
+      return Promise.resolve(DBOS.workflowID);
     }
 
     @DBOS.workflow()
@@ -809,8 +807,20 @@ describe('test-list-steps', () => {
     expect(wfsteps[0].error).toBe(null);
     expect(wfsteps[0].child_workflow_id).toBe(childID);
     expect(wfsteps[1].function_name).toBe('DBOS.getResult');
+    expect(wfsteps[1].function_id).toBe(1);
+    expect(wfsteps[1].output).toBe(childID);
+    expect(wfsteps[1].error).toBe(null);
+    expect(wfsteps[1].child_workflow_id).toBe(childID);
     expect(wfsteps[2].function_name).toBe('getStatus');
+    expect(wfsteps[2].function_id).toBe(2);
+    expect(wfsteps[2].output).toBeTruthy();
+    expect(wfsteps[2].error).toBe(null);
+    expect(wfsteps[2].child_workflow_id).toBe(null);
     expect(wfsteps[3].function_name).toBe('stepOne');
+    expect(wfsteps[3].function_id).toBe(3);
+    expect(wfsteps[3].output).toBe(wfid);
+    expect(wfsteps[3].error).toBe(null);
+    expect(wfsteps[3].child_workflow_id).toBe(null);
     expect(wfsteps[4].function_name).toBe('stepTwo');
   });
 

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -708,9 +708,10 @@ describe('test-list-steps', () => {
 
     @DBOS.workflow()
     static async directCallWorkflow() {
-      await TestListSteps.testWorkflow();
+      const childID = await TestListSteps.testWorkflow();
       await TestListSteps.stepOne();
       await TestListSteps.stepTwo();
+      return childID;
     }
 
     @DBOS.workflow()
@@ -899,11 +900,19 @@ describe('test-list-steps', () => {
   test('test-direct-call-workflow', async () => {
     const wfid = uuidv4();
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).directCallWorkflow();
-    await handle.getResult();
+    const childID = await handle.getResult();
     const wfsteps = await listWorkflowSteps(config, wfid);
     expect(wfsteps.length).toBe(4);
     expect(wfsteps[0].function_name).toBe('testWorkflow');
+    expect(wfsteps[0].function_id).toBe(0);
+    expect(wfsteps[0].output).toBe(null);
+    expect(wfsteps[0].error).toBe(null);
+    expect(wfsteps[0].child_workflow_id).toBe(childID);
     expect(wfsteps[1].function_name).toBe('DBOS.getResult');
+    expect(wfsteps[1].function_id).toBe(1);
+    expect(wfsteps[1].output).toBe(childID);
+    expect(wfsteps[1].error).toBe(null);
+    expect(wfsteps[1].child_workflow_id).toBe(childID);
     expect(wfsteps[2].function_name).toBe('stepOne');
     expect(wfsteps[3].function_name).toBe('stepTwo');
   });

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -621,6 +621,7 @@ describe('test-list-steps', () => {
       await TestListSteps.stepOne();
       await TestListSteps.stepTwo();
       await DBOS.sleep(10);
+      return DBOS.workflowID;
     }
 
     @DBOS.step()
@@ -654,16 +655,20 @@ describe('test-list-steps', () => {
     @DBOS.workflow()
     static async callChildWorkflowfirst() {
       const handle = await DBOS.startWorkflow(TestListSteps).testWorkflow();
+      const childID = await handle.getResult();
       await handle.getStatus();
       await TestListSteps.stepOne();
       await TestListSteps.stepTwo();
+      return childID;
     }
     @DBOS.workflow()
     static async callChildWorkflowMiddle() {
       await TestListSteps.stepOne();
       const handle = await DBOS.startWorkflow(TestListSteps).testWorkflow();
       await handle.getStatus();
+      const childID = await handle.getResult();
       await TestListSteps.stepTwo();
+      return childID;
     }
     @DBOS.workflow()
     static async callChildWorkflowLast() {
@@ -671,14 +676,17 @@ describe('test-list-steps', () => {
       await TestListSteps.stepTwo();
       const handle = await DBOS.startWorkflow(TestListSteps).testWorkflow();
       await handle.getStatus();
+      return await handle.getResult();
     }
 
     @DBOS.workflow()
     static async enqueueChildWorkflowFirst() {
       const handle = await DBOS.startWorkflow(TestListSteps, { queueName: queue.name }).testWorkflow();
       await handle.getStatus();
+      const childID = await handle.getResult();
       await TestListSteps.stepOne();
       await TestListSteps.stepTwo();
+      return childID;
     }
 
     @DBOS.workflow()
@@ -686,7 +694,9 @@ describe('test-list-steps', () => {
       await TestListSteps.stepOne();
       const handle = await DBOS.startWorkflow(TestListSteps, { queueName: queue.name }).testWorkflow();
       await handle.getStatus();
+      const childID = await handle.getResult();
       await TestListSteps.stepTwo();
+      return childID;
     }
 
     @DBOS.workflow()
@@ -695,6 +705,7 @@ describe('test-list-steps', () => {
       await TestListSteps.stepTwo();
       const handle = await DBOS.startWorkflow(TestListSteps, { queueName: queue.name }).testWorkflow();
       await handle.getStatus();
+      return await handle.getResult();
     }
 
     @DBOS.workflow()
@@ -761,10 +772,12 @@ describe('test-list-steps', () => {
     await handle.getStatus();
     await handle.getResult();
     const wfsteps = await listWorkflowSteps(config, wfid);
+    expect(wfsteps.length).toBe(5);
     expect(wfsteps[0].function_name).toBe('testWorkflow');
-    expect(wfsteps[1].function_name).toBe('getStatus');
-    expect(wfsteps[2].function_name).toBe('stepOne');
-    expect(wfsteps[3].function_name).toBe('stepTwo');
+    expect(wfsteps[1].function_name).toBe('DBOS.getResult');
+    expect(wfsteps[2].function_name).toBe('getStatus');
+    expect(wfsteps[3].function_name).toBe('stepOne');
+    expect(wfsteps[4].function_name).toBe('stepTwo');
   });
 
   test('test-call-child-workflow-middle', async () => {
@@ -773,11 +786,12 @@ describe('test-list-steps', () => {
     await handle.getStatus();
     await handle.getResult();
     const wfsteps = await listWorkflowSteps(config, wfid);
-    expect(wfsteps.length).toBe(4);
+    expect(wfsteps.length).toBe(5);
     expect(wfsteps[0].function_name).toBe('stepOne');
     expect(wfsteps[1].function_name).toBe('testWorkflow');
     expect(wfsteps[2].function_name).toBe('getStatus');
-    expect(wfsteps[3].function_name).toBe('stepTwo');
+    expect(wfsteps[3].function_name).toBe('DBOS.getResult');
+    expect(wfsteps[4].function_name).toBe('stepTwo');
   });
 
   test('test-call-child-workflow-last', async () => {
@@ -786,11 +800,12 @@ describe('test-list-steps', () => {
     await handle.getStatus();
     await handle.getResult();
     const wfsteps = await listWorkflowSteps(config, wfid);
-    expect(wfsteps.length).toBe(4);
+    expect(wfsteps.length).toBe(5);
     expect(wfsteps[0].function_name).toBe('stepOne');
     expect(wfsteps[1].function_name).toBe('stepTwo');
     expect(wfsteps[2].function_name).toBe('testWorkflow');
     expect(wfsteps[3].function_name).toBe('getStatus');
+    expect(wfsteps[4].function_name).toBe('DBOS.getResult');
   });
 
   test('test-queue-child-workflow-first', async () => {
@@ -799,11 +814,12 @@ describe('test-list-steps', () => {
     await handle.getStatus();
     await handle.getResult();
     const wfsteps = await listWorkflowSteps(config, wfid);
-    expect(wfsteps.length).toBe(4);
+    expect(wfsteps.length).toBe(5);
     expect(wfsteps[0].function_name).toBe('testWorkflow');
     expect(wfsteps[1].function_name).toBe('getStatus');
-    expect(wfsteps[2].function_name).toBe('stepOne');
-    expect(wfsteps[3].function_name).toBe('stepTwo');
+    expect(wfsteps[2].function_name).toBe('DBOS.getResult');
+    expect(wfsteps[3].function_name).toBe('stepOne');
+    expect(wfsteps[4].function_name).toBe('stepTwo');
   });
 
   test('test-queue-child-workflow-middle', async () => {
@@ -812,11 +828,12 @@ describe('test-list-steps', () => {
     await handle.getStatus();
     await handle.getResult();
     const wfsteps = await listWorkflowSteps(config, wfid);
-    expect(wfsteps.length).toBe(4);
+    expect(wfsteps.length).toBe(5);
     expect(wfsteps[0].function_name).toBe('stepOne');
     expect(wfsteps[1].function_name).toBe('testWorkflow');
     expect(wfsteps[2].function_name).toBe('getStatus');
-    expect(wfsteps[3].function_name).toBe('stepTwo');
+    expect(wfsteps[3].function_name).toBe('DBOS.getResult');
+    expect(wfsteps[4].function_name).toBe('stepTwo');
   });
 
   test('test-queue-child-workflow-last', async () => {
@@ -825,11 +842,12 @@ describe('test-list-steps', () => {
     await handle.getStatus();
     await handle.getResult();
     const wfsteps = await listWorkflowSteps(config, wfid);
-    expect(wfsteps.length).toBe(4);
+    expect(wfsteps.length).toBe(5);
     expect(wfsteps[0].function_name).toBe('stepOne');
     expect(wfsteps[1].function_name).toBe('stepTwo');
     expect(wfsteps[2].function_name).toBe('testWorkflow');
     expect(wfsteps[3].function_name).toBe('getStatus');
+    expect(wfsteps[4].function_name).toBe('DBOS.getResult');
   });
 
   test('test-child-rerun', async () => {

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -680,8 +680,8 @@ describe('test-list-steps', () => {
     @DBOS.workflow()
     static async enqueueChildWorkflowFirst() {
       const handle = await DBOS.startWorkflow(TestListSteps, { queueName: queue.name }).testWorkflow();
-      await handle.getStatus();
       const childID = await handle.getResult();
+      await handle.getStatus();
       await TestListSteps.stepOne();
       await TestListSteps.stepTwo();
       return childID;
@@ -797,7 +797,6 @@ describe('test-list-steps', () => {
   test('test-call-child-workflow-first', async () => {
     const wfid = uuidv4();
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).callChildWorkflowfirst();
-    await handle.getStatus();
     const childID = await handle.getResult();
     const wfsteps = await listWorkflowSteps(config, wfid);
     expect(wfsteps.length).toBe(5);
@@ -827,7 +826,6 @@ describe('test-list-steps', () => {
   test('test-call-child-workflow-middle', async () => {
     const wfid = uuidv4();
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).callChildWorkflowMiddle();
-    await handle.getStatus();
     await handle.getResult();
     const wfsteps = await listWorkflowSteps(config, wfid);
     expect(wfsteps.length).toBe(5);
@@ -841,7 +839,6 @@ describe('test-list-steps', () => {
   test('test-call-child-workflow-last', async () => {
     const wfid = uuidv4();
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).callChildWorkflowLast();
-    await handle.getStatus();
     await handle.getResult();
     const wfsteps = await listWorkflowSteps(config, wfid);
     expect(wfsteps.length).toBe(5);
@@ -855,13 +852,20 @@ describe('test-list-steps', () => {
   test('test-queue-child-workflow-first', async () => {
     const wfid = uuidv4();
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).enqueueChildWorkflowFirst();
-    await handle.getStatus();
-    await handle.getResult();
+    const childID = await handle.getResult();
     const wfsteps = await listWorkflowSteps(config, wfid);
     expect(wfsteps.length).toBe(5);
     expect(wfsteps[0].function_name).toBe('testWorkflow');
-    expect(wfsteps[1].function_name).toBe('getStatus');
-    expect(wfsteps[2].function_name).toBe('DBOS.getResult');
+    expect(wfsteps[0].function_id).toBe(0);
+    expect(wfsteps[0].output).toBe(null);
+    expect(wfsteps[0].error).toBe(null);
+    expect(wfsteps[0].child_workflow_id).toBe(childID);
+    expect(wfsteps[1].function_name).toBe('DBOS.getResult');
+    expect(wfsteps[1].function_id).toBe(1);
+    expect(wfsteps[1].output).toBe(childID);
+    expect(wfsteps[1].error).toBe(null);
+    expect(wfsteps[1].child_workflow_id).toBe(childID);
+    expect(wfsteps[2].function_name).toBe('getStatus');
     expect(wfsteps[3].function_name).toBe('stepOne');
     expect(wfsteps[4].function_name).toBe('stepTwo');
   });
@@ -869,7 +873,6 @@ describe('test-list-steps', () => {
   test('test-queue-child-workflow-middle', async () => {
     const wfid = uuidv4();
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).enqueueChildWorkflowMiddle();
-    await handle.getStatus();
     await handle.getResult();
     const wfsteps = await listWorkflowSteps(config, wfid);
     expect(wfsteps.length).toBe(5);
@@ -883,7 +886,6 @@ describe('test-list-steps', () => {
   test('test-queue-child-workflow-last', async () => {
     const wfid = uuidv4();
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).enqueueChildWorkflowLast();
-    await handle.getStatus();
     await handle.getResult();
     const wfsteps = await listWorkflowSteps(config, wfid);
     expect(wfsteps.length).toBe(5);
@@ -897,7 +899,6 @@ describe('test-list-steps', () => {
   test('test-direct-call-workflow', async () => {
     const wfid = uuidv4();
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).directCallWorkflow();
-    await handle.getStatus();
     await handle.getResult();
     const wfsteps = await listWorkflowSteps(config, wfid);
     expect(wfsteps.length).toBe(4);

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -925,6 +925,9 @@ describe('test-list-steps', () => {
     let wfsteps = await listWorkflowSteps(config, wfid);
     expect(wfsteps.length).toBe(1);
     expect(wfsteps[0].function_name).toBe('failingStep');
+    expect(wfsteps[0].output).toBe(null);
+    expect(wfsteps[0].error).toBeInstanceOf(Error);
+    expect(wfsteps[0].child_workflow_id).toBe(null);
     // Test starting a failing step
     wfid = uuidv4();
     handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).startFailingStep();
@@ -932,7 +935,13 @@ describe('test-list-steps', () => {
     wfsteps = await listWorkflowSteps(config, wfid);
     expect(wfsteps.length).toBe(2);
     expect(wfsteps[0].function_name).toBe('temp_workflow-step-failingStep');
+    expect(wfsteps[0].output).toBe(null);
+    expect(wfsteps[0].error).toBe(null);
+    expect(wfsteps[0].child_workflow_id).toBe(`${wfid}-0`);
     expect(wfsteps[1].function_name).toBe('DBOS.getResult');
+    expect(wfsteps[1].output).toBe(null);
+    expect(wfsteps[1].error).toBeInstanceOf(Error);
+    expect(wfsteps[1].child_workflow_id).toBe(`${wfid}-0`);
     // Test enqueueing a failing step
     wfid = uuidv4();
     handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).enqueueFailingStep();
@@ -940,7 +949,13 @@ describe('test-list-steps', () => {
     wfsteps = await listWorkflowSteps(config, wfid);
     expect(wfsteps.length).toBe(2);
     expect(wfsteps[0].function_name).toBe('temp_workflow-step-failingStep');
+    expect(wfsteps[0].output).toBe(null);
+    expect(wfsteps[0].error).toBe(null);
+    expect(wfsteps[0].child_workflow_id).toBe(`${wfid}-0`);
     expect(wfsteps[1].function_name).toBe('DBOS.getResult');
+    expect(wfsteps[1].output).toBe(null);
+    expect(wfsteps[1].error).toBeInstanceOf(Error);
+    expect(wfsteps[1].child_workflow_id).toBe(`${wfid}-0`);
   });
 
   test('test-child-rerun', async () => {

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -709,6 +709,13 @@ describe('test-list-steps', () => {
     }
 
     @DBOS.workflow()
+    static async directCallWorkflow() {
+      await TestListSteps.testWorkflow();
+      await TestListSteps.stepOne();
+      await TestListSteps.stepTwo();
+    }
+
+    @DBOS.workflow()
     // eslint-disable-next-line  @typescript-eslint/require-await
     static async childWorkflowWithCounter(id: string) {
       return id;
@@ -848,6 +855,19 @@ describe('test-list-steps', () => {
     expect(wfsteps[2].function_name).toBe('testWorkflow');
     expect(wfsteps[3].function_name).toBe('getStatus');
     expect(wfsteps[4].function_name).toBe('DBOS.getResult');
+  });
+
+  test('test-direct-call-workflow', async () => {
+    const wfid = uuidv4();
+    const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).directCallWorkflow();
+    await handle.getStatus();
+    await handle.getResult();
+    const wfsteps = await listWorkflowSteps(config, wfid);
+    expect(wfsteps.length).toBe(4);
+    expect(wfsteps[0].function_name).toBe('testWorkflow');
+    expect(wfsteps[1].function_name).toBe('DBOS.getResult');
+    expect(wfsteps[2].function_name).toBe('stepOne');
+    expect(wfsteps[3].function_name).toBe('stepTwo');
   });
 
   test('test-child-rerun', async () => {

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -907,7 +907,7 @@ describe('test-list-steps', () => {
     await expect(handle.getResult()).rejects.toThrow(new Error('fail'));
     wfsteps = await listWorkflowSteps(config, wfid);
     expect(wfsteps.length).toBe(2);
-    expect(wfsteps[0].function_name).toBe('temp_workflow');
+    expect(wfsteps[0].function_name).toBe('temp_workflow-step-failingStep');
     expect(wfsteps[1].function_name).toBe('DBOS.getResult');
     // Test enqueueing a failing step
     wfid = uuidv4();
@@ -915,7 +915,7 @@ describe('test-list-steps', () => {
     await expect(handle.getResult()).rejects.toThrow(new Error('fail'));
     wfsteps = await listWorkflowSteps(config, wfid);
     expect(wfsteps.length).toBe(2);
-    expect(wfsteps[0].function_name).toBe('temp_workflow');
+    expect(wfsteps[0].function_name).toBe('temp_workflow-step-failingStep');
     expect(wfsteps[1].function_name).toBe('DBOS.getResult');
   });
 

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -800,10 +800,14 @@ describe('test-list-steps', () => {
     const wfid = uuidv4();
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).callChildWorkflowfirst();
     await handle.getStatus();
-    await handle.getResult();
+    const childID = await handle.getResult();
     const wfsteps = await listWorkflowSteps(config, wfid);
     expect(wfsteps.length).toBe(5);
     expect(wfsteps[0].function_name).toBe('testWorkflow');
+    expect(wfsteps[0].function_id).toBe(0);
+    expect(wfsteps[0].output).toBe(null);
+    expect(wfsteps[0].error).toBe(null);
+    expect(wfsteps[0].child_workflow_id).toBe(childID);
     expect(wfsteps[1].function_name).toBe('DBOS.getResult');
     expect(wfsteps[2].function_name).toBe('getStatus');
     expect(wfsteps[3].function_name).toBe('stepOne');


### PR DESCRIPTION
- Record `get_result` as a step (`DBOS.getResult`).
- Record child workflows in the `operation_outputs` table with the same name as in the `workflow_status` table.
- Eliminate some more uses of "external" in favor of "step".
- `getWorkflowSteps` should return deserialized results, to be consistent with the workflow introspection operations.