### PR TITLE
Remove buffers

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -22,7 +22,6 @@ import {
   WorkflowContextImpl,
   WorkflowStatus,
   StatusString,
-  BufferedResult,
   ContextFreeFunction,
   GetWorkflowQueueInput,
   GetWorkflowQueueOutput,
@@ -234,13 +233,9 @@ export class DBOSExecutor implements DBOSExecutorContext {
   readonly procedureInfoMap: Map<string, ProcedureRegInfo> = new Map();
   readonly registeredOperations: Array<MethodRegistrationBase> = [];
   readonly pendingWorkflowMap: Map<string, Promise<unknown>> = new Map(); // Map from workflowUUID to workflow promise
-  readonly workflowResultBuffer: Map<string, Map<number, BufferedResult>> = new Map(); // Map from workflowUUID to its remaining result buffer.
   readonly workflowCancellationMap: Map<string, boolean> = new Map(); // Map from workflowUUID to its cancellation status.
 
   readonly telemetryCollector: TelemetryCollector;
-  readonly flushBufferIntervalMs: number = 1000;
-  readonly flushBufferID: NodeJS.Timeout;
-  isFlushingBuffers = false;
 
   static readonly defaultNotificationTimeoutSec = 60;
 
@@ -323,14 +318,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
         this.config.sysDbPoolSize,
       );
     }
-
-    this.flushBufferID = setInterval(() => {
-      if (!this.isDebugging && !this.isFlushingBuffers) {
-        this.isFlushingBuffers = true;
-        void this.flushWorkflowBuffers();
-      }
-    }, this.flushBufferIntervalMs);
-    this.logger.debug('Started workflow status buffer worker');
 
     this.initialized = false;
     DBOSExecutor.globalInstance = this;
@@ -581,15 +568,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
         this.logger.info('Waiting for pending workflows to finish.');
         await Promise.allSettled(this.pendingWorkflowMap.values());
       }
-      clearInterval(this.flushBufferID);
-      if (!this.isDebugging && !this.isFlushingBuffers) {
-        // Don't flush the buffers if we're already flushing them in the background.
-        await this.flushWorkflowBuffers();
-      }
-      while (this.isFlushingBuffers) {
-        this.logger.info('Waiting for result buffers to be exported.');
-        await sleepms(1000);
-      }
       await this.systemDatabase.destroy();
       if (this.userDatabase) {
         await this.userDatabase.destroy();
@@ -793,50 +771,44 @@ export class DBOSExecutor implements DBOSExecutorContext {
 
     let status: string | undefined = undefined;
 
-    // Synchronously set the workflow's status to PENDING and record workflow inputs (for non single-transaction workflows).
+    // Synchronously set the workflow's status to PENDING and record workflow inputs.
     // We have to do it for all types of workflows because operation_outputs table has a foreign key constraint on workflow status table.
-    if (
-      (wCtxt.tempWfOperationType !== TempWorkflowType.transaction &&
-        wCtxt.tempWfOperationType !== TempWorkflowType.procedure) ||
-      params.queueName !== undefined
-    ) {
-      if (this.isDebugging) {
-        const wfStatus = await this.systemDatabase.getWorkflowStatus(workflowUUID);
-        const wfInputs = await this.systemDatabase.getWorkflowInputs<T>(workflowUUID);
-        if (!wfStatus || !wfInputs) {
-          throw new DBOSDebuggerError(`Failed to find inputs for workflow UUID ${workflowUUID}`);
-        }
-
-        // Make sure we use the same input.
-        if (DBOSJSON.stringify(args) !== DBOSJSON.stringify(wfInputs)) {
-          throw new DBOSDebuggerError(
-            `Detected different inputs for workflow UUID ${workflowUUID}.\n Received: ${DBOSJSON.stringify(args)}\n Original: ${DBOSJSON.stringify(wfInputs)}`,
-          );
-        }
-        status = wfStatus.status;
-      } else {
-        // TODO: Make this transactional (and with the queue step below)
-        if (callerFunctionID !== undefined && callerUUID !== undefined) {
-          const child_id = await this.systemDatabase.checkChildWorkflow(callerUUID, callerFunctionID);
-          if (child_id !== null) {
-            return new RetrievedHandle(this.systemDatabase, child_id, callerUUID, callerFunctionID);
-          }
-        }
-        const ires = await this.systemDatabase.initWorkflowStatus(internalStatus, args);
-
-        if (callerFunctionID !== undefined && callerUUID !== undefined) {
-          await this.systemDatabase.recordChildWorkflow(
-            callerUUID,
-            workflowUUID,
-            callerFunctionID,
-            internalStatus.workflowName,
-          );
-        }
-
-        args = ires.args;
-        status = ires.status;
-        await debugTriggerPoint(DEBUG_TRIGGER_WORKFLOW_ENQUEUE);
+    if (this.isDebugging) {
+      const wfStatus = await this.systemDatabase.getWorkflowStatus(workflowUUID);
+      const wfInputs = await this.systemDatabase.getWorkflowInputs<T>(workflowUUID);
+      if (!wfStatus || !wfInputs) {
+        throw new DBOSDebuggerError(`Failed to find inputs for workflow UUID ${workflowUUID}`);
       }
+
+      // Make sure we use the same input.
+      if (DBOSJSON.stringify(args) !== DBOSJSON.stringify(wfInputs)) {
+        throw new DBOSDebuggerError(
+          `Detected different inputs for workflow UUID ${workflowUUID}.\n Received: ${DBOSJSON.stringify(args)}\n Original: ${DBOSJSON.stringify(wfInputs)}`,
+        );
+      }
+      status = wfStatus.status;
+    } else {
+      // TODO: Make this transactional (and with the queue step below)
+      if (callerFunctionID !== undefined && callerUUID !== undefined) {
+        const child_id = await this.systemDatabase.checkChildWorkflow(callerUUID, callerFunctionID);
+        if (child_id !== null) {
+          return new RetrievedHandle(this.systemDatabase, child_id, callerUUID, callerFunctionID);
+        }
+      }
+      const ires = await this.systemDatabase.initWorkflowStatus(internalStatus, args);
+
+      if (callerFunctionID !== undefined && callerUUID !== undefined) {
+        await this.systemDatabase.recordChildWorkflow(
+          callerUUID,
+          workflowUUID,
+          callerFunctionID,
+          internalStatus.workflowName,
+        );
+      }
+
+      args = ires.args;
+      status = ires.status;
+      await debugTriggerPoint(DEBUG_TRIGGER_WORKFLOW_ENQUEUE);
     }
 
     const runWorkflow = async () => {
@@ -879,7 +851,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
           await this.systemDatabase.dequeueWorkflow(workflowUUID, this.#getQueueByName(internalStatus.queueName));
         }
         if (!this.isDebugging) {
-          this.systemDatabase.bufferWorkflowOutput(workflowUUID, internalStatus);
+          await this.systemDatabase.recordWorkflowOutput(workflowUUID, internalStatus);
         }
         wCtxt.span.setStatus({ code: SpanStatusCode.OK });
       } catch (err) {
@@ -922,20 +894,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
         }
       } finally {
         this.tracer.endSpan(wCtxt.span);
-        if (
-          wCtxt.tempWfOperationType === TempWorkflowType.transaction ||
-          wCtxt.tempWfOperationType === TempWorkflowType.procedure
-        ) {
-          // For single-transaction workflows, asynchronously record inputs.
-          // We must buffer inputs after workflow status is buffered/flushed because workflow_inputs table has a foreign key reference to the workflow_status table.
-          if (!this.isDebugging) {
-            this.systemDatabase.bufferWorkflowInputs(workflowUUID, args);
-          }
-        }
-      }
-      // Asynchronously flush the result buffer.
-      if (wCtxt.resultBuffer.size > 0) {
-        this.workflowResultBuffer.set(wCtxt.workflowUUID, wCtxt.resultBuffer);
       }
       return result;
     };
@@ -1089,74 +1047,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
     }
   }
 
-  /**
-   * Write all entries in the workflow result buffer to the database.
-   * If it encounters a primary key error, this indicates a concurrent execution with the same UUID, so throw an DBOSError.
-   */
-  async #flushResultBuffer(
-    query: QueryFunction,
-    resultBuffer: Map<number, BufferedResult>,
-    workflowUUID: string,
-    isKeyConflict: (error: unknown) => boolean,
-  ): Promise<void> {
-    const funcIDs = Array.from(resultBuffer.keys());
-    if (funcIDs.length === 0) {
-      return;
-    }
-    if (this.isDebugging) {
-      throw new DBOSDebuggerError('Cannot flush result buffer in debug mode.');
-    }
-    funcIDs.sort();
-    try {
-      let sqlStmt =
-        'INSERT INTO dbos.transaction_outputs (workflow_uuid, function_id, output, error, txn_id, txn_snapshot, created_at) VALUES ';
-      let paramCnt = 1;
-      const values: any[] = [];
-      for (const funcID of funcIDs) {
-        // Capture output and also transaction snapshot information.
-        // Initially, no txn_id because no queries executed.
-        const recorded = resultBuffer.get(funcID);
-        const output = recorded!.output;
-        const txnSnapshot = recorded!.txn_snapshot;
-        const createdAt = recorded!.created_at!;
-        if (paramCnt > 1) {
-          sqlStmt += ', ';
-        }
-        sqlStmt += `($${paramCnt++}, $${paramCnt++}, $${paramCnt++}, $${paramCnt++}, null, $${paramCnt++}, $${paramCnt++})`;
-        values.push(workflowUUID, funcID, DBOSJSON.stringify(output), DBOSJSON.stringify(null), txnSnapshot, createdAt);
-      }
-      this.logger.debug(sqlStmt);
-      await query(sqlStmt, values);
-    } catch (error) {
-      if (isKeyConflict(error)) {
-        // Serialization and primary key conflict (Postgres).
-        throw new DBOSWorkflowConflictUUIDError(workflowUUID);
-      } else {
-        throw error;
-      }
-    }
-  }
-
-  flushResultBuffer(
-    client: UserDatabaseClient,
-    resultBuffer: Map<number, BufferedResult>,
-    workflowUUID: string,
-  ): Promise<void> {
-    const func = <T>(sql: string, args: unknown[]) => this.userDatabase.queryWithClient<T>(client, sql, ...args);
-    return this.#flushResultBuffer(func, resultBuffer, workflowUUID, (error) =>
-      this.userDatabase.isKeyConflictError(error),
-    );
-  }
-
-  #flushResultBufferProc(
-    client: PoolClient,
-    resultBuffer: Map<number, BufferedResult>,
-    workflowUUID: string,
-  ): Promise<void> {
-    const func = <T>(sql: string, args: unknown[]) => client.query(sql, args).then((v) => v.rows as T[]);
-    return this.#flushResultBuffer(func, resultBuffer, workflowUUID, pgNodeIsKeyConflictError);
-  }
-
   async transaction<T extends unknown[], R>(txn: Transaction<T, R>, params: WorkflowParams, ...args: T): Promise<R> {
     return await (await this.startTransactionTempWF(txn, params, undefined, undefined, ...args)).getResult();
   }
@@ -1202,7 +1092,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
       throw new DBOSWorkflowCancelledError(wfCtx.workflowUUID);
     }
 
-    const readOnly = txnInfo.config.readOnly ?? false;
     let retryWaitMillis = 1;
     const backoffFactor = 1.5;
     const maxRetryWaitMs = 2000; // Maximum wait 2 seconds.
@@ -1215,7 +1104,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
         authenticatedUser: wfCtx.authenticatedUser,
         assumedRole: wfCtx.assumedRole,
         authenticatedRoles: wfCtx.authenticatedRoles,
-        readOnly: readOnly,
         isolationLevel: txnInfo.config.isolationLevel,
       },
       wfCtx.span,
@@ -1274,11 +1162,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
           );
         }
 
-        // For non-read-only transactions, flush the result buffer.
-        if (!this.isDebugging && !readOnly) {
-          await this.flushResultBuffer(client, wfCtx.resultBuffer, wfCtx.workflowUUID);
-        }
-
         // Execute the user's transaction.
         const result = await (async function () {
           try {
@@ -1315,36 +1198,25 @@ export class DBOSExecutor implements DBOSExecutorContext {
         }
 
         // Record the execution, commit, and return.
-        if (readOnly) {
-          // Buffer the output of read-only transactions instead of synchronously writing it.
-          const readOutput: BufferedResult = {
-            output: result,
-            txn_snapshot: txn_snapshot,
-            created_at: Date.now(),
-          };
-          wfCtx.resultBuffer.set(funcId, readOutput);
-        } else {
-          try {
-            // Synchronously record the output of write transactions and obtain the transaction ID.
-            const pg_txn_id = await this.#recordOutput(
-              queryFunc,
-              wfCtx.workflowUUID,
-              funcId,
-              txn_snapshot,
-              result,
-              (error) => this.userDatabase.isKeyConflictError(error),
+        try {
+          // Synchronously record the output of write transactions and obtain the transaction ID.
+          const pg_txn_id = await this.#recordOutput(
+            queryFunc,
+            wfCtx.workflowUUID,
+            funcId,
+            txn_snapshot,
+            result,
+            (error) => this.userDatabase.isKeyConflictError(error),
+          );
+          tCtxt.span.setAttribute('pg_txn_id', pg_txn_id);
+        } catch (error) {
+          if (this.userDatabase.isFailedSqlTransactionError(error)) {
+            this.logger.error(
+              `Postgres aborted the ${txn.name} @DBOS.transaction of Workflow ${workflowUUID}, but the function did not raise an exception.  Please ensure that the @DBOS.transaction method raises an exception if the database transaction is aborted.`,
             );
-            tCtxt.span.setAttribute('pg_txn_id', pg_txn_id);
-            wfCtx.resultBuffer.clear();
-          } catch (error) {
-            if (this.userDatabase.isFailedSqlTransactionError(error)) {
-              this.logger.error(
-                `Postgres aborted the ${txn.name} @Transaction of Workflow ${workflowUUID}, but the function did not raise an exception.  Please ensure that the @Transaction method raises an exception if the database transaction is aborted.`,
-              );
-              throw new DBOSFailedSqlTransactionError(workflowUUID, txn.name);
-            } else {
-              throw error;
-            }
+            throw new DBOSFailedSqlTransactionError(workflowUUID, txn.name);
+          } else {
+            throw error;
           }
         }
 
@@ -1373,7 +1245,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
           const e: Error = err as Error;
           await this.userDatabase.transaction(
             async (client: UserDatabaseClient) => {
-              await this.flushResultBuffer(client, wfCtx.resultBuffer, wfCtx.workflowUUID);
               const func = <T>(sql: string, args: unknown[]) =>
                 this.userDatabase.queryWithClient<T>(client, sql, ...args);
               await this.#recordError(func, wfCtx.workflowUUID, funcId, txn_snapshot, e, (error) =>
@@ -1382,7 +1253,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
             },
             { isolationLevel: IsolationLevel.ReadCommitted },
           );
-          wfCtx.resultBuffer.clear();
         }
         span.setStatus({ code: SpanStatusCode.ERROR, message: e.message });
         this.tracer.endSpan(span);
@@ -1435,7 +1305,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
         authenticatedUser: wfCtx.authenticatedUser,
         assumedRole: wfCtx.assumedRole,
         authenticatedRoles: wfCtx.authenticatedRoles,
-        readOnly: procInfo.config.readOnly ?? false,
         isolationLevel: procInfo.config.isolationLevel,
         executeLocally,
       },
@@ -1468,7 +1337,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
     let retryWaitMillis = 1;
     const backoffFactor = 1.5;
     const maxRetryWaitMs = 2000; // Maximum wait 2 seconds.
-    const readOnly = procInfo.config.readOnly ?? false;
 
     while (true) {
       if (this.workflowCancellationMap.get(wfCtx.workflowUUID) === true) {
@@ -1512,11 +1380,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
           );
         }
 
-        // For non-read-only transactions, flush the result buffer.
-        if (!this.isDebugging && !readOnly) {
-          await this.#flushResultBufferProc(client, wfCtx.resultBuffer, wfCtx.workflowUUID);
-        }
-
         // Execute the user's transaction.
         const result = await (async function () {
           try {
@@ -1551,30 +1414,19 @@ export class DBOSExecutor implements DBOSExecutorContext {
           throw result;
         }
 
-        if (readOnly) {
-          // Buffer the output of read-only transactions instead of synchronously writing it.
-          const readOutput: BufferedResult = {
-            output: result,
-            txn_snapshot: txn_snapshot,
-            created_at: Date.now(),
-          };
-          wfCtx.resultBuffer.set(funcId, readOutput);
-        } else {
-          // Synchronously record the output of write transactions and obtain the transaction ID.
-          const func = <T>(sql: string, args: unknown[]) => client.query(sql, args).then((v) => v.rows as T[]);
-          const pg_txn_id = await this.#recordOutput(
-            func,
-            wfCtx.workflowUUID,
-            funcId,
-            txn_snapshot,
-            result,
-            pgNodeIsKeyConflictError,
-          );
+        // Synchronously record the output of write transactions and obtain the transaction ID.
+        const func = <T>(sql: string, args: unknown[]) => client.query(sql, args).then((v) => v.rows as T[]);
+        const pg_txn_id = await this.#recordOutput(
+          func,
+          wfCtx.workflowUUID,
+          funcId,
+          txn_snapshot,
+          result,
+          pgNodeIsKeyConflictError,
+        );
 
-          // const pg_txn_id = await wfCtx.recordOutputProc<R>(client, funcId, txn_snapshot, result);
-          ctxt.span.setAttribute('pg_txn_id', pg_txn_id);
-          wfCtx.resultBuffer.clear();
-        }
+        // const pg_txn_id = await wfCtx.recordOutputProc<R>(client, funcId, txn_snapshot, result);
+        ctxt.span.setAttribute('pg_txn_id', pg_txn_id);
 
         return result;
       };
@@ -1601,7 +1453,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
           const e: Error = err as Error;
           await this.invokeStoredProcFunction(
             async (client: PoolClient) => {
-              await this.#flushResultBufferProc(client, wfCtx.resultBuffer, wfCtx.workflowUUID);
               const func = <T>(sql: string, args: unknown[]) => client.query(sql, args).then((v) => v.rows as T[]);
               await this.#recordError(func, wfCtx.workflowUUID, funcId, txn_snapshot, e, pgNodeIsKeyConflictError);
             },
@@ -1610,7 +1461,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
 
           await this.userDatabase.transaction(
             async (client: UserDatabaseClient) => {
-              await this.flushResultBuffer(client, wfCtx.resultBuffer, wfCtx.workflowUUID);
               const func = <T>(sql: string, args: unknown[]) =>
                 this.userDatabase.queryWithClient<T>(client, sql, ...args);
               await this.#recordError(func, wfCtx.workflowUUID, funcId, txn_snapshot, e, (error) =>
@@ -1619,7 +1469,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
             },
             { isolationLevel: IsolationLevel.ReadCommitted },
           );
-          wfCtx.resultBuffer.clear();
         }
         throw err;
       }
@@ -1637,7 +1486,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
     if (this.isDebugging) {
       throw new DBOSDebuggerError("Can't invoke stored procedure in debug mode.");
     }
-    const readOnly = config.readOnly ?? false;
 
     if (this.workflowCancellationMap.get(wfCtx.workflowUUID) === true) {
       throw new DBOSWorkflowCancelledError(wfCtx.workflowUUID);
@@ -1650,19 +1498,11 @@ export class DBOSExecutor implements DBOSExecutorContext {
       assumedRole: wfCtx.assumedRole,
     };
 
+    // TODO (Qian/Harry): remove this unshift when we remove the resultBuffer argument
     // Note, node-pg converts JS arrays to postgres array literals, so must call JSON.strigify on
     // args and bufferedResults before being passed to #invokeStoredProc
     const $args = [wfCtx.workflowUUID, funcId, wfCtx.presetUUID, $jsonCtx, null, JSON.stringify(args)] as unknown[];
-    if (!readOnly) {
-      // function_id, output, txn_snapshot, created_at
-      const bufferedResults = new Array<[number, unknown, string, number?]>();
-      for (const [functionID, { output, txn_snapshot, created_at }] of wfCtx.resultBuffer.entries()) {
-        bufferedResults.push([functionID, output, txn_snapshot, created_at]);
-      }
-      // sort by function ID
-      bufferedResults.sort((a, b) => a[0] - b[0]);
-      $args.unshift(bufferedResults.length > 0 ? JSON.stringify(bufferedResults) : null);
-    }
+    $args.unshift(null);
 
     type ReturnValue = {
       return_value: { output?: R; error?: unknown; txn_id?: string; txn_snapshot?: string; created_at?: number };
@@ -1674,28 +1514,10 @@ export class DBOSExecutor implements DBOSExecutorContext {
 
     const { error, output, txn_snapshot, txn_id, created_at } = return_value;
 
-    // buffered results are persisted in r/w stored procs, even if it returns an error
-    if (!readOnly) {
-      wfCtx.resultBuffer.clear();
-    }
-
     // if the stored proc returns an error, deserialize and throw it.
     // stored proc saves the error in tx_output before returning
     if (error) {
       throw deserializeError(error);
-    }
-
-    // if txn_snapshot is provided, the output needs to be buffered
-    if (readOnly && txn_snapshot) {
-      wfCtx.resultBuffer.set(funcId, {
-        output,
-        txn_snapshot,
-        created_at: created_at ?? Date.now(),
-      });
-    }
-
-    if (!readOnly) {
-      wfCtx.resultBuffer.clear();
     }
 
     if (txn_id) {
@@ -1729,12 +1551,8 @@ export class DBOSExecutor implements DBOSExecutorContext {
   async invokeStoredProcFunction<R>(func: (client: PoolClient) => Promise<R>, config: TransactionConfig): Promise<R> {
     const client = await this.procedurePool.connect();
     try {
-      const readOnly = config.readOnly ?? false;
       const isolationLevel = config.isolationLevel ?? IsolationLevel.Serializable;
       await client.query(`BEGIN ISOLATION LEVEL ${isolationLevel}`);
-      if (readOnly) {
-        await client.query(`SET TRANSACTION READ ONLY`);
-      }
       const result: R = await func(client);
       await client.query(`COMMIT`);
       return result;
@@ -1817,14 +1635,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
     );
 
     const ctxt: StepContextImpl = new StepContextImpl(wfCtx, funcID, span, this.logger, commInfo.config, stepFn.name);
-
-    await this.userDatabase.transaction(
-      async (client: UserDatabaseClient) => {
-        await this.flushResultBuffer(client, wfCtx.resultBuffer, wfCtx.workflowUUID);
-      },
-      { isolationLevel: IsolationLevel.ReadCommitted },
-    );
-    wfCtx.resultBuffer.clear();
 
     // Check if this execution previously happened, returning its original result if it did.
     const check: R | DBOSNull = await this.systemDatabase.checkOperationOutput<R>(wfCtx.workflowUUID, ctxt.functionID);
@@ -2255,79 +2065,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
   }
 
   /* BACKGROUND PROCESSES */
-  /**
-   * Periodically flush the workflow output buffer to the system database.
-   */
-  async flushWorkflowBuffers() {
-    if (this.initialized && !this.isDebugging) {
-      await this.flushWorkflowResultBuffer();
-      await this.systemDatabase.flushWorkflowSystemBuffers();
-    }
-    this.isFlushingBuffers = false;
-  }
-
-  async flushWorkflowResultBuffer(): Promise<void> {
-    if (this.isDebugging) {
-      throw new DBOSDebuggerError(`Cannot flush workflow result buffer in debug mode.`);
-    }
-
-    const localBuffer = new Map(this.workflowResultBuffer);
-    this.workflowResultBuffer.clear();
-    const totalSize = localBuffer.size;
-    const flushBatchSize = 50;
-    try {
-      let finishedCnt = 0;
-      while (finishedCnt < totalSize) {
-        let sqlStmt =
-          'INSERT INTO dbos.transaction_outputs (workflow_uuid, function_id, output, error, txn_id, txn_snapshot, created_at) VALUES ';
-        let paramCnt = 1;
-        const values: any[] = [];
-        const batchUUIDs: string[] = [];
-        for (const [workflowUUID, wfBuffer] of localBuffer) {
-          for (const [funcID, recorded] of wfBuffer) {
-            const output = recorded.output;
-            const txnSnapshot = recorded.txn_snapshot;
-            const createdAt = recorded.created_at!;
-            if (paramCnt > 1) {
-              sqlStmt += ', ';
-            }
-            sqlStmt += `($${paramCnt++}, $${paramCnt++}, $${paramCnt++}, $${paramCnt++}, null, $${paramCnt++}, $${paramCnt++})`;
-            values.push(
-              workflowUUID,
-              funcID,
-              DBOSJSON.stringify(output),
-              DBOSJSON.stringify(null),
-              txnSnapshot,
-              createdAt,
-            );
-          }
-          batchUUIDs.push(workflowUUID);
-          finishedCnt++;
-          if (batchUUIDs.length >= flushBatchSize) {
-            // Cap at the batch size.
-            break;
-          }
-        }
-        this.logger.debug(sqlStmt);
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        await this.userDatabase.query(sqlStmt, ...values);
-
-        // Clean up after each batch succeeds
-        batchUUIDs.forEach((value) => {
-          localBuffer.delete(value);
-        });
-      }
-    } catch (error) {
-      (error as Error).message = `Error flushing workflow result buffer: ${(error as Error).message}`;
-      this.logger.error(error);
-      // If there is a failure in flushing the buffer, return items to the global buffer for retrying later.
-      for (const [workflowUUID, wfBuffer] of localBuffer) {
-        if (!this.workflowResultBuffer.has(workflowUUID)) {
-          this.workflowResultBuffer.set(workflowUUID, wfBuffer);
-        }
-      }
-    }
-  }
 
   logRegisteredHTTPUrls() {
     this.logger.info('HTTP endpoints supported:');

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -1512,7 +1512,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
       $args,
     );
 
-    const { error, output, txn_snapshot, txn_id, created_at } = return_value;
+    const { error, output, txn_id } = return_value;
 
     // if the stored proc returns an error, deserialize and throw it.
     // stored proc saves the error in tx_output before returning

--- a/src/eventreceiver.ts
+++ b/src/eventreceiver.ts
@@ -62,7 +62,6 @@ export interface DBOSExecutorContext {
   send<T>(destinationUUID: string, message: T, topic?: string, idempotencyKey?: string): Promise<void>;
   getEvent<T>(workflowUUID: string, key: string, timeoutSeconds?: number): Promise<T | null>;
   retrieveWorkflow<R>(workflowUUID: string): WorkflowHandle<R>;
-  flushWorkflowBuffers(): Promise<void>;
   getWorkflowStatus(workflowID: string): Promise<WorkflowStatus | null>;
   getWorkflows(input: GetWorkflowsInput): Promise<GetWorkflowsOutput>;
   getWorkflowQueue(input: GetWorkflowQueueInput): Promise<GetWorkflowQueueOutput>;

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -400,7 +400,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     DO UPDATE SET status=EXCLUDED.status, output=EXCLUDED.output, updated_at=EXCLUDED.updated_at;`,
       [
         workflowUUID,
-        StatusString.ERROR,
+        StatusString.SUCCESS,
         status.workflowName,
         status.workflowClassName,
         status.workflowConfigName,

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -12,7 +12,7 @@ export type TransactionFunction<T extends unknown[], R> = Transaction<T, R>;
 
 export interface TransactionConfig {
   isolationLevel?: IsolationLevel;
-  readOnly?: boolean;
+  readOnly?: boolean; // Deprecated
 }
 
 export const IsolationLevel = {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1,9 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { DBOSExecutor, OperationType } from './dbos-executor';
-import { IsolationLevel, Transaction, TransactionContext } from './transaction';
+import { Transaction, TransactionContext } from './transaction';
 import { StepFunction, StepContext } from './step';
 import { SystemDatabase } from './system_database';
-import { UserDatabaseClient } from './user_database';
 import { HTTPRequest, DBOSContext, DBOSContextImpl } from './context';
 import { ConfiguredInstance, getRegisteredOperations } from './decorators';
 import { StoredProcedure, StoredProcedureContext } from './procedure';

--- a/tests/appversion.test.ts
+++ b/tests/appversion.test.ts
@@ -72,7 +72,6 @@ describe('test-app-version', () => {
     await DBOS.launch();
     const handle = await DBOS.startWorkflow(TestAppVersionRecovery).testWorkflow();
     await expect(handle.getResult()).resolves.toEqual(0);
-    await DBOS.executor.flushWorkflowBuffers();
     await DBOSExecutor.globalInstance?.systemDatabase.setWorkflowStatus(
       handle.getWorkflowUUID(),
       StatusString.PENDING,
@@ -86,7 +85,6 @@ describe('test-app-version', () => {
     expect(handles.length).toBe(1);
     expect(handles[0].workflowID).toBe(handle.workflowID);
     await expect(handles[0].getResult()).resolves.toEqual(0);
-    await DBOS.executor.flushWorkflowBuffers();
     await DBOSExecutor.globalInstance?.systemDatabase.setWorkflowStatus(
       handle.getWorkflowUUID(),
       StatusString.PENDING,

--- a/tests/appversion.test.ts
+++ b/tests/appversion.test.ts
@@ -69,6 +69,7 @@ describe('test-app-version', () => {
     }
 
     // Complete the workflow, then set its status to PENDING
+    await DBOS.shutdown();
     await DBOS.launch();
     const handle = await DBOS.startWorkflow(TestAppVersionRecovery).testWorkflow();
     await expect(handle.getResult()).resolves.toEqual(0);
@@ -79,6 +80,7 @@ describe('test-app-version', () => {
     );
 
     // Shutdown and restart with the same source code, verify it recovers correctly. Set status to PENDING again
+    process.env.DBOS__VMID = 'test-app-version-recovery';
     await DBOS.shutdown();
     await DBOS.launch();
     let handles = await DBOS.recoverPendingWorkflows();

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -113,7 +113,7 @@ class ConcurrTestClass {
 
   static resolve3: () => void;
   static promise3 = new Promise<void>((r) => {
-    ConcurrTestClass.resolve2 = r;
+    ConcurrTestClass.resolve3 = r;
   });
 
   @DBOS.transaction()

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -2,7 +2,7 @@ import { DBOS } from '../src';
 import { v1 as uuidv1 } from 'uuid';
 import { sleepms } from '../src/utils';
 import { generateDBOSTestConfig, setUpDBOSTestDb } from './helpers';
-import { DBOSConfig, DBOSExecutor } from '../src/dbos-executor';
+import { DBOSConfig } from '../src/dbos-executor';
 
 const testTableName = 'dbos_concurrency_test_kv';
 

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -41,17 +41,17 @@ describe('concurrency-tests', () => {
   });
 
   test('concurrent-workflow', async () => {
-    // Invoke testWorkflow twice with the same UUID and flush workflow output buffer right before the second transaction starts.
+    // Invoke testWorkflow twice with the same UUID and the first one completes right before the second transaction starts.
     // The second transaction should get the correct recorded execution without being executed.
     const uuid = uuidv1();
-    await (await DBOS.startWorkflow(ConcurrTestClass, { workflowID: uuid }).testWorkflow()).getResult();
-    const handle = await DBOS.startWorkflow(ConcurrTestClass, { workflowID: uuid }).testWorkflow();
+    const handle1 = await DBOS.startWorkflow(ConcurrTestClass, { workflowID: uuid }).testWorkflow();
+    const handle2 = await DBOS.startWorkflow(ConcurrTestClass, { workflowID: uuid }).testWorkflow();
     await ConcurrTestClass.promise2;
+    ConcurrTestClass.resolve3();
+    await handle1.getResult();
 
-    const dbosExec = DBOSExecutor.globalInstance!;
-    await dbosExec.flushWorkflowBuffers();
     ConcurrTestClass.resolve();
-    await handle.getResult();
+    await handle2.getResult();
 
     expect(ConcurrTestClass.cnt).toBe(1);
     expect(ConcurrTestClass.wfCnt).toBe(2);
@@ -111,6 +111,11 @@ class ConcurrTestClass {
     ConcurrTestClass.resolve2 = r;
   });
 
+  static resolve3: () => void;
+  static promise3 = new Promise<void>((r) => {
+    ConcurrTestClass.resolve2 = r;
+  });
+
   @DBOS.transaction()
   static async testReadWriteFunction(id: number) {
     await DBOS.pgClient.query(`INSERT INTO ${testTableName}(id, value) VALUES ($1, $2)`, [1, id]);
@@ -123,6 +128,8 @@ class ConcurrTestClass {
     if (ConcurrTestClass.wfCnt++ === 1) {
       ConcurrTestClass.resolve2();
       await ConcurrTestClass.promise;
+    } else {
+      await ConcurrTestClass.promise3;
     }
     await ConcurrTestClass.testReadWriteFunction(1);
   }

--- a/tests/configuredinstances.test.ts
+++ b/tests/configuredinstances.test.ts
@@ -11,7 +11,7 @@ import {
   configureInstance,
 } from '../src';
 import { generateDBOSTestConfig, setUpDBOSTestDb } from './helpers';
-import { DBOSConfig, DBOSExecutor } from '../src/dbos-executor';
+import { DBOSConfig } from '../src/dbos-executor';
 import request from 'supertest';
 import { v1 as uuidv1 } from 'uuid';
 

--- a/tests/configuredinstances.test.ts
+++ b/tests/configuredinstances.test.ts
@@ -173,7 +173,6 @@ describe('dbos-configclass-tests', () => {
     expect(configA.tracker.nTrans).toBe(1);
 
     // Make sure we correctly record the function's class name and config name
-    await DBOSExecutor.globalInstance!.flushWorkflowBuffers();
     let stat = await DBOS.getWorkflowStatus(wfUUID1);
     expect(stat?.workflowClassName).toBe('DBOSTestConfiguredClass');
     expect(stat?.workflowName).toContain('testTransaction1');

--- a/tests/contextfreeapi.test.ts
+++ b/tests/contextfreeapi.test.ts
@@ -151,7 +151,7 @@ class TestSec2 {
 }
 
 class ChildWorkflows {
-  @DBOS.transaction({ readOnly: true })
+  @DBOS.transaction()
   static async childTx() {
     await DBOS.pgClient.query('SELECT 1');
     return Promise.resolve(`selected ${DBOS.workflowID}`);
@@ -320,7 +320,6 @@ async function main() {
   const wfs = await DBOS.getWorkflows({ workflowName: 'doWorkflow' });
   expect(wfs.workflowUUIDs.length).toBeGreaterThanOrEqual(1);
   expect(wfs.workflowUUIDs.length).toBe(1);
-  await DBOS.executor.flushWorkflowBuffers();
   const wfh = DBOS.retrieveWorkflow(wfs.workflowUUIDs[0]);
   expect((await wfh.getStatus())?.status).toBe('SUCCESS');
   const wfstat = await DBOS.getWorkflowStatus(wfs.workflowUUIDs[0]);

--- a/tests/contextfreeinst.test.ts
+++ b/tests/contextfreeinst.test.ts
@@ -139,7 +139,6 @@ async function main() {
   const wfs = await DBOS.getWorkflows({ workflowName: 'doWorkflow' });
   expect(wfs.workflowUUIDs.length).toBeGreaterThanOrEqual(2);
   expect(wfs.workflowUUIDs.length).toBe(2);
-  await DBOS.executor.flushWorkflowBuffers();
   const wfh1 = DBOS.retrieveWorkflow(wfs.workflowUUIDs[0]);
   const wfh2 = DBOS.retrieveWorkflow(wfs.workflowUUIDs[1]);
   const stat1 = await wfh1.getStatus();

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -334,8 +334,6 @@ describe('dbos-config', () => {
       expect(ctx.getConfig('no_key')).toBeUndefined();
       // Config key does not exist, default value
       expect(ctx.getConfig('no_key', 'default')).toBe('default');
-      // We didn't init, so do some manual cleanup only
-      clearInterval(dbosExec.flushBufferID);
       await dbosExec.telemetryCollector.destroy();
     });
 
@@ -364,8 +362,6 @@ describe('dbos-config', () => {
         undefined,
       );
       expect(ctx.getConfig<string>('payments_url', 'default')).toBe('default');
-      // We didn't init, so do some manual cleanup only
-      clearInterval(dbosExec.flushBufferID);
       await dbosExec.telemetryCollector.destroy();
     });
 
@@ -388,8 +384,6 @@ describe('dbos-config', () => {
       const dbosExec = new DBOSExecutor(dbosConfig);
       expect(process.env.FOOFOO).toBe('barbar');
       expect(process.env.RANDENV).toBe(''); // Empty string
-      // We didn't init, so do some manual cleanup only
-      clearInterval(dbosExec.flushBufferID);
       await dbosExec.telemetryCollector.destroy();
     });
 
@@ -533,8 +527,6 @@ describe('dbos-config', () => {
         undefined,
       );
       expect(() => ctx.getConfig<number>('payments_url', 1234)).toThrow(DBOSConfigKeyTypeError);
-      // We didn't init, so do some manual cleanup only
-      clearInterval(dbosExec.flushBufferID);
       await dbosExec.telemetryCollector.destroy();
     });
 

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -2,7 +2,7 @@ import { WorkflowHandle, DBOSInitializer, InitContext, DBOS } from '../src/';
 import { generateDBOSTestConfig, setUpDBOSTestDb, TestKvTable } from './helpers';
 import { v1 as uuidv1 } from 'uuid';
 import { StatusString } from '../src/workflow';
-import { DBOSConfigInternal, DBOSExecutor } from '../src/dbos-executor';
+import { DBOSConfigInternal } from '../src/dbos-executor';
 import { Client } from 'pg';
 import { transaction_outputs } from '../schemas/user_db_schema';
 import { DBOSFailedSqlTransactionError } from '../src/error';

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -268,8 +268,7 @@ describe('dbos-tests', () => {
     RetrieveWorkflowStatus.resolve2();
     await expect(workflowHandle.getResult()).resolves.toBe('hello');
 
-    // Flush workflow output buffer so the retrieved handle can proceed and the status would transition to SUCCESS.
-    await DBOSExecutor.globalInstance!.flushWorkflowBuffers();
+    // The status should transition to SUCCESS.
     const retrievedHandle = DBOS.retrieveWorkflow<string>(workflowUUID);
     expect(retrievedHandle).not.toBeNull();
     expect(retrievedHandle.workflowID).toBe(workflowUUID);

--- a/tests/httpServer/adminserver.test.ts
+++ b/tests/httpServer/adminserver.test.ts
@@ -130,7 +130,6 @@ describe('running-admin-server-tests', () => {
     const handle = await DBOS.startWorkflow(testAdminWorkflow).simpleWorkflow();
     await handle.getResult();
     expect(testAdminWorkflow.counter).toBe(1);
-    await DBOSExecutor.globalInstance?.flushWorkflowBuffers();
     await expect(handle.getStatus()).resolves.toMatchObject({
       status: StatusString.SUCCESS,
     });
@@ -155,7 +154,6 @@ describe('running-admin-server-tests', () => {
       },
     });
     expect(response.status).toBe(204);
-    await DBOSExecutor.globalInstance?.flushWorkflowBuffers();
     expect(testAdminWorkflow.counter).toBe(2);
     await expect(handle.getStatus()).resolves.toMatchObject({
       status: StatusString.SUCCESS,
@@ -169,7 +167,6 @@ describe('running-admin-server-tests', () => {
       },
     });
     expect(response.status).toBe(204);
-    await DBOSExecutor.globalInstance?.flushWorkflowBuffers();
     expect(testAdminWorkflow.counter).toBe(2);
     await expect(handle.getStatus()).resolves.toMatchObject({
       status: StatusString.SUCCESS,
@@ -183,14 +180,12 @@ describe('running-admin-server-tests', () => {
       },
     });
     expect(response.status).toBe(204);
-    await DBOSExecutor.globalInstance?.flushWorkflowBuffers();
     expect(testAdminWorkflow.counter).toBe(3);
   });
 
   test('test-admin-list-workflow-steps', async () => {
     const handle = await DBOS.startWorkflow(testAdminWorkflow).workflowWithSteps();
     await handle.getResult();
-    await DBOSExecutor.globalInstance?.flushWorkflowBuffers();
     await expect(handle.getStatus()).resolves.toMatchObject({
       status: StatusString.SUCCESS,
     });
@@ -218,7 +213,6 @@ describe('running-admin-server-tests', () => {
     const handle = await DBOS.startWorkflow(testAdminWorkflow).simpleWorkflow();
     await handle.getResult();
     expect(testAdminWorkflow.counter).toBe(1);
-    await DBOSExecutor.globalInstance?.flushWorkflowBuffers();
     await expect(handle.getStatus()).resolves.toMatchObject({
       status: StatusString.SUCCESS,
     });

--- a/tests/httpServer/adminserver.test.ts
+++ b/tests/httpServer/adminserver.test.ts
@@ -1,5 +1,5 @@
 import { DBOS, DBOSRuntimeConfig, StatusString } from '../../src';
-import { DBOSConfig, DBOSConfigInternal, DBOSExecutor } from '../../src/dbos-executor';
+import { DBOSConfig, DBOSConfigInternal } from '../../src/dbos-executor';
 import { WorkflowQueue } from '../../src';
 import { generateDBOSTestConfig, generatePublicDBOSTestConfig, setUpDBOSTestDb } from '../helpers';
 import { QueueMetadataResponse } from '../../src/httpServer/server';

--- a/tests/httpServer/server.test.ts
+++ b/tests/httpServer/server.test.ts
@@ -273,9 +273,6 @@ describe('httpserver-tests', () => {
     expect(response.statusCode).toBe(200);
     expect(response.text).toBe('hello 1');
 
-    const dbosExec = DBOSExecutor.globalInstance!;
-    await dbosExec.flushWorkflowBuffers();
-
     // Retrieve the workflow with UUID.
     const retrievedHandle = DBOS.retrieveWorkflow(workflowUUID);
     expect(retrievedHandle).not.toBeNull();

--- a/tests/httpServer/server.test.ts
+++ b/tests/httpServer/server.test.ts
@@ -22,7 +22,7 @@ import { ArgSource, HandlerContext } from '../../src/httpServer/handler';
 import { ArgSources } from '../../src/httpServer/handlerTypes';
 import { Authentication, KoaBodyParser, RequestIDHeader } from '../../src/httpServer/middleware';
 import { v1 as uuidv1, validate as uuidValidate } from 'uuid';
-import { DBOSConfig, DBOSExecutor } from '../../src/dbos-executor';
+import { DBOSConfig } from '../../src/dbos-executor';
 import { DBOSNotAuthorizedError, DBOSResponseError } from '../../src/error';
 import { PoolClient } from 'pg';
 import { IncomingMessage } from 'http';

--- a/tests/httpserve_v2.test.ts
+++ b/tests/httpserve_v2.test.ts
@@ -462,8 +462,6 @@ describe('dbos-v2api-tests-http', () => {
     expect(response.statusCode).toBe(200);
     expect(response.text).toBe('hello 1');
 
-    await DBOS.executor.flushWorkflowBuffers();
-
     // Retrieve the workflow with UUID.
     const retrievedHandle = DBOS.retrieveWorkflow(workflowUUID);
     expect(retrievedHandle).not.toBeNull();

--- a/tests/oaoo.test.ts
+++ b/tests/oaoo.test.ts
@@ -218,21 +218,16 @@ describe('oaoo-tests', () => {
   });
 
   test('nested-workflow-oaoo', async () => {
-    const dbosExec = DBOSExecutor.globalInstance!;
-    clearInterval(dbosExec.flushBufferID); // Don't flush the output buffer.
-
     const workflowUUID = uuidv1();
     await DBOS.withNextWorkflowID(workflowUUID, async () => {
       await expect(WorkflowOAOO.nestedWorkflow(username)).resolves.toBe(1);
     });
 
-    await dbosExec.flushWorkflowBuffers();
     await DBOS.withNextWorkflowID(workflowUUID, async () => {
       await expect(WorkflowOAOO.nestedWorkflow(username)).resolves.toBe(1);
     });
 
     // Retrieve output of the child workflow.
-    await dbosExec.flushWorkflowBuffers();
     const retrievedHandle = DBOS.retrieveWorkflow(workflowUUID + '-0');
     await expect(retrievedHandle.getResult()).resolves.toBe(1);
 
@@ -337,9 +332,6 @@ describe('oaoo-tests', () => {
     // Execute a workflow (w/ getUUID) to get an event and retrieve a workflow that doesn't exist, then invoke the setEvent workflow as a child workflow.
     // If we execute the get workflow without UUID, both getEvent and retrieveWorkflow should return values.
     // But if we run the get workflow again with getUUID, getEvent/retrieveWorkflow should still return null.
-    const dbosExec = DBOSExecutor.globalInstance!;
-    clearInterval(dbosExec.flushBufferID); // Don't flush the output buffer.
-
     const getUUID = uuidv1();
     const setUUID = uuidv1();
 
@@ -362,6 +354,7 @@ describe('oaoo-tests', () => {
     await DBOS.withNextWorkflowID(getUUID, async () => {
       await expect(EventStatusOAOO.getEventRetrieveWorkflow(setUUID)).resolves.toBe('valueNull-statusNull-PENDING');
     });
+    // TODO(Qian): look at this test
     expect(EventStatusOAOO.wfCnt).toBe(6); // Should re-execute the workflow because we're not flushing the result buffer.
   });
 });

--- a/tests/oaoo.test.ts
+++ b/tests/oaoo.test.ts
@@ -1,5 +1,5 @@
 import { DBOS } from '../src';
-import { DBOSConfigInternal, DBOSExecutor } from '../src/dbos-executor';
+import { DBOSConfigInternal } from '../src/dbos-executor';
 import { TestKvTable, generateDBOSTestConfig, setUpDBOSTestDb } from './helpers';
 import { v1 as uuidv1 } from 'uuid';
 

--- a/tests/proc-test/src/operations.ts
+++ b/tests/proc-test/src/operations.ts
@@ -7,7 +7,7 @@ export interface dbos_hello {
 }
 
 export class StoredProcTest {
-  @DBOS.storedProcedure({ readOnly: true })
+  @DBOS.storedProcedure()
   static async getGreetCount(user: string): Promise<number> {
     const query = 'SELECT greet_count FROM dbos_hello WHERE name = $1;';
     const { rows } = await DBOS.pgClient.query<dbos_hello>(query, [user]);
@@ -52,7 +52,7 @@ export class StoredProcTest {
     return greeting;
   }
 
-  @DBOS.storedProcedure({ readOnly: true, executeLocally: true })
+  @DBOS.storedProcedure({ executeLocally: true })
   static async getGreetCountLocal(user: string): Promise<number> {
     const query = 'SELECT greet_count FROM dbos_hello WHERE name = $1;';
     const { rows } = await DBOS.pgClient.query<dbos_hello>(query, [user]);
@@ -84,7 +84,7 @@ export class StoredProcTest {
     return { count, greeting, rowCount };
   }
 
-  @DBOS.transaction({ readOnly: true })
+  @DBOS.transaction()
   static async getGreetCountTx(user: string): Promise<number> {
     const query = 'SELECT greet_count FROM dbos_hello WHERE name = ?;';
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
@@ -125,7 +125,7 @@ export class StoredProcTest {
     return { count, greeting, local };
   }
 
-  @DBOS.transaction({ readOnly: true })
+  @DBOS.transaction()
   static async getGreetCountTx_v2(user: string): Promise<number> {
     const query = 'SELECT greet_count FROM dbos_hello WHERE name = ?;';
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion

--- a/tests/proc-test/src/operations.ts
+++ b/tests/proc-test/src/operations.ts
@@ -14,7 +14,7 @@ export class StoredProcTest {
     return rows.length === 0 ? 0 : rows[0].greet_count;
   }
 
-  @DBOS.storedProcedure() // not marking this read only so the tx output table write is not buffered
+  @DBOS.storedProcedure()
   static async getHelloRowCount(): Promise<number> {
     const query = 'SELECT COUNT(*) FROM dbos_hello;';
     const { rows } = await DBOS.pgClient.query<{ count: string }>(query);
@@ -69,7 +69,7 @@ export class StoredProcTest {
     return `Hello, ${user}! You have been greeted ${greet_count} times.\n`;
   }
 
-  @DBOS.storedProcedure({ executeLocally: true }) // like getHelloRowCount, not marked as read only so the tx output does not get buffered
+  @DBOS.storedProcedure({ executeLocally: true })
   static async getHelloRowCountLocal(): Promise<number> {
     const query = 'SELECT COUNT(*) FROM dbos_hello;';
     const { rows } = await DBOS.pgClient.query<{ count: string }>(query);

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -1,7 +1,6 @@
 import { WorkflowQueue, DBOS } from '../src/';
 import { generateDBOSTestConfig, setUpDBOSTestDb, Event } from './helpers';
-import { DBOSConfigInternal, DBOSExecutor } from '../src/dbos-executor';
-import { PostgresSystemDatabase } from '../src/system_database';
+import { DBOSConfigInternal } from '../src/dbos-executor';
 import { Client } from 'pg';
 import { StatusString } from '../dist/src';
 import { DBOSDeadLetterQueueError } from '../src/error';

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -337,13 +337,13 @@ describe('debugger-test', () => {
     const wfUUID2 = uuidv1();
     await DBOS.withNextWorkflowID(wfUUID2, async () => {
       await expect(DebuggerTest.testFunction(username)).rejects.toThrow(
-        `DEBUGGER: Failed to find the recorded output for the transaction: workflow UUID ${wfUUID2}, step number 0`,
+        `DEBUGGER: Failed to find inputs for workflow UUID ${wfUUID2}`,
       );
     });
 
     // Execute a workflow without specifying the UUID should fail.
     await expect(DebuggerTest.testFunction(username)).rejects.toThrow(
-      /DEBUGGER: Failed to find the recorded output for the transaction: workflow UUID [0-9a-f]{8}-[0-9a-f]{4}-[4][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gm,
+      /DEBUGGER: Failed to find inputs for workflow UUID [0-9a-f]{8}-[0-9a-f]{4}-[4][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gm,
     );
     await DBOS.shutdown();
 
@@ -351,49 +351,6 @@ describe('debugger-test', () => {
     DBOS.setConfig(debugProxyConfig);
     await DBOS.launch({ debugMode: DebugMode.TIME_TRAVEL });
     await expect(DBOS.executeWorkflowById(wfUUID).then((x) => x.getResult())).resolves.toBe(1);
-    await DBOS.shutdown();
-  });
-
-  test('debug-read-only-transaction', async () => {
-    const wfUUID = uuidv1();
-
-    DBOS.setConfig(config);
-    await DBOS.launch();
-
-    // Execute the workflow and destroy the runtime
-    await DBOS.withNextWorkflowID(wfUUID, async () => {
-      await expect(DebuggerTest.testReadOnlyFunction(1)).resolves.toBe(2);
-    });
-    await DBOS.shutdown();
-
-    // Execute again in debug mode.
-    DBOS.setConfig(debugConfig);
-    await DBOS.launch({ debugMode: DebugMode.ENABLED });
-    await DBOS.withNextWorkflowID(wfUUID, async () => {
-      await expect(DebuggerTest.testReadOnlyFunction(1)).resolves.toBe(2);
-    });
-
-    // Execute again with the provided UUID.
-    await expect(DBOS.executeWorkflowById(wfUUID).then((x) => x.getResult())).resolves.toBe(2);
-
-    // Execute a non-exist UUID should fail.
-    const wfUUID2 = uuidv1();
-    await DBOS.withNextWorkflowID(wfUUID2, async () => {
-      await expect(DebuggerTest.testReadOnlyFunction(1)).rejects.toThrow(
-        `DEBUGGER: Failed to find the recorded output for the transaction: workflow UUID ${wfUUID2}, step number 0`,
-      );
-    });
-
-    // Execute a workflow without specifying the UUID should fail.
-    await expect(DebuggerTest.testReadOnlyFunction(1)).rejects.toThrow(
-      /DEBUGGER: Failed to find the recorded output for the transaction: workflow UUID [0-9a-f]{8}-[0-9a-f]{4}-[4][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gm,
-    );
-    await DBOS.shutdown();
-
-    // Proxy mode should return the same result.
-    DBOS.setConfig(debugProxyConfig);
-    await DBOS.launch({ debugMode: DebugMode.TIME_TRAVEL });
-    await expect(DBOS.executeWorkflowById(wfUUID).then((x) => x.getResult())).resolves.toBe(2);
     await DBOS.shutdown();
   });
 

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -299,7 +299,6 @@ describe('debugger-test', () => {
     // Execute again with the provided UUID.
     await expect(DBOS.executeWorkflowById(wfUUID).then((x) => x.getResult())).resolves.toBeFalsy();
     expect(DebuggerTest.count).toBe(1);
-    await DBOSExecutor.globalInstance!.flushWorkflowBuffers();
     await DBOS.shutdown();
 
     // Make sure we correctly record the function's class name
@@ -435,7 +434,6 @@ describe('debugger-test', () => {
     );
 
     // Make sure we correctly record the function's class name
-    await DBOSExecutor.globalInstance!.flushWorkflowBuffers();
     await DBOS.shutdown();
     const result = await systemDBClient.query<{ status: string; name: string; class_name: string }>(
       `SELECT status, name, class_name FROM dbos.workflow_status WHERE workflow_uuid=$1`,

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -1,7 +1,7 @@
 import { DBOSInitializer, DBOS } from '../../src/';
 import { generateDBOSTestConfig, setUpDBOSTestDb, TestKvTable } from '../helpers';
 import { v1 as uuidv1 } from 'uuid';
-import { DBOSConfigInternal, DBOSExecutor, DebugMode } from '../../src/dbos-executor';
+import { DBOSConfigInternal, DebugMode } from '../../src/dbos-executor';
 import { Client } from 'pg';
 
 const testTableName = 'debugger_test_kv';

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -110,9 +110,6 @@ describe('queued-wf-tests-simple', () => {
     // Verify all queue entries eventually get cleaned up.
     expect(await queueEntriesAreCleanedUp()).toBe(true);
 
-    // Verify all workflows get the SUCCESS status eventually
-    await DBOS.executor.flushWorkflowBuffers();
-
     // Verify that each "wave" of tasks started at the ~same time.
     for (let wave = 0; wave < numWaves; ++wave) {
       for (let i = wave * qlimit; i < (wave + 1) * qlimit - 1; ++i) {
@@ -162,9 +159,6 @@ describe('queued-wf-tests-simple', () => {
     for (const h of handles) {
       times.push(await h.getResult());
     }
-
-    // Verify all workflows get the SUCCESS status eventually
-    await DBOS.executor.flushWorkflowBuffers();
 
     // Verify that each "wave" of tasks started at the ~same time.
     for (let wave = 0; wave < numWaves; ++wave) {

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -94,8 +94,6 @@ describe('workflow-management-tests', () => {
     expect(response.statusCode).toBe(200);
     expect(response.text).toBe('alice');
 
-    await DBOSExecutor.globalInstance!.flushWorkflowBuffers();
-
     const input: GetWorkflowsInput = {
       status: StatusString.SUCCESS,
     };
@@ -244,8 +242,6 @@ describe('workflow-management-tests', () => {
     const failResponse = await request(DBOS.getHTTPHandlersCallback()!).post('/fail/alice');
     expect(failResponse.statusCode).toBe(500);
 
-    await DBOSExecutor.globalInstance!.flushWorkflowBuffers();
-
     const input: GetWorkflowsInput = {};
     const infos = await listWorkflows(config, input, false);
     expect(infos.length).toBe(2);
@@ -314,7 +310,6 @@ describe('workflow-management-tests', () => {
     expect(TestEndpoints.tries).toBe(2);
     await handle.getResult();
 
-    await DBOSExecutor.globalInstance!.flushWorkflowBuffers();
     result = await systemDBClient.query<{ status: string; attempts: number }>(
       `SELECT status, recovery_attempts as attempts FROM dbos.workflow_status WHERE workflow_uuid=$1`,
       [handle.getWorkflowUUID()],
@@ -326,7 +321,6 @@ describe('workflow-management-tests', () => {
     const wfh = await DBOS.executeWorkflowById(handle.getWorkflowUUID(), true);
     await wfh.getResult();
     expect(TestEndpoints.tries).toBe(3);
-    await DBOSExecutor.globalInstance!.flushWorkflowBuffers();
     // Validate a new workflow is started and successful
     result = await systemDBClient.query<{ status: string; attempts: number }>(
       `SELECT status, recovery_attempts as attempts FROM dbos.workflow_status WHERE workflow_uuid!=$1`,
@@ -348,7 +342,6 @@ describe('workflow-management-tests', () => {
 
     await DBOS.invoke(TestEndpoints).testTransaction();
     expect(TestEndpoints.tries).toBe(1);
-    await DBOSExecutor.globalInstance!.flushWorkflowBuffers();
 
     let result = await systemDBClient.query<{ status: string; workflow_uuid: string; name: string }>(
       `SELECT status, workflow_uuid, name FROM dbos.workflow_status`,
@@ -362,7 +355,6 @@ describe('workflow-management-tests', () => {
     let wfh = await DBOS.executeWorkflowById(workflowUUID, true);
     await wfh.getResult();
     expect(TestEndpoints.tries).toBe(2);
-    await DBOSExecutor.globalInstance!.flushWorkflowBuffers();
 
     result = await systemDBClient.query<{ status: string; workflow_uuid: string; name: string }>(
       `SELECT status, workflow_uuid, name FROM dbos.workflow_status WHERE workflow_uuid!=$1`,

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -8,7 +8,7 @@ import {
   WorkflowQueue,
 } from '../src';
 import request from 'supertest';
-import { DBOSConfigInternal, DBOSExecutor } from '../src/dbos-executor';
+import { DBOSConfigInternal } from '../src/dbos-executor';
 import { generateDBOSTestConfig, setUpDBOSTestDb, Event } from './helpers';
 import {
   WorkflowInformation,


### PR DESCRIPTION
This PR removes pre-mature optimizations on workflow status/input buffering and read-only transactions.
- No more input buffering for single-transaction workflows.
- No more output buffering for all workflows. When a workflow returns a result, it is guaranteed that the workflow status is updated to `SUCCESS` with its output.
- Deprecate `readOnly` transactions.
- Fixed all the tests with the new behavior.