### PR TITLE
Use connection strings to configure user DB clients

### DIFF
--- a/dbos-config.schema.json
+++ b/dbos-config.schema.json
@@ -60,10 +60,6 @@
           "type": "string",
           "description": "If using SSL/TLS to securely connect to a database, path to an SSL root certificate file"
         },
-        "local_suffix": {
-          "type": "boolean",
-          "description": "Whether to suffix app_db_name with '_local'. Set to true when doing local development using a DBOS Cloud database."
-        },
         "app_db_client": {
           "type": "string",
           "description": "Specify the database client to use to connect to the application database",

--- a/packages/create/templates/dbos-drizzle/drizzle.config.ts
+++ b/packages/create/templates/dbos-drizzle/drizzle.config.ts
@@ -9,11 +9,6 @@ export default defineConfig({
   out: './drizzle',
   dialect: 'postgresql',
   dbCredentials: {
-    host: dbosConfig.poolConfig.host,
-    port: dbosConfig.poolConfig.port,
-    user: dbosConfig.poolConfig.user,
-    password: dbosConfig.poolConfig.password,
-    database: dbosConfig.poolConfig.database,
-    ssl: dbosConfig.poolConfig.ssl,
+    url: dbosConfig.poolConfig.connectionString,
   },
 });

--- a/packages/create/templates/dbos-knex/knexfile.js
+++ b/packages/create/templates/dbos-knex/knexfile.js
@@ -4,14 +4,7 @@ const [dbosConfig] = parseConfigFile();
 
 const config = {
   client: 'pg',
-  connection: {
-    host: dbosConfig.poolConfig.host,
-    port: dbosConfig.poolConfig.port,
-    user: dbosConfig.poolConfig.user,
-    password: dbosConfig.poolConfig.password,
-    database: dbosConfig.poolConfig.database,
-    ssl: dbosConfig.poolConfig.ssl,
-  },
+  connection: dbosConfig.poolConfig.connectionString,
   migrations: {
     directory: './migrations',
   },

--- a/packages/create/templates/dbos-typeorm/datasource.ts
+++ b/packages/create/templates/dbos-typeorm/datasource.ts
@@ -6,12 +6,7 @@ const [dbosConfig] = parseConfigFile();
 
 const AppDataSource = new DataSource({
   type: 'postgres',
-  host: dbosConfig.poolConfig!.host,
-  port: dbosConfig.poolConfig!.port,
-  username: dbosConfig.poolConfig!.user,
-  password: dbosConfig.poolConfig!.password as string,
-  database: dbosConfig.poolConfig!.database,
-  ssl: dbosConfig.poolConfig!.ssl as TlsOptions,
+  url: dbosConfig.poolConfig.connectionString,
   entities: ['dist/entities/*.js'],
   migrations: ['dist/migrations/*.js'],
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,7 +3,7 @@ import { PostgresSystemDatabase, SystemDatabase, WorkflowStatusInternal } from '
 import { GlobalLogger as Logger } from './telemetry/logs';
 import { v4 as uuidv4 } from 'uuid';
 import { RetrievedHandle, StatusString, WorkflowHandle } from './workflow';
-import { parseDbString, parseSSLConfig } from './dbos-runtime/config';
+import { constructPoolConfig } from './dbos-runtime/config';
 
 /**
  * EnqueueOptions defines the options that can be passed to the `enqueue` method of the DBOSClient.
@@ -42,19 +42,14 @@ export class DBOSClient {
   private readonly systemDatabase: SystemDatabase;
 
   private constructor(databaseUrl: string, systemDatabase?: string) {
-    const dbConfig = parseDbString(databaseUrl);
+    const poolConfig: PoolConfig = constructPoolConfig({
+      database: {},
+      database_url: databaseUrl,
+      application: {},
+      env: {},
+    });
 
-    const poolConfig: PoolConfig = {
-      host: dbConfig.hostname,
-      port: dbConfig.port,
-      user: dbConfig.username,
-      password: dbConfig.password,
-      database: dbConfig.app_db_name,
-      ssl: parseSSLConfig(dbConfig),
-      connectionTimeoutMillis: dbConfig.connectionTimeoutMillis,
-    };
-
-    systemDatabase ??= `${dbConfig.app_db_name}_dbos_sys`;
+    systemDatabase ??= `${poolConfig.database}_dbos_sys`;
 
     this.logger = new Logger();
     this.systemDatabase = new PostgresSystemDatabase(poolConfig, systemDatabase, this.logger);

--- a/src/client.ts
+++ b/src/client.ts
@@ -144,9 +144,7 @@ export class DBOSClient {
       maxRetries: 50,
     };
     await this.systemDatabase.initWorkflowStatus(internalStatus, [destinationID, message, topic]);
-    await this.systemDatabase.send(internalStatus.workflowUUID, 0, destinationID, 
-                                   
-                                   .stringify(message), topic);
+    await this.systemDatabase.send(internalStatus.workflowUUID, 0, destinationID, DBOSJSON.stringify(message), topic);
   }
 
   /**

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -325,24 +325,12 @@ export class DBOSExecutor implements DBOSExecutorContext {
       // TODO: make Prisma work with debugger proxy.
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-require-imports
       const { PrismaClient } = require(path.join(process.cwd(), 'node_modules', '@prisma', 'client')); // Find the prisma client in the node_modules of the current project
-      let dbUrl = `postgresql://${userDBConfig.user}:${userDBConfig.password as string}@${userDBConfig.host}:${userDBConfig.port}/${userDBConfig.database}`;
-      const queryParams: Record<string, string | number> = {};
-      if (userDBConfig.connectionTimeoutMillis) {
-        queryParams['connect_timeout'] = userDBConfig.connectionTimeoutMillis;
-      }
-      if (userDBConfig.max) {
-        queryParams['connection_limit'] = String(userDBConfig.max);
-      }
-      const queryString = new URLSearchParams(queryParams as Record<string, string>).toString();
-      if (queryString) {
-        dbUrl += `?${queryString}`;
-      }
       this.userDatabase = new PrismaUserDatabase(
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call
         new PrismaClient({
           datasources: {
             db: {
-              url: dbUrl,
+              url: userDBConfig.connectionString,
             },
           },
         }),
@@ -356,11 +344,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
           new DataSourceExports.DataSource({
             type: 'postgres', // perhaps should move to config file
-            host: userDBConfig.host,
-            port: userDBConfig.port,
-            username: userDBConfig.user,
-            password: userDBConfig.password,
-            database: userDBConfig.database,
+            url: userDBConfig.connectionString,
             entities: this.typeormEntities,
             ssl: userDBConfig.ssl,
             poolSize: userDBConfig.max,
@@ -375,15 +359,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
     } else if (userDbClient === UserDatabaseName.KNEX) {
       const knexConfig: Knex.Config = {
         client: 'postgres',
-        connection: {
-          host: userDBConfig.host,
-          port: userDBConfig.port,
-          user: userDBConfig.user,
-          password: userDBConfig.password,
-          database: userDBConfig.database,
-          ssl: userDBConfig.ssl,
-          connectTimeout: userDBConfig.connectionTimeoutMillis,
-        },
+        connection: userDBConfig.connectionString,
         pool: {
           min: 0,
           max: userDBConfig.max,

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -343,7 +343,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
         this.userDatabase = new TypeORMDatabase(
           // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
           new DataSourceExports.DataSource({
-            type: 'postgres', // perhaps should move to config file
+            type: 'postgres',
             url: userDBConfig.connectionString,
             entities: this.typeormEntities,
             ssl: userDBConfig.ssl,
@@ -359,7 +359,11 @@ export class DBOSExecutor implements DBOSExecutorContext {
     } else if (userDbClient === UserDatabaseName.KNEX) {
       const knexConfig: Knex.Config = {
         client: 'postgres',
-        connection: userDBConfig.connectionString,
+        connection: {
+          connectionString: userDBConfig.connectionString,
+          ssl: userDBConfig.ssl,
+          connectionTimeoutMillis: userDBConfig.connectionTimeoutMillis,
+        },
         pool: {
           min: 0,
           max: userDBConfig.max,

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -351,6 +351,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
           new DataSourceExports.DataSource({
             type: 'postgres',
             url: userDBConfig.connectionString,
+            connectTimeoutMS: userDBConfig.connectionTimeoutMillis,
             entities: this.typeormEntities,
             poolSize: userDBConfig.max,
           }),
@@ -365,6 +366,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
         client: 'postgres',
         connection: {
           connectionString: userDBConfig.connectionString,
+          connectionTimeoutMillis: userDBConfig.connectionTimeoutMillis,
         },
         pool: {
           min: 0,

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -346,9 +346,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
             type: 'postgres',
             url: userDBConfig.connectionString,
             entities: this.typeormEntities,
-            ssl: userDBConfig.ssl,
             poolSize: userDBConfig.max,
-            connectTimeoutMS: userDBConfig.connectionTimeoutMillis,
           }),
         );
       } catch (s) {
@@ -361,8 +359,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
         client: 'postgres',
         connection: {
           connectionString: userDBConfig.connectionString,
-          ssl: userDBConfig.ssl,
-          connectionTimeoutMillis: userDBConfig.connectionTimeoutMillis,
         },
         pool: {
           min: 0,

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -287,9 +287,6 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
     }
 
     userDbPoolSize = cliOptions?.userDbPoolSize || 20;
-    if (userDbPoolSize && userDbPoolSize > 0) {
-      queryParams.push(`connection_limit=${userDbPoolSize}`);
-    }
 
     // SSL configuration
     const ssl = parseSSLConfig(configFile.database);

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -11,7 +11,6 @@ import Ajv, { ValidateFunction } from 'ajv';
 import { parse } from 'pg-connection-string';
 import path from 'path';
 import validator from 'validator';
-import fs from 'fs';
 import { GlobalLogger } from '../telemetry/logs';
 import dbosConfigSchema from '../../dbos-config.schema.json';
 

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -529,6 +529,7 @@ export function overwrite_config(
 
   const appName = configFile!.name || providedDBOSConfig.name;
 
+  configFile.database_url = undefined;
   const poolConfig = constructPoolConfig(configFile!);
 
   if (!providedDBOSConfig.telemetry.OTLPExporter) {

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -213,6 +213,16 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
 
     const queryParams = Object.fromEntries(url.searchParams.entries());
 
+    if (!cliOptions?.silent) {
+      const logger = new GlobalLogger();
+      let logConnectionString = `postgresql://${configFile.database.username}:***@${configFile.database.hostname}:${configFile.database.port}/${databaseName}`;
+      const logQueryParamsArray = Object.entries(queryParams).map(([key, value]) => `${key}=${value}`);
+      if (logQueryParamsArray.length > 0) {
+        logConnectionString += `?${logQueryParamsArray.join('&')}`;
+      }
+      logger.info(`Using database connection string: ${logConnectionString}`);
+    }
+
     // Validate required fields
     const missingFields: string[] = [];
     if (!url.username) missingFields.push('username');
@@ -294,6 +304,15 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
 
     if (queryParams.length > 0) {
       connectionString += `?${queryParams.join('&')}`;
+    }
+
+    if (!cliOptions?.silent) {
+      const logger = new GlobalLogger();
+      let logConnectionString = `postgresql://${configFile.database.username}:***@${configFile.database.hostname}:${configFile.database.port}/${databaseName}`;
+      if (queryParams.length > 0) {
+        logConnectionString += `?${queryParams.join('&')}`;
+      }
+      logger.info(`Using database connection string: ${logConnectionString}`);
     }
   }
 

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -146,7 +146,12 @@ function retrieveApplicationName(configFile: ConfigFile): string {
  * Build a PoolConfig object from the config file and CLI options.
  *
  * If configFile.database_url is provided, this function expects configFile.database to be built from the database_url.
- * If not, a connection string will be built from configFile.database, after it is fully resolved.
+ * A connection string will be built from configFile.database, after it is fully resolved.
+ * If a database_url with query parameters are provided, they will be used.
+ * If no database_url is provided, or if the provided database_url does not contain query parameters, the function will build a connection string with the following query parameters:
+ *  - connect_timeout
+ *  - connection_limit
+ *  - sslmode
  *
  * Default configuration:
  * - Hostname: localhost

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -253,7 +253,7 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
     configFile.database.username = process.env.DBOS_DBUSER || configFile.database.username || 'postgres';
     configFile.database.password =
       process.env.DBOS_DBPASSWORD || configFile.database.password || process.env.PGPASSWORD || 'dbos';
-    configFile.database.connectionTimeoutMillis = configFile.database.connectionTimeoutMillis || 3000;
+    connectionTimeoutMillis = configFile.database.connectionTimeoutMillis || 3000;
 
     databaseName = configFile.database.app_db_name;
     // Construct the database name from the application name, if needed
@@ -269,9 +269,7 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
     // Build connection string query parameters
     const queryParams: string[] = [];
 
-    if (configFile.database.connectionTimeoutMillis) {
-      queryParams.push(`connect_timeout=${configFile.database.connectionTimeoutMillis / 1000}`);
-    }
+    queryParams.push(`connect_timeout=${connectionTimeoutMillis / 1000}`);
 
     // SSL configuration
     const ssl = parseSSLConfig(configFile.database);

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -142,12 +142,13 @@ function retrieveApplicationName(configFile: ConfigFile): string {
 
 /**
  * Build a PoolConfig object.
- * If in debug mode or if no database url is provided, use the provided config.database and consider environment variable overrides.
  *
  * If configFile.database_url is provided, set it directly in poolConfig.connectionString and backfill the other poolConfig options.
  * Backfilling allows the rest of the code to access database parameters easily.
  * We configure the ORMs with the connection string
  * ORMs accepting a poolConfig object, like pg-node, state the connectionString takes precedence.
+ *
+ * If in debug mode or if no database url is provided, use the provided config.database and consider environment variable overrides.
  *
  * Default configuration:
  * - Hostname: localhost

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -519,34 +519,6 @@ export function translatePublicDBOSconfig(
   return [translatedConfig, runtimeConfig];
 }
 
-export function parseDbString(dbString: string): DBConfig {
-  const parsed = parse(dbString);
-  const url = new URL(dbString);
-  const queryParams = Object.fromEntries(url.searchParams.entries());
-
-  const missingFields: string[] = [];
-  if (!parsed.user) missingFields.push('username');
-  if (!parsed.password) missingFields.push('password');
-  if (!parsed.host) missingFields.push('hostname');
-
-  if (missingFields.length > 0) {
-    throw new Error(`Invalid database URL: missing required field(s): ${missingFields.join(', ')}`);
-  }
-
-  return {
-    hostname: parsed.host as string,
-    port: parsed.port ? parseInt(parsed.port, 10) : undefined,
-    username: parsed.user,
-    password: parsed.password,
-    app_db_name: parsed.database || undefined,
-    ssl: 'sslmode' in parsed && (parsed.sslmode === 'require' || parsed.sslmode === 'verify-full'),
-    ssl_ca: queryParams['sslrootcert'] || undefined,
-    connectionTimeoutMillis: queryParams['connect_timeout']
-      ? parseInt(queryParams['connect_timeout'], 10) * 1000
-      : undefined,
-  };
-}
-
 export function overwrite_config(
   providedDBOSConfig: DBOSConfigInternal,
   providedRuntimeConfig: DBOSRuntimeConfig,

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -152,7 +152,7 @@ function retrieveApplicationName(configFile: ConfigFile): string {
  * - Hostname: localhost
  * - Port: 5432
  * - Username: postgres
- * - Password: dbos
+ * - Password: $PGPASSWORD
  * - Database name: transformed application name. The name is either the one provided in the config file or the one found in package.json.
  *
  * @param configFile - The configuration to be used.

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -505,7 +505,6 @@ export function parseDbString(dbString: string): DBConfig {
   if (!parsed.user) missingFields.push('username');
   if (!parsed.password) missingFields.push('password');
   if (!parsed.host) missingFields.push('hostname');
-  if (!parsed.port) missingFields.push('port');
 
   if (missingFields.length > 0) {
     throw new Error(`Invalid database URL: missing required field(s): ${missingFields.join(', ')}`);
@@ -513,7 +512,7 @@ export function parseDbString(dbString: string): DBConfig {
 
   return {
     hostname: parsed.host as string,
-    port: parseInt(parsed.port!, 10),
+    port: parsed.port ? parseInt(parsed.port, 10) : undefined,
     username: parsed.user,
     password: parsed.password,
     app_db_name: parsed.database || undefined,

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -145,7 +145,7 @@ function retrieveApplicationName(configFile: ConfigFile): string {
  * If configFile.database_url is provided, set it directly in poolConfig.connectionString and backfill the other poolConfig options.
  * Backfilling allows the rest of the code to access database parameters easily.
  * We configure the ORMs with the connection string
- * ORMs accepting a poolConfig object, like pg-node, state the connectionString takes precedence.
+ * We still need to extract pool size and connectionTimeoutMillis from the config file and give them manually to the ORMs.
  *
  * If configFile.database_url is not provided, we build the connection string from the configFile.database object.
  *

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -189,10 +189,7 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
 
   // If a database_url is found, parse it to backfill the poolConfig
   if (configFile.database_url) {
-    connectionString = configFile.database_url;
-
     const url = new URL(configFile.database_url);
-
     // If in debug mode, apply the debug overrides
     if (isDebugMode) {
       if (process.env.DBOS_DBHOST) {
@@ -209,6 +206,9 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
       }
       configFile.database_url = url.toString();
     }
+    connectionString = configFile.database_url;
+
+    // From here backfill the poolConfig
 
     const queryParams = Object.fromEntries(url.searchParams.entries());
 

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -196,6 +196,7 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
     password: configFile.database.password,
     connectionTimeoutMillis: configFile.database.connectionTimeoutMillis || 3000,
     database: databaseName,
+    max: cliOptions?.userDbPoolSize || 20,
   };
 
   if (!poolConfig.database) {
@@ -218,6 +219,9 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
     const queryParams: string[] = [];
     if (poolConfig.connectionTimeoutMillis) {
       queryParams.push(`connect_timeout=${poolConfig.connectionTimeoutMillis / 1000}`);
+    }
+    if (poolConfig.max) {
+      queryParams.push(`connection_limit=${poolConfig.max}`);
     }
     if (poolConfig.ssl === false || poolConfig.ssl === undefined) {
       queryParams.push(`sslmode=disable`);
@@ -275,6 +279,7 @@ export interface ParseOptions {
   appVersion?: string | boolean;
   silent?: boolean;
   forceConsole?: boolean;
+  userDbPoolSize?: number;
 }
 
 /*
@@ -441,9 +446,8 @@ export function translatePublicDBOSconfig(
       application: {},
       env: {},
     },
-    { silent: true },
+    { silent: true, userDbPoolSize: config.userDbPoolSize },
   );
-  poolConfig.max = config.userDbPoolSize || 20;
 
   const translatedConfig: DBOSConfigInternal = {
     name: appName,

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -275,7 +275,7 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
       queryParams.push(`sslmode=verify-full`);
       queryParams.push(`sslrootcert=${configFile.database.ssl_ca}`);
     } else {
-      queryParams.push(`sslmode=require`);
+      queryParams.push(`sslmode=no-verify`);
     }
 
     if (queryParams.length > 0) {

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -591,7 +591,7 @@ export function overwrite_config(
     name: appName,
     poolConfig: poolConfig,
     telemetry: providedDBOSConfig.telemetry,
-    system_database: configFile!.database.sys_db_name || poolConfig.database + '_dbos_sys', // Unexepected, but possible
+    system_database: configFile!.database.sys_db_name || poolConfig.database + '_dbos_sys', // Unexpected, but possible
   };
 
   const overwriteDBOSRuntimeConfig = {

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -499,7 +499,6 @@ export function parseDbString(dbString: string): DBConfig {
   const url = new URL(dbString);
   const queryParams = Object.fromEntries(url.searchParams.entries());
 
-  // Throw if any required field is missing
   const missingFields: string[] = [];
   if (!parsed.user) missingFields.push('username');
   if (!parsed.password) missingFields.push('password');

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -186,6 +186,7 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
 
   let connectionString = undefined;
   let databaseName = undefined;
+  let connectionTimeoutMillis = 3000;
 
   // If a database_url is found, parse it to backfill the poolConfig
   if (configFile.database_url) {
@@ -208,6 +209,11 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
     }
     connectionString = configFile.database_url;
     databaseName = url.pathname.substring(1);
+
+    const queryParams = url.searchParams;
+    if (queryParams.has('connect_timeout')) {
+      connectionTimeoutMillis = parseInt(queryParams.get('connect_timeout')!, 10) * 1000;
+    }
 
     // Validate required fields
     const missingFields: string[] = [];
@@ -295,6 +301,7 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
   // Build the final poolConfig
   const poolConfig: PoolConfig = {
     connectionString,
+    connectionTimeoutMillis,
     host: configFile.database.hostname,
     port: configFile.database.port,
     user: configFile.database.username,

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -505,7 +505,6 @@ export function parseDbString(dbString: string): DBConfig {
   if (!parsed.password) missingFields.push('password');
   if (!parsed.host) missingFields.push('hostname');
   if (!parsed.port) missingFields.push('port');
-  if (!parsed.database) missingFields.push('app_db_name');
 
   if (missingFields.length > 0) {
     throw new Error(`Invalid database URL: missing required field(s): ${missingFields.join(', ')}`);
@@ -516,7 +515,7 @@ export function parseDbString(dbString: string): DBConfig {
     port: parseInt(parsed.port!, 10),
     username: parsed.user,
     password: parsed.password,
-    app_db_name: parsed.database as string,
+    app_db_name: parsed.database || undefined,
     ssl: 'sslmode' in parsed && (parsed.sslmode === 'require' || parsed.sslmode === 'verify-full'),
     ssl_ca: queryParams['sslrootcert'] || undefined,
     connectionTimeoutMillis: queryParams['connect_timeout']

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -186,7 +186,6 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
 
   let connectionString = undefined;
   let databaseName = undefined;
-  let userDbPoolSize = undefined;
 
   // If a database_url is found, parse it to backfill the poolConfig
   if (configFile.database_url) {
@@ -237,9 +236,6 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
         : 3000,
     };
 
-    // Calculate pool size
-    userDbPoolSize = queryParams['connection_limit'] ? parseInt(queryParams['connection_limit'], 10) : 20;
-
     databaseName = configFile.database.app_db_name;
     // Construct the database name from the application name, if needed
     if (databaseName === undefined) {
@@ -286,8 +282,6 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
       queryParams.push(`connect_timeout=${configFile.database.connectionTimeoutMillis / 1000}`);
     }
 
-    userDbPoolSize = cliOptions?.userDbPoolSize || 20;
-
     // SSL configuration
     const ssl = parseSSLConfig(configFile.database);
     if (ssl === false) {
@@ -322,7 +316,7 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
     password: configFile.database.password,
     connectionTimeoutMillis: configFile.database.connectionTimeoutMillis,
     database: databaseName,
-    max: userDbPoolSize,
+    max: cliOptions?.userDbPoolSize || 20,
   };
 
   if (!poolConfig.database) {

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -213,16 +213,6 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
 
     const queryParams = Object.fromEntries(url.searchParams.entries());
 
-    if (!cliOptions?.silent) {
-      const logger = new GlobalLogger();
-      let logConnectionString = `postgresql://${configFile.database.username}:***@${configFile.database.hostname}:${configFile.database.port}/${databaseName}`;
-      const logQueryParamsArray = Object.entries(queryParams).map(([key, value]) => `${key}=${value}`);
-      if (logQueryParamsArray.length > 0) {
-        logConnectionString += `?${logQueryParamsArray.join('&')}`;
-      }
-      logger.info(`Using database connection string: ${logConnectionString}`);
-    }
-
     // Validate required fields
     const missingFields: string[] = [];
     if (!url.username) missingFields.push('username');
@@ -257,6 +247,16 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
       if (databaseName.match(/^\d/)) {
         databaseName = '_' + databaseName; // Append an underscore if the name starts with a digit
       }
+    }
+
+    if (!cliOptions?.silent) {
+      const logger = new GlobalLogger();
+      let logConnectionString = `postgresql://${configFile.database.username}:***@${configFile.database.hostname}:${configFile.database.port}/${databaseName}`;
+      const logQueryParamsArray = Object.entries(queryParams).map(([key, value]) => `${key}=${value}`);
+      if (logQueryParamsArray.length > 0) {
+        logConnectionString += `?${logQueryParamsArray.join('&')}`;
+      }
+      logger.info(`Using database connection string: ${logConnectionString}`);
     }
   } else {
     // Else, build the config from configFile.database and apply overrides

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -30,7 +30,6 @@ export interface DBConfig {
   app_db_client?: UserDatabaseName;
   migrate?: string[];
   rollback?: string[];
-  local_suffix?: boolean;
 }
 
 export interface ConfigFile {
@@ -309,12 +308,6 @@ export function parseConfigFile(cliOptions?: ParseOptions): [DBOSConfigInternal,
   const configFile: ConfigFile | undefined = loadConfigFile(configFilePath);
   if (!configFile) {
     throw new DBOSInitializationError(`DBOS configuration file ${configFilePath} is empty`);
-  }
-
-  if (configFile.database.local_suffix === true && configFile.database.hostname === 'localhost') {
-    throw new DBOSInitializationError(
-      `Invalid configuration (${configFilePath}): local_suffix may only be true when connecting to remote databases, not to localhost`,
-    );
   }
 
   if (configFile.language && configFile.language !== 'node') {

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -283,7 +283,7 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
 
     // SSL configuration
     const ssl = parseSSLConfig(configFile.database);
-    if (ssl === false || ssl === undefined) {
+    if (ssl === false) {
       queryParams.push(`sslmode=disable`);
     } else if (ssl && 'ca' in ssl) {
       queryParams.push(`sslmode=verify-full`);

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -240,6 +240,7 @@ export function constructPoolConfig(configFile: ConfigFile, cliOptions?: ParseOp
       queryParams.push(`sslmode=disable`);
     } else if (poolConfig.ssl && 'ca' in poolConfig.ssl) {
       queryParams.push(`sslmode=verify-full`);
+      queryParams.push(`sslrootcert=${configFile.database.ssl_ca}`);
     } else {
       queryParams.push(`sslmode=require`);
     }

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -241,7 +241,6 @@ export class PostgresSystemDatabase implements SystemDatabase {
     systemDbConnectionString.pathname = `/${systemDatabaseName}`;
 
     this.systemPoolConfig = {
-      ...pgPoolConfig,
       connectionString: systemDbConnectionString.toString(),
       // This sets the application_name column in pg_stat_activity
       application_name: `dbos_transact_${globalParams.executorID}_${globalParams.appVersion}`,

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -197,12 +197,12 @@ export class PostgresSystemDatabase implements SystemDatabase {
     readonly logger: Logger,
     readonly sysDbPoolSize?: number,
   ) {
-    pgPoolConfig.connectionString = undefined; // connection string would otherwise take precedence over the config object
     this.systemPoolConfig = { ...pgPoolConfig };
     this.systemPoolConfig.database = systemDatabaseName;
     this.systemPoolConfig.connectionTimeoutMillis = PostgresSystemDatabase.connectionTimeoutMillis;
     // This sets the application_name column in pg_stat_activity
     this.systemPoolConfig.application_name = `dbos_transact_${globalParams.executorID}_${globalParams.appVersion}`;
+    this.systemPoolConfig.connectionString = undefined; // connection string would otherwise take precedence over the config object
     this.pool = new Pool(this.systemPoolConfig);
     const knexConfig = {
       client: 'pg',

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -189,20 +189,22 @@ export class PostgresSystemDatabase implements SystemDatabase {
   readonly notificationsMap: Record<string, () => void> = {};
   readonly workflowEventsMap: Record<string, () => void> = {};
 
-  static readonly connectionTimeoutMillis = 10000; // 10 second timeout
-
   constructor(
     readonly pgPoolConfig: PoolConfig,
     readonly systemDatabaseName: string,
     readonly logger: Logger,
     readonly sysDbPoolSize?: number,
   ) {
-    this.systemPoolConfig = { ...pgPoolConfig };
-    this.systemPoolConfig.database = systemDatabaseName;
-    this.systemPoolConfig.connectionTimeoutMillis = PostgresSystemDatabase.connectionTimeoutMillis;
-    // This sets the application_name column in pg_stat_activity
-    this.systemPoolConfig.application_name = `dbos_transact_${globalParams.executorID}_${globalParams.appVersion}`;
-    this.systemPoolConfig.connectionString = undefined; // connection string would otherwise take precedence over the config object
+    // Craft a db string from the app db string, replacing the database name:
+    const systemDbConnectionString = new URL(pgPoolConfig.connectionString!);
+    systemDbConnectionString.pathname = `/${systemDatabaseName}`;
+
+    this.systemPoolConfig = {
+      ...pgPoolConfig,
+      connectionString: systemDbConnectionString.toString(),
+      // This sets the application_name column in pg_stat_activity
+      application_name: `dbos_transact_${globalParams.executorID}_${globalParams.appVersion}`,
+    };
     this.pool = new Pool(this.systemPoolConfig);
     const knexConfig = {
       client: 'pg',

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -202,6 +202,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     this.systemPoolConfig.connectionTimeoutMillis = PostgresSystemDatabase.connectionTimeoutMillis;
     // This sets the application_name column in pg_stat_activity
     this.systemPoolConfig.application_name = `dbos_transact_${globalParams.executorID}_${globalParams.appVersion}`;
+    this.systemPoolConfig.connectionString = undefined; // connection string would otherwise take precedence over the config object
     this.pool = new Pool(this.systemPoolConfig);
     const knexConfig = {
       client: 'pg',

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -197,12 +197,12 @@ export class PostgresSystemDatabase implements SystemDatabase {
     readonly logger: Logger,
     readonly sysDbPoolSize?: number,
   ) {
+    pgPoolConfig.connectionString = undefined; // connection string would otherwise take precedence over the config object
     this.systemPoolConfig = { ...pgPoolConfig };
     this.systemPoolConfig.database = systemDatabaseName;
     this.systemPoolConfig.connectionTimeoutMillis = PostgresSystemDatabase.connectionTimeoutMillis;
     // This sets the application_name column in pg_stat_activity
     this.systemPoolConfig.application_name = `dbos_transact_${globalParams.executorID}_${globalParams.appVersion}`;
-    this.systemPoolConfig.connectionString = undefined; // connection string would otherwise take precedence over the config object
     this.pool = new Pool(this.systemPoolConfig);
     const knexConfig = {
       client: 'pg',

--- a/src/user_database.ts
+++ b/src/user_database.ts
@@ -22,7 +22,7 @@ export async function createDBIfDoesNotExist(poolConfig: PoolConfig, logger: Log
     logger.info(`Database ${poolConfig.database} does not exist, creating...`);
   }
   const app_database = poolConfig.database;
-  const postgresConfig = { ...poolConfig, database: 'postgres' };
+  const postgresConfig = { ...poolConfig, database: 'postgres', connectionString: undefined };
   const postgresClient = new Client(postgresConfig);
   let connection_failed = true;
   try {

--- a/src/user_database.ts
+++ b/src/user_database.ts
@@ -21,8 +21,15 @@ export async function createDBIfDoesNotExist(poolConfig: PoolConfig, logger: Log
   } catch (error) {
     logger.info(`Database ${poolConfig.database} does not exist, creating...`);
   }
+  // Craft a db string from the app db string, replacing the database name:
+  const pgDbConnectionString = new URL(poolConfig.connectionString!);
+  pgDbConnectionString.pathname = '/postgres';
+
   const app_database = poolConfig.database;
-  const postgresConfig = { ...poolConfig, database: 'postgres', connectionString: undefined };
+  const postgresConfig = {
+    ...poolConfig,
+    connectionString: pgDbConnectionString.toString(),
+  };
   const postgresClient = new Client(postgresConfig);
   let connection_failed = true;
   try {

--- a/src/user_database.ts
+++ b/src/user_database.ts
@@ -23,9 +23,9 @@ export async function createDBIfDoesNotExist(poolConfig: PoolConfig, logger: Log
   }
   // Craft a db string from the app db string, replacing the database name:
   const pgDbConnectionString = new URL(poolConfig.connectionString!);
+  const app_database = pgDbConnectionString.pathname.substring(1);
   pgDbConnectionString.pathname = '/postgres';
 
-  const app_database = poolConfig.database;
   const postgresConfig = {
     ...poolConfig,
     connectionString: pgDbConnectionString.toString(),

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -49,6 +49,7 @@ describe('DBOSClient', () => {
 
   beforeAll(async () => {
     config = generateDBOSTestConfig();
+    config.poolConfig!.connectionString = undefined;
     const $poolConfig = config.poolConfig!;
     database_url = `postgres://${$poolConfig.user}:${$poolConfig.password as string}@${$poolConfig.host}:${$poolConfig.port}/${$poolConfig.database}`;
     poolConfig = { ...$poolConfig, database: config.system_database };

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -49,8 +49,8 @@ describe('DBOSClient', () => {
 
   beforeAll(async () => {
     config = generateDBOSTestConfig();
-    config.poolConfig!.connectionString = undefined;
-    const $poolConfig = config.poolConfig!;
+    const $poolConfig = structuredClone(config.poolConfig!);
+    $poolConfig.connectionString = undefined;
     database_url = `postgres://${$poolConfig.user}:${$poolConfig.password as string}@${$poolConfig.host}:${$poolConfig.port}/${$poolConfig.database}`;
     poolConfig = { ...$poolConfig, database: config.system_database };
     await setUpDBOSTestDb(config);

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -982,11 +982,6 @@ describe('dbos-config', () => {
       expect(() => parseDbString(dbString)).toThrow(/missing required field\(s\): password/);
     });
 
-    test('should throw if port is missing', () => {
-      const dbString = 'postgres://user:password@localhost/mydatabase';
-      expect(() => parseDbString(dbString)).toThrow(/missing required field\(s\): port/);
-    });
-
     test('should throw if username and password are missing', () => {
       const dbString = 'postgres://localhost:5432/mydatabase';
       expect(() => parseDbString(dbString)).toThrow(/missing required field\(s\): username, password/);

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -196,7 +196,8 @@ describe('dbos-config', () => {
         database: 'test_app',
         connectionTimeoutMillis: 3000,
         ssl: { ca: ['CA_CERT'], rejectUnauthorized: true },
-        connectionString: 'postgresql://u:p@db:5432/test_app?connect_timeout=3&connection_limit=20&sslmode=verify-full',
+        connectionString:
+          'postgresql://u:p@db:5432/test_app?connect_timeout=3&connection_limit=20&sslmode=verify-full&sslrootcert=ca.pem',
       });
     });
 

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -25,9 +25,9 @@ describe('dbos-config', () => {
       name: 'some app'
       language: 'node'
       database:
-        hostname: 'some host'
+        hostname: 'somehost'
         port: 1234
-        username: 'some user'
+        username: 'someuser'
         password: \${PGPASSWORD}
         app_db_name: 'some_db'
         ssl: false
@@ -237,7 +237,7 @@ describe('dbos-config', () => {
       expect(() => constructPoolConfig(config)).toThrow();
     });
 
-    test.only('constructPoolConfig throws when database_url is missing required fields', () => {
+    test('constructPoolConfig throws when database_url is missing required fields', () => {
       // Test missing password
       const config1 = baseConfig();
       config1.database_url = 'postgres://user@host:5432/db';
@@ -482,9 +482,9 @@ describe('dbos-config', () => {
       const localMockDBOSConfigYamlString = `
         name: some-app
         database:
-          hostname: 'some host'
+          hostname: 'somehost'
           port: 1234
-          username: 'some user'
+          username: 'someuser'
           password: \${PGPASSWORD}
           connectionTimeoutMillis: 3000
           app_db_name: 'some_db'
@@ -511,9 +511,9 @@ describe('dbos-config', () => {
       const localMockDBOSConfigYamlString = `
         name: some-app
         database:
-          hostname: 'some host'
+          hostname: 'somehost'
           port: 1234
-          username: 'some user'
+          username: 'someuser'
           password: \${PGPASSWORD}
           connectionTimeoutMillis: 3000
           app_db_name: 'some_db'

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -991,11 +991,6 @@ describe('dbos-config', () => {
       expect(() => parseDbString(dbString)).toThrow(/missing required field\(s\): username, password/);
     });
 
-    test('should throw if database name is missing', () => {
-      const dbString = 'postgres://user:password@localhost:5432';
-      expect(() => parseDbString(dbString)).toThrow(/missing required field\(s\): app_db_name/);
-    });
-
     test('should throw on empty connection string', () => {
       expect(() => parseDbString('')).toThrow();
     });

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -98,8 +98,7 @@ describe('dbos-config', () => {
         password: 'dbos',
         database: 'test_app',
         connectionTimeoutMillis: 3000,
-        connectionString:
-          'postgresql://postgres:dbos@localhost:5432/test_app?connect_timeout=3&connection_limit=20&sslmode=disable',
+        connectionString: 'postgresql://postgres:dbos@localhost:5432/test_app?connect_timeout=3&sslmode=disable',
       });
     });
 
@@ -131,8 +130,7 @@ describe('dbos-config', () => {
         password: 'envpass',
         database: 'appdb',
         connectionTimeoutMillis: 3000,
-        connectionString:
-          'postgresql://envuser:envpass@envhost:7777/appdb?connect_timeout=3&connection_limit=20&sslmode=disable',
+        connectionString: 'postgresql://envuser:envpass@envhost:7777/appdb?connect_timeout=3&sslmode=disable',
       });
     });
 
@@ -156,7 +154,7 @@ describe('dbos-config', () => {
         connectionTimeoutMillis: 3000,
         max: 7, // from userDbPoolSize
         connectionString:
-          'postgresql://configured_user:dbos@env-host.com:5432/configured_db?connect_timeout=3&connection_limit=7&sslmode=require',
+          'postgresql://configured_user:dbos@env-host.com:5432/configured_db?connect_timeout=3&sslmode=require',
       });
     });
 
@@ -180,8 +178,7 @@ describe('dbos-config', () => {
         password: 'p',
         database: 'test_app',
         connectionTimeoutMillis: 3000,
-        connectionString:
-          'postgresql://u:p@db:5432/test_app?connect_timeout=3&connection_limit=20&sslmode=verify-full&sslrootcert=ca.pem',
+        connectionString: 'postgresql://u:p@db:5432/test_app?connect_timeout=3&sslmode=verify-full&sslrootcert=ca.pem',
       });
     });
 
@@ -715,8 +712,7 @@ describe('dbos-config', () => {
           database: 'appname',
           connectionTimeoutMillis: 3000,
           max: 20,
-          connectionString:
-            'postgresql://postgres:dbos@localhost:5432/appname?connect_timeout=3&connection_limit=20&sslmode=disable',
+          connectionString: 'postgresql://postgres:dbos@localhost:5432/appname?connect_timeout=3&sslmode=disable',
         },
         userDbclient: UserDatabaseName.KNEX,
         telemetry: {
@@ -789,8 +785,7 @@ describe('dbos-config', () => {
           database: 'appname',
           connectionTimeoutMillis: 3000,
           max: 20,
-          connectionString:
-            'postgresql://postgres:dbos@localhost:5432/appname?connect_timeout=3&connection_limit=20&sslmode=disable',
+          connectionString: 'postgresql://postgres:dbos@localhost:5432/appname?connect_timeout=3&sslmode=disable',
         },
         userDbclient: UserDatabaseName.KNEX,
         telemetry: {

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -231,6 +231,37 @@ describe('dbos-config', () => {
       });
     });
 
+    test('append connection parameters from config.database when none are provided in the database_url', () => {
+      const dbUrl = 'postgresql://url_user:url_pass@url_host:9999/url_db';
+
+      jest.spyOn(utils, 'readFileSync').mockReturnValueOnce('{}'); // loadDatabaseConnection()
+
+      const config = baseConfig();
+      config.database = {
+        hostname: 'url_host',
+        port: 9999,
+        username: 'url_user',
+        password: 'url_pass',
+        app_db_name: 'url_db',
+        connectionTimeoutMillis: 42000,
+      };
+      config.database_url = dbUrl;
+
+      const pool = constructPoolConfig(config, { userDbPoolSize: 2 });
+
+      assertPoolConfig(pool, {
+        host: 'url_host',
+        port: 9999,
+        user: 'url_user',
+        password: 'url_pass',
+        database: 'url_db',
+        connectionTimeoutMillis: 42000,
+        ssl: { rejectUnauthorized: false },
+        connectionString:
+          'postgresql://url_user:url_pass@url_host:9999/url_db?connect_timeout=42&connection_limit=2&sslmode=require',
+      });
+    });
+
     test('constructPoolConfig correctly handles app names with spaces', () => {
       const config = baseConfig();
       config.name = 'app name with spaces';

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -120,6 +120,7 @@ describe('dbos-config', () => {
       const config = baseConfig();
       config.database.app_db_name = 'appdb';
       config.database.ssl = false;
+      config.database.hostname = 'something else';
 
       const pool = constructPoolConfig(config);
 
@@ -131,6 +132,29 @@ describe('dbos-config', () => {
         database: 'appdb',
         connectionTimeoutMillis: 3000,
         connectionString: 'postgresql://envuser:envpass@envhost:7777/appdb?connect_timeout=3&sslmode=disable',
+      });
+    });
+
+    test('uses environment variable overrides with connection string input', () => {
+      process.env.DBOS_DBHOST = 'envhost';
+      process.env.DBOS_DBPORT = '7777';
+      process.env.DBOS_DBUSER = 'envuser';
+      process.env.DBOS_DBPASSWORD = 'envpass';
+      process.env.DBOS_DEBUG_WORKFLOW_ID = 'debug-workflow-id';
+
+      const config = baseConfig();
+      config.database_url = 'postgresql://a:b@c:1234/appdb?connect_timeout=22&sslmode=disable';
+
+      const pool = constructPoolConfig(config);
+
+      assertPoolConfig(pool, {
+        host: 'envhost',
+        port: 7777,
+        user: 'envuser',
+        password: 'envpass',
+        database: 'appdb',
+        connectionTimeoutMillis: 22000,
+        connectionString: 'postgresql://envuser:envpass@envhost:7777/appdb?connect_timeout=22&sslmode=disable',
       });
     });
 

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -174,7 +174,7 @@ describe('dbos-config', () => {
         database: 'configured_db', // from config.database
         max: 7, // from userDbPoolSize
         connectionString:
-          'postgresql://configured_user:dbos@env-host.com:5432/configured_db?connect_timeout=3&sslmode=require',
+          'postgresql://configured_user:dbos@env-host.com:5432/configured_db?connect_timeout=3&sslmode=no-verify',
       });
     });
 
@@ -233,7 +233,7 @@ describe('dbos-config', () => {
         password: 'dbos',
         database: 'app_name_with_spaces',
         connectionString:
-          'postgresql://postgres:dbos@localhost:5432/app_name_with_spaces?connect_timeout=3&sslmode=require',
+          'postgresql://postgres:dbos@localhost:5432/app_name_with_spaces?connect_timeout=3&sslmode=no-verify',
       });
     });
 

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -102,7 +102,8 @@ describe('dbos-config', () => {
         database: 'test_app',
         connectionTimeoutMillis: 3000,
         ssl: false,
-        connectionString: 'postgresql://postgres:dbos@localhost:5432/test_app?connect_timeout=3&sslmode=disable',
+        connectionString:
+          'postgresql://postgres:dbos@localhost:5432/test_app?connect_timeout=3&connection_limit=20&sslmode=disable',
       });
     });
 
@@ -140,7 +141,8 @@ describe('dbos-config', () => {
         database: 'appdb',
         connectionTimeoutMillis: 3000,
         ssl: false,
-        connectionString: 'postgresql://envuser:envpass@envhost:7777/appdb?connect_timeout=3&sslmode=disable',
+        connectionString:
+          'postgresql://envuser:envpass@envhost:7777/appdb?connect_timeout=3&connection_limit=20&sslmode=disable',
       });
     });
 
@@ -154,7 +156,7 @@ describe('dbos-config', () => {
         app_db_name: 'configured_db',
       };
 
-      const pool = constructPoolConfig(config);
+      const pool = constructPoolConfig(config, { userDbPoolSize: 7 });
 
       assertPoolConfig(pool, {
         host: 'env-host.com', // from DBOS_DBHOST
@@ -164,8 +166,9 @@ describe('dbos-config', () => {
         database: 'configured_db', // from config.database
         connectionTimeoutMillis: 3000,
         ssl: { rejectUnauthorized: false }, // default
+        max: 7, // from userDbPoolSize
         connectionString:
-          'postgresql://configured_user:dbos@env-host.com:5432/configured_db?connect_timeout=3&sslmode=require',
+          'postgresql://configured_user:dbos@env-host.com:5432/configured_db?connect_timeout=3&connection_limit=7&sslmode=require',
       });
     });
 
@@ -193,7 +196,7 @@ describe('dbos-config', () => {
         database: 'test_app',
         connectionTimeoutMillis: 3000,
         ssl: { ca: ['CA_CERT'], rejectUnauthorized: true },
-        connectionString: 'postgresql://u:p@db:5432/test_app?connect_timeout=3&sslmode=verify-full',
+        connectionString: 'postgresql://u:p@db:5432/test_app?connect_timeout=3&connection_limit=20&sslmode=verify-full',
       });
     });
 
@@ -241,7 +244,7 @@ describe('dbos-config', () => {
         connectionTimeoutMillis: 3000,
         ssl: false,
         connectionString:
-          'postgresql://postgres:dbos@localhost:5432/app_name_with_spaces?connect_timeout=3&sslmode=disable',
+          'postgresql://postgres:dbos@localhost:5432/app_name_with_spaces?connect_timeout=3&connection_limit=20&sslmode=disable',
       });
     });
   });
@@ -778,7 +781,8 @@ describe('dbos-config', () => {
           connectionTimeoutMillis: 3000,
           ssl: false,
           max: 20,
-          connectionString: 'postgresql://postgres:dbos@localhost:5432/appname?connect_timeout=3&sslmode=disable',
+          connectionString:
+            'postgresql://postgres:dbos@localhost:5432/appname?connect_timeout=3&connection_limit=20&sslmode=disable',
         },
         userDbclient: UserDatabaseName.KNEX,
         telemetry: {
@@ -852,7 +856,8 @@ describe('dbos-config', () => {
           connectionTimeoutMillis: 3000,
           ssl: false,
           max: 20,
-          connectionString: 'postgresql://postgres:dbos@localhost:5432/appname?connect_timeout=3&sslmode=disable',
+          connectionString:
+            'postgresql://postgres:dbos@localhost:5432/appname?connect_timeout=3&connection_limit=20&sslmode=disable',
         },
         userDbclient: UserDatabaseName.KNEX,
         telemetry: {

--- a/tests/dbos-runtime/runtime.test.ts
+++ b/tests/dbos-runtime/runtime.test.ts
@@ -16,6 +16,15 @@ async function waitForMessageTest(
   const stdin = command.stdin as unknown as Writable;
   const stderr = command.stderr as unknown as Writable;
 
+  // Capture and print stdout/stderr
+  stdout?.on('data', (data) => {
+    process.stdout.write(`[child stdout]: ${data}`);
+  });
+
+  stderr?.on('data', (data) => {
+    process.stderr.write(`[child stderr]: ${data}`);
+  });
+
   if (!adminPort) {
     adminPort = (Number(port) + 1).toString();
   }

--- a/tests/dbos-runtime/runtime.test.ts
+++ b/tests/dbos-runtime/runtime.test.ts
@@ -132,7 +132,7 @@ describe('runtime-tests-typeorm', () => {
   });
 
   test('test hello-typeorm runtime', async () => {
-    const command = spawn('node_modules/@dbos-inc/dbos-sdk/dist/src/dbos-runtime/cli.js', ['start'], {
+    const command = spawn('node', ['node_modules/@dbos-inc/dbos-sdk/dist/src/dbos-runtime/cli.js', 'start'], {
       env: process.env,
     });
     await waitForMessageTest(command, '3000');
@@ -156,7 +156,7 @@ describe('runtime-tests-prisma', () => {
   });
 
   test('test hello-prisma runtime', async () => {
-    const command = spawn('node_modules/@dbos-inc/dbos-sdk/dist/src/dbos-runtime/cli.js', ['start'], {
+    const command = spawn('node', ['node_modules/@dbos-inc/dbos-sdk/dist/src/dbos-runtime/cli.js', 'start'], {
       env: process.env,
     });
     await waitForMessageTest(command, '3000');
@@ -180,7 +180,7 @@ describe('runtime-tests-drizzle', () => {
   });
 
   test('test hello-drizzle runtime', async () => {
-    const command = spawn('node_modules/@dbos-inc/dbos-sdk/dist/src/dbos-runtime/cli.js', ['start'], {
+    const command = spawn('node', ['node_modules/@dbos-inc/dbos-sdk/dist/src/dbos-runtime/cli.js', 'start'], {
       env: process.env,
     });
     await waitForMessageTest(command, '3000');

--- a/tests/dbos-runtime/runtime.test.ts
+++ b/tests/dbos-runtime/runtime.test.ts
@@ -79,7 +79,7 @@ function configureTemplate() {
   if (process.env.PGPASSWORD === undefined) {
     process.env.PGPASSWORD = 'dbos';
   }
-  execSync('npx dbos migrate', { env: process.env });
+  execSync('npx dbos migrate', { env: process.env, stdio: 'inherit' });
 }
 
 describe('runtime-tests-knex', () => {

--- a/tests/drizzle.test.ts
+++ b/tests/drizzle.test.ts
@@ -12,9 +12,9 @@ import {
   Transaction,
   TransactionContext,
 } from '../src';
-import { DBOSConfig } from '../src/dbos-executor';
+import { DBOSConfig, DBOSConfigInternal } from '../src/dbos-executor';
 import { UserDatabaseName } from '../src/user_database';
-import { generateDBOSTestConfig, generatePublicDBOSTestConfig, setUpDBOSTestDb } from './helpers';
+import { generateDBOSTestConfig, setUpDBOSTestDb } from './helpers';
 import { pgTable, serial, text } from 'drizzle-orm/pg-core';
 import { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { eq } from 'drizzle-orm';
@@ -213,9 +213,10 @@ describe('drizzle-auth-tests', () => {
 class TestEngine {
   @DBOS.transaction()
   static async testEngine() {
+    const pc = (DBOS.dbosConfig as DBOSConfigInternal).poolConfig;
     const ds = DBOS.drizzleClient;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((ds as any).session.client._connectionTimeoutMillis).toEqual(3000);
+    expect((ds as any).session.client._connectionTimeoutMillis).toEqual(pc.connectionTimeoutMillis);
     // Drizzle doesn't expose the pool directly
     await Promise.resolve();
   }
@@ -223,10 +224,12 @@ class TestEngine {
 
 describe('typeorm-engine-config-tests', () => {
   test('engine-config', async () => {
-    const config = generatePublicDBOSTestConfig({
+    const config = {
+      name: 'dbostest',
       userDbclient: UserDatabaseName.DRIZZLE,
       userDbPoolSize: 2,
-    });
+      databaseUrl: `postgres://postgres:${process.env.PGPASSWORD || 'dbos'}@localhost:5432/dbostest?connect_timeout=7`,
+    };
     await setUpDBOSTestDb(config);
     DBOS.setConfig(config);
     await DBOS.launch();

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -29,7 +29,6 @@ export function generateDBOSTestConfig(dbClient?: UserDatabaseName): DBOSConfigI
     telemetry: {
       logs: {
         silent: silenceLogs,
-        logLevel: 'debug',
       },
     },
   };

--- a/tests/knex.test.ts
+++ b/tests/knex.test.ts
@@ -194,10 +194,6 @@ class TestEngine {
     const pc = (DBOS.dbosConfig as DBOSConfigInternal).poolConfig;
     const ds = DBOS.knexClient;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((ds as any).context.client.config.connection.connectionTimeoutMillis).toEqual(3000);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((ds as any).context.client.config.connection.ssl).toEqual(false);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     expect((ds as any).context.client.config.connection.connectionString).toEqual(pc.connectionString);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     expect((ds as any).context.client.config.pool.max).toEqual(2);

--- a/tests/knex.test.ts
+++ b/tests/knex.test.ts
@@ -194,9 +194,11 @@ class TestEngine {
     const pc = (DBOS.dbosConfig as DBOSConfigInternal).poolConfig;
     const ds = DBOS.knexClient;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((ds as any).context.client.config.connection.connectionString).toEqual(pc.connectionString);
+    expect((ds as any).context.client.connectionSettings.connectionString).toEqual(pc.connectionString);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((ds as any).context.client.config.pool.max).toEqual(2);
+    expect((ds as any).context.client.config.pool.max).toEqual(pc.max);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    expect((ds as any).context.client.connectionSettings.connectionTimeoutMillis).toBe(pc.connectionTimeoutMillis);
     await Promise.resolve();
   }
 }
@@ -207,6 +209,7 @@ describe('knex-engine-config-tests', () => {
       name: 'dbostest',
       userDbclient: UserDatabaseName.KNEX,
       userDbPoolSize: 2,
+      databaseUrl: `postgres://postgres:${process.env.PGPASSWORD || 'dbos'}@localhost:5432/dbostest?connect_timeout=7`,
     };
     await setUpDBOSTestDb(config);
     DBOS.setConfig(config);

--- a/tests/knex.test.ts
+++ b/tests/knex.test.ts
@@ -2,9 +2,9 @@ import request from 'supertest';
 
 import { DBOS, Authentication, MiddlewareContext } from '../src';
 import { DBOSInvalidWorkflowTransitionError, DBOSNotAuthorizedError } from '../src/error';
-import { DBOSConfig } from '../src/dbos-executor';
+import { DBOSConfig, DBOSConfigInternal } from '../src/dbos-executor';
 import { UserDatabaseName } from '../src/user_database';
-import { TestKvTable, generateDBOSTestConfig, generatePublicDBOSTestConfig, setUpDBOSTestDb } from './helpers';
+import { TestKvTable, generateDBOSTestConfig, setUpDBOSTestDb } from './helpers';
 import { v1 as uuidv1 } from 'uuid';
 import { Knex } from 'knex';
 import { DatabaseError } from 'pg';
@@ -191,9 +191,14 @@ describe('knex-auth-tests', () => {
 class TestEngine {
   @DBOS.transaction()
   static async testEngine() {
+    const pc = (DBOS.dbosConfig as DBOSConfigInternal).poolConfig;
     const ds = DBOS.knexClient;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((ds as any).context.client.config.connection.connectTimeout).toEqual(3000);
+    expect((ds as any).context.client.config.connection.connectionTimeoutMillis).toEqual(3000);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    expect((ds as any).context.client.config.connection.ssl).toEqual(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    expect((ds as any).context.client.config.connection.connectionString).toEqual(pc.connectionString);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     expect((ds as any).context.client.config.pool.max).toEqual(2);
     await Promise.resolve();
@@ -202,10 +207,11 @@ class TestEngine {
 
 describe('knex-engine-config-tests', () => {
   test('engine-config', async () => {
-    const config = generatePublicDBOSTestConfig({
+    const config = {
+      name: 'dbostest',
       userDbclient: UserDatabaseName.KNEX,
       userDbPoolSize: 2,
-    });
+    };
     await setUpDBOSTestDb(config);
     DBOS.setConfig(config);
     await DBOS.launch();

--- a/tests/pgnode.test.ts
+++ b/tests/pgnode.test.ts
@@ -1,15 +1,16 @@
 import { DBOS } from '../src';
-import { DBOSExecutor } from '../src/dbos-executor';
+import { DBOSExecutor, DBOSConfigInternal } from '../src/dbos-executor';
 import { PostgresSystemDatabase } from '../src/system_database';
 import { UserDatabaseName } from '../src/user_database';
-import { generatePublicDBOSTestConfig, setUpDBOSTestDb } from './helpers';
+import { setUpDBOSTestDb } from './helpers';
 
 class TestEngine {
   @DBOS.transaction()
   static async testEngine() {
+    const pc = (DBOS.dbosConfig as DBOSConfigInternal).poolConfig;
     const ds = DBOS.pgClient;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((ds as any)._connectionTimeoutMillis).toEqual(3000);
+    expect((ds as any)._connectionTimeoutMillis).toEqual(pc.connectionTimeoutMillis);
     // PG doesn't expose the pool directly
     await Promise.resolve();
   }
@@ -17,11 +18,12 @@ class TestEngine {
 
 describe('pgnode-engine-config-tests', () => {
   test('engine-config', async () => {
-    const config = generatePublicDBOSTestConfig({
+    const config = {
       userDbclient: UserDatabaseName.PGNODE,
       userDbPoolSize: 2,
       sysDbPoolSize: 42,
-    });
+      databaseUrl: `postgres://postgres:${process.env.PGPASSWORD || 'dbos'}@localhost:5432/dbostest?connect_timeout=7`,
+    };
     await setUpDBOSTestDb(config);
     DBOS.setConfig(config);
     await DBOS.launch();

--- a/tests/prisma.test.ts
+++ b/tests/prisma.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 
 import { PrismaClient, testkv } from '@prisma/client';
-import { generateDBOSTestConfig, generatePublicDBOSTestConfig, setUpDBOSTestDb } from './helpers';
+import { generateDBOSTestConfig, setUpDBOSTestDb } from './helpers';
 import {
   Transaction,
   TransactionContext,
@@ -242,9 +242,7 @@ class TestEngine {
   static async testEngine() {
     const pc = (DBOS.dbosConfig as DBOSConfigInternal).poolConfig;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((DBOS.prismaClient as any)._engineConfig.overrideDatasources.db.url).toBe(
-      `postgresql://${String(pc.user)}:${String(pc.password)}@${String(pc.host)}:${String(pc.port)}/${String(pc.database)}?connect_timeout=3000&connection_limit=2`,
-    );
+    expect((DBOS.prismaClient as any)._engineConfig.overrideDatasources.db.url).toBe(pc.connectionString);
     const r = await DBOS.prismaClient.$queryRawUnsafe('SELECT 1');
     expect(r.length).toBe(1);
     await Promise.resolve();
@@ -255,10 +253,11 @@ describe('prisma-engine-config-tests', () => {
   let config: DBOSConfig;
 
   test('prisma-engine-config', async () => {
-    config = generatePublicDBOSTestConfig({
+    config = {
+      name: 'dbostest',
       userDbclient: UserDatabaseName.PRISMA,
       userDbPoolSize: 2,
-    });
+    };
     await setUpDBOSTestDb(config);
     DBOS.setConfig(config);
     await DBOS.launch();

--- a/tests/prisma.test.ts
+++ b/tests/prisma.test.ts
@@ -256,7 +256,8 @@ describe('prisma-engine-config-tests', () => {
     config = {
       name: 'dbostest',
       userDbclient: UserDatabaseName.PRISMA,
-      userDbPoolSize: 2,
+      userDbPoolSize: 2, // This is ignored with Prisma
+      databaseUrl: `postgresql://postgres:${process.env.PGPASSWORD || 'dbos'}@localhost:5432/dbostest?connection_limit=2&connect_timeout=3`,
     };
     await setUpDBOSTestDb(config);
     DBOS.setConfig(config);

--- a/tests/proc-test/knexfile.js
+++ b/tests/proc-test/knexfile.js
@@ -4,14 +4,7 @@ const [dbosConfig] = parseConfigFile();
 
 const config = {
   client: 'pg',
-  connection: {
-    host: dbosConfig.poolConfig.host,
-    port: dbosConfig.poolConfig.port,
-    user: dbosConfig.poolConfig.user,
-    password: dbosConfig.poolConfig.password,
-    database: dbosConfig.poolConfig.database,
-    ssl: dbosConfig.poolConfig.ssl,
-  },
+  connection: dbosConfig.poolConfig.connectionString,
   migrations: {
     directory: './migrations',
   },

--- a/tests/stored-proc.test.ts
+++ b/tests/stored-proc.test.ts
@@ -20,7 +20,7 @@ describe('stored-proc-tests', () => {
     process.chdir('tests/proc-test');
 
     const [config] = parseConfigFile();
-    await runSql({ ...config.poolConfig, database: 'postgres' }, async (client) => {
+    await runSql({ ...config.poolConfig, database: 'postgres', connectionString: undefined }, async (client) => {
       await client.query(`DROP DATABASE IF EXISTS ${config.poolConfig.database};`);
       await client.query(`DROP DATABASE IF EXISTS ${config.system_database};`);
       await client.query(`CREATE DATABASE ${config.poolConfig.database};`);

--- a/tests/typeorm.test.ts
+++ b/tests/typeorm.test.ts
@@ -217,10 +217,6 @@ class TestEngine {
     const pc = (DBOS.dbosConfig as DBOSConfigInternal).poolConfig;
     const ds = DBOS.typeORMClient;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((ds as any).connection.driver.master.options.connectionTimeoutMillis).toBe(3000);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((ds as any).connection.driver.master.options.ssl).toBe(false);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     expect((ds as any).connection.driver.master.options.connectionString).toBe(pc.connectionString);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     expect((ds as any).connection.driver.master.options.max).toBe(2);
@@ -234,6 +230,8 @@ describe('typeorm-engine-config-tests', () => {
       name: 'dbostest',
       userDbclient: UserDatabaseName.TYPEORM,
       userDbPoolSize: 2,
+      database_url:
+        'postgresql://maxime:maxime123@userdb-257cbb1e-d285-464a-abe9-58268dbad05e.cvc4gmaa6qm9.us-east-1.rds.amazonaws.com:5432/maximedb',
     };
     await setUpDBOSTestDb(config);
     DBOS.setConfig(config);

--- a/tests/typeorm.test.ts
+++ b/tests/typeorm.test.ts
@@ -230,8 +230,6 @@ describe('typeorm-engine-config-tests', () => {
       name: 'dbostest',
       userDbclient: UserDatabaseName.TYPEORM,
       userDbPoolSize: 2,
-      database_url:
-        'postgresql://maxime:maxime123@userdb-257cbb1e-d285-464a-abe9-58268dbad05e.cvc4gmaa6qm9.us-east-1.rds.amazonaws.com:5432/maximedb',
     };
     await setUpDBOSTestDb(config);
     DBOS.setConfig(config);

--- a/tests/typeorm.test.ts
+++ b/tests/typeorm.test.ts
@@ -219,7 +219,9 @@ class TestEngine {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     expect((ds as any).connection.driver.master.options.connectionString).toBe(pc.connectionString);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((ds as any).connection.driver.master.options.max).toBe(2);
+    expect((ds as any).connection.driver.master.options.max).toBe(pc.max);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    expect((ds as any).queryRunner.databaseConnection._connectionTimeoutMillis).toBe(pc.connectionTimeoutMillis);
     await Promise.resolve();
   }
 }
@@ -230,6 +232,7 @@ describe('typeorm-engine-config-tests', () => {
       name: 'dbostest',
       userDbclient: UserDatabaseName.TYPEORM,
       userDbPoolSize: 2,
+      databaseUrl: `postgres://postgres:${process.env.PGPASSWORD || 'dbos'}@localhost:5432/dbostest?connect_timeout=7`,
     };
     await setUpDBOSTestDb(config);
     DBOS.setConfig(config);

--- a/tests/typeorm.test.ts
+++ b/tests/typeorm.test.ts
@@ -3,9 +3,9 @@ import request from 'supertest';
 import { Entity, Column, PrimaryColumn, PrimaryGeneratedColumn } from 'typeorm';
 import { EntityManager, Unique } from 'typeorm';
 
-import { generateDBOSTestConfig, generatePublicDBOSTestConfig, setUpDBOSTestDb } from './helpers';
+import { generateDBOSTestConfig, setUpDBOSTestDb } from './helpers';
 import { OrmEntities, Authentication, MiddlewareContext, DBOS } from '../src';
-import { DBOSConfig } from '../src/dbos-executor';
+import { DBOSConfig, DBOSConfigInternal } from '../src/dbos-executor';
 import { v1 as uuidv1 } from 'uuid';
 import { UserDatabaseName } from '../src/user_database';
 import { DBOSInvalidWorkflowTransitionError, DBOSNotAuthorizedError } from '../src/error';
@@ -214,9 +214,14 @@ describe('typeorm-auth-tests', () => {
 class TestEngine {
   @DBOS.transaction()
   static async testEngine() {
+    const pc = (DBOS.dbosConfig as DBOSConfigInternal).poolConfig;
     const ds = DBOS.typeORMClient;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     expect((ds as any).connection.driver.master.options.connectionTimeoutMillis).toBe(3000);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    expect((ds as any).connection.driver.master.options.ssl).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+    expect((ds as any).connection.driver.master.options.connectionString).toBe(pc.connectionString);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     expect((ds as any).connection.driver.master.options.max).toBe(2);
     await Promise.resolve();
@@ -225,10 +230,11 @@ class TestEngine {
 
 describe('typeorm-engine-config-tests', () => {
   test('engine-config', async () => {
-    const config = generatePublicDBOSTestConfig({
+    const config = {
+      name: 'dbostest',
       userDbclient: UserDatabaseName.TYPEORM,
       userDbPoolSize: 2,
-    });
+    };
     await setUpDBOSTestDb(config);
     DBOS.setConfig(config);
     await DBOS.launch();


### PR DESCRIPTION
This PR crafts connection strings to create user DB clients.

The key changes are:
- All ORMs use the connection string for config
- Except: connect_timeout and pool size, which must be given separately to be considered
- When the config provides a database url, pass it as is (except for debug user/password/host/port overrides if needed)
- When no url is provided, rebuild one from provided parameters and/or defaults


Notes:
- During DBOS Cloud overrides, craft a connection string from the config file. no-verify for linked databases (no ssl_ca), full-verify otherwise
- When a user provides a connection string, we do a little backfill of the poolConfig params for other parts of the code to keep working
- This PR enforces user / password / hostname / dbname are present in a connection string


Others:
- Remove dangling "local suffix" references
