### PR TITLE
Fix is initialized

### DIFF
--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -298,7 +298,7 @@ export class DBOS {
    * @returns `true` if DBOS has been launched, or `false` otherwise
    */
   static isInitialized(): boolean {
-    return !!DBOSExecutor.globalInstance;
+    return !!DBOSExecutor.globalInstance?.initialized;
   }
 
   /**


### PR DESCRIPTION
Fix a small bug in the DBOS initialization check used by the queue module to warn users if DBOS was already launched when they registered a new queue.

This only happens on the "DBOS runtime" path because it:
- creates an executor
- load the classes
- then calls init

Whereas the common path creates and initializes the executor at once (then load the classes).

**BEFORE:**

Shows up on the dbos runtime path:
![Screenshot 2025-04-23 at 16 16 55](https://github.com/user-attachments/assets/233788a0-4937-4782-96e2-cf1b3f169772)

does not show on the common path:

![Screenshot 2025-04-23 at 16 15 32](https://github.com/user-attachments/assets/c18efbab-c23a-4759-807e-7f0fd5bd802d)


**AFTER THE FIX**
dbos runtime path:
![Screenshot 2025-04-23 at 16 18 20](https://github.com/user-attachments/assets/e40e0003-b5e6-4ab9-b7c2-acdf7b6266da)

common path still warns as expected
![Screenshot 2025-04-23 at 16 18 47](https://github.com/user-attachments/assets/458ebc7c-c33d-4fa4-80e1-faecdeb5138d)
