### PR TITLE
db connect returns dbString + remove rollback and local commands

### DIFF
--- a/packages/dbos-cloud/applications/secrets.ts
+++ b/packages/dbos-cloud/applications/secrets.ts
@@ -34,12 +34,12 @@ export async function createSecret(
   }
 
   if (!secretName) {
-    logger.error('Secret name is required.');
+    logger.error('Variable name is required.');
     return 1;
   }
 
   if (!secretValue) {
-    logger.error('Secret value is required.');
+    logger.error('Variable value is required.');
     return 1;
   }
 
@@ -68,11 +68,11 @@ export async function postCreateSecret(
     );
 
     if (res.status !== 200) {
-      logger.error(`Failed to create secret for application ${request.ApplicationName}`);
+      logger.error(`Failed to create variable for application ${request.ApplicationName}`);
       return 1;
     }
 
-    logger.info(`Secret ${request.SecretName} successfully updated!`);
+    logger.info(`Variable ${request.SecretName} successfully updated!`);
     return 0;
   } catch (e) {
     const errorLabel = `Failed to retrieve versions for application ${request.ApplicationName}`;
@@ -95,7 +95,7 @@ export async function importSecrets(host: string, appName: string | undefined, e
     return 1;
   }
 
-  logger.info(`Importing secrets from ${envPath}`);
+  logger.info(`Importing variables from ${envPath}`);
 
   const envConfig = readFileSync(envPath, 'utf-8');
 
@@ -112,7 +112,7 @@ export async function importSecrets(host: string, appName: string | undefined, e
   for (const secret of Object.keys(parsed)) {
     const expandedValue = expandedEnv[secret];
     if (expandedValue === undefined) {
-      logger.error(`No value found for secret ${secret}`);
+      logger.error(`No value found for variable ${secret}`);
       return 1;
     }
     const request = { ApplicationName: appName, SecretName: secret, ClearSecretValue: expandedValue };
@@ -148,7 +148,7 @@ export async function listSecrets(host: string, appName: string | undefined, jso
     );
 
     if (res.status !== 200) {
-      logger.error(`Failed to list secret for application ${appName}`);
+      logger.error(`Failed to list variables for application ${appName}`);
       return 1;
     }
 

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -219,18 +219,6 @@ applicationCommands
   );
 
 applicationCommands
-  .command('rollback')
-  .description('Deploy this application to the cloud and run associated database rollback commands')
-  .argument('[string]', 'application name (Default: name from package.json)')
-  .action(async (appName: string | undefined) => {
-    console.warn(
-      `dbos-cloud app rollback is deprecated. Please use 'dbos-cloud db connect' instead and run rollback commands locally`,
-    );
-    const exitCode = await deployAppCode(DBOSCloudHost, true, null, false, null, appName);
-    process.exit(exitCode);
-  });
-
-applicationCommands
   .command('change-database-instance')
   .description("Change this application's database instance and redeploy it")
   .argument('[string]', 'application name (Default: name from package.json)')
@@ -470,18 +458,9 @@ databaseCommands
   .description(`Load cloud database connection information into ${dbosConfigFilePath}`)
   .argument('[name]', 'database instance name')
   .option('-W, --password <string>', 'Specify the database user password')
-  .action(async (dbname: string | undefined, options: { password: string | undefined }) => {
-    const exitCode = await connect(DBOSCloudHost, dbname, options.password, false);
-    process.exit(exitCode);
-  });
-
-databaseCommands
-  .command('local')
-  .description(`Configure ${dbosConfigFilePath} to use a DBOS Cloud database for local development`)
-  .argument('[name]', 'database instance name')
-  .option('-W, --password <string>', 'Specify the database user password')
-  .action(async (dbname: string | undefined, options: { password: string | undefined }) => {
-    const exitCode = await connect(DBOSCloudHost, dbname, options.password, true);
+  .option('-S, --show-password', 'Show the password in the output')
+  .action(async (dbname: string | undefined, options: { password: string | undefined; showPassword: boolean }) => {
+    const exitCode = await connect(DBOSCloudHost, dbname, options.password, options.showPassword);
     process.exit(exitCode);
   });
 

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -294,15 +294,16 @@ applicationCommands
   });
 
 const secretsCommands = applicationCommands
-  .command('secret')
+  .command('env')
+  .alias('environment')
   .alias('secrets')
   .alias('sec')
-  .alias('env')
-  .description('Manage your application environment and secrets');
+  .alias('secret')
+  .description('Manage your application environment variables');
 
 secretsCommands
   .command('create')
-  .description('Create a secret for this application')
+  .description('Create an environment variable for this application')
   .argument('[string]', 'application name (Default: name from package.json)')
   .requiredOption('-s, --name <string>', 'Specify the name of the variable to create')
   .requiredOption('-v, --value <string>', 'Specify the value of the variable')
@@ -313,7 +314,7 @@ secretsCommands
 
 secretsCommands
   .command('import')
-  .description('Import environment variables and secrets from a dotenv file')
+  .description('Import environment variables from a dotenv file')
   .argument('[string]', 'application name (Default: name from package.json)')
   .requiredOption('-d, --dotenv <string>', 'Path to a dotenv file')
   .action(async (appName: string | undefined, options: { dotenv: string }) => {
@@ -323,7 +324,7 @@ secretsCommands
 
 secretsCommands
   .command('list')
-  .description('List secrets for this application')
+  .description('List environment variables for this application')
   .argument('[string]', 'application name (Default: name from package.json)')
   .option('--json', 'Emit JSON output')
   .action(async (appName: string | undefined, options: { json: boolean }) => {

--- a/packages/dbos-cloud/databases/databases.ts
+++ b/packages/dbos-cloud/databases/databases.ts
@@ -420,37 +420,24 @@ export async function connect(
   }
 
   try {
-    if (!existsSync(dbosConfigFilePath)) {
-      logger.error(`Error: ${dbosConfigFilePath} not found`);
-      return 1;
-    }
-
-    const backupConfigFilePath = `dbos-config.yaml.${Date.now()}.bak`;
-    logger.info(`Backing up ${dbosConfigFilePath} to ${backupConfigFilePath}`);
-    copyFileSync(dbosConfigFilePath, backupConfigFilePath);
-
     logger.info('Retrieving cloud database info...');
     const userDBInfo = await getUserDBInfo(host, dbName, userCredentials);
     const isSupabase = userDBInfo.SupabaseReference !== null;
 
-    const prompt = promptSync({ sigint: true });
-    if (!password) {
-      if (isSupabase) {
-        password = prompt('Enter Supabase Database Password: ', { echo: '*' });
-      } else {
-        password = prompt('Enter Database Password: ', { echo: '*' });
+    if (showPassword) {
+      const prompt = promptSync({ sigint: true });
+      if (!password) {
+        if (isSupabase) {
+          password = prompt('Enter Supabase Database Password: ', { echo: '*' });
+        } else {
+          password = prompt('Enter Database Password: ', { echo: '*' });
+        }
       }
     }
 
     const databaseUsername = isSupabase ? `postgres.${userDBInfo.SupabaseReference}` : userDBInfo.DatabaseUsername;
 
-    console.log(`Postgres Instance Name: ${userDBInfo.PostgresInstanceName}`);
-    console.log(`Host Name: ${userDBInfo.HostName}`);
-    console.log(`Port: ${userDBInfo.Port}`);
-    console.log(`Database Username: ${databaseUsername}`);
-    console.log(`Status: ${userDBInfo.Status}`);
-
-    const displayPassword = showPassword ? password : password.replace(/./g, '*');
+    const displayPassword = showPassword ? password : '***';
     const dbString = `postgresql://${databaseUsername}:${displayPassword}@${userDBInfo.HostName}:${userDBInfo.Port}/${
       userDBInfo.PostgresInstanceName
     }`;

--- a/packages/dbos-cloud/databases/databases.ts
+++ b/packages/dbos-cloud/databases/databases.ts
@@ -9,7 +9,6 @@ import {
   DBOSCloudCredentials,
 } from '../cloudutils.js';
 import { Logger } from 'winston';
-import { ConfigFile, loadConfigFile, writeConfigFile } from '../configutils.js';
 import { copyFileSync, existsSync } from 'fs';
 import { UserDBInstance } from '../applications/types.js';
 import { input, select } from '@inquirer/prompts';

--- a/packages/dbos-cloud/databases/databases.ts
+++ b/packages/dbos-cloud/databases/databases.ts
@@ -409,7 +409,7 @@ export async function connect(
   host: string,
   dbName: string | undefined,
   password: string | undefined,
-  local_suffix: boolean,
+  showPassword: boolean,
 ) {
   const logger = getLogger();
 
@@ -451,15 +451,11 @@ export async function connect(
     console.log(`Database Username: ${databaseUsername}`);
     console.log(`Status: ${userDBInfo.Status}`);
 
-    logger.info(`Loading cloud database connection information into ${dbosConfigFilePath}...`);
-    const config: ConfigFile = loadConfigFile(dbosConfigFilePath);
-    config.database.hostname = userDBInfo.HostName;
-    config.database.port = userDBInfo.Port;
-    config.database.username = databaseUsername;
-    config.database.password = password;
-    config.database.local_suffix = local_suffix;
-    writeConfigFile(config, dbosConfigFilePath);
-    logger.info(`Cloud database connection information loaded into ${dbosConfigFilePath}`);
+    const displayPassword = showPassword ? password : password.replace(/./g, '*');
+    const dbString = `postgresql://${databaseUsername}:${displayPassword}@${userDBInfo.HostName}:${userDBInfo.Port}/${
+      userDBInfo.PostgresInstanceName
+    }`;
+    console.log(dbString);
     return 0;
   } catch (e) {
     const errorLabel = `Failed to retrieve database record ${dbName}`;

--- a/packages/dbos-cloud/databases/databases.ts
+++ b/packages/dbos-cloud/databases/databases.ts
@@ -5,11 +5,9 @@ import {
   getCloudCredentials,
   getLogger,
   sleepms,
-  dbosConfigFilePath,
   DBOSCloudCredentials,
 } from '../cloudutils.js';
 import { Logger } from 'winston';
-import { copyFileSync, existsSync } from 'fs';
 import { UserDBInstance } from '../applications/types.js';
 import { input, select } from '@inquirer/prompts';
 import promptSync from 'prompt-sync';


### PR DESCRIPTION
- Remove app rollback command
- Remove db local command
- Have db connect return a db string (password hidden by default) instead of modifying dbos-config.yaml
- Update secrets vocabulary to use "environment variables". See screenshots.

![Screenshot 2025-04-04 at 11 59 39](https://github.com/user-attachments/assets/63333e4c-bb86-4185-8148-c189ce6b1dc7)
![Screenshot 2025-04-04 at 11 55 00](https://github.com/user-attachments/assets/2d06327b-9465-4dd2-a2af-b37a9fca3480)
![Screenshot 2025-04-04 at 11 54 23](https://github.com/user-attachments/assets/2a0b63fd-62af-413b-9aeb-5bc564b01363)


![Screenshot 2025-04-04 at 11 42 01](https://github.com/user-attachments/assets/207e97e3-d669-4ce9-a172-5b81d4dc854a)
