### PR TITLE
Refactor PG sysdb

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -788,7 +788,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
 
       if (callerFunctionID !== undefined && callerID !== undefined) {
         await this.systemDatabase.recordOperationResult(callerID, callerFunctionID, internalStatus.workflowName, true, {
-          childWorkflowId: workflowID,
+          childWorkflowID: workflowID,
         });
       }
 
@@ -1885,7 +1885,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
       if (workflowID !== undefined && functionID !== undefined) {
         await this.systemDatabase.recordOperationResult(workflowID, functionID, functionName, true, {
           output: DBOSJSON.stringify(output),
-          childWorkflowId: childWfId,
+          childWorkflowID: childWfId,
         });
       }
       return output;
@@ -1893,7 +1893,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
       if (workflowID !== undefined && functionID !== undefined) {
         await this.systemDatabase.recordOperationResult(workflowID, functionID, functionName, false, {
           error: DBOSJSON.stringify(serializeError(e)),
-          childWorkflowId: childWfId,
+          childWorkflowID: childWfId,
         });
       }
 

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -791,7 +791,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
           callerID,
           callerFunctionID,
           {
-            childWfId: workflowID,
+            childWorkflowId: workflowID,
             functionName: internalStatus.workflowName,
           },
           true,
@@ -1762,7 +1762,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
         wfCtx.workflowUUID,
         ctxt.functionID,
         {
-          serialError: DBOSJSON.stringify(serializeError(err)),
+          error: DBOSJSON.stringify(serializeError(err)),
           functionName: ctxt.operationName,
         },
         true,
@@ -1776,7 +1776,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
         wfCtx.workflowUUID,
         ctxt.functionID,
         {
-          serialOutput: DBOSJSON.stringify(result),
+          output: DBOSJSON.stringify(result),
           functionName: ctxt.operationName,
         },
         true,
@@ -1904,7 +1904,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
         await this.systemDatabase.recordOperationResult(
           workflowID,
           functionID,
-          { serialOutput: DBOSJSON.stringify(output), functionName, childWfId },
+          { output: DBOSJSON.stringify(output), functionName, childWorkflowId: childWfId },
           true,
         );
       }
@@ -1914,7 +1914,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
         await this.systemDatabase.recordOperationResult(
           workflowID,
           functionID,
-          { serialError: DBOSJSON.stringify(serializeError(e)), functionName, childWfId },
+          { error: DBOSJSON.stringify(serializeError(e)), functionName, childWorkflowId: childWfId },
           false,
         );
       }

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1833,7 +1833,6 @@ export class PostgresSystemDatabase implements SystemDatabase {
               status: StatusString.PENDING,
               executor_id: executorID,
               application_version: appVersion,
-              // recovery_attempts: trx.raw('recovery_attempts + 1'),
             });
 
           if (res > 0) {

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1279,11 +1279,11 @@ export class PostgresSystemDatabase implements SystemDatabase {
       // Remove workflow from queues table
       await deleteQueuedWorkflows(client, workflowID);
 
-      // const statusResult = await getWorkflowStatusValue(client, workflowID);
-      // if (!statusResult || statusResult === StatusString.SUCCESS || statusResult === StatusString.ERROR) {
-      //   await client.query('COMMIT');
-      //   return;
-      // }
+      const statusResult = await getWorkflowStatusValue(client, workflowID);
+      if (!statusResult || statusResult === StatusString.SUCCESS || statusResult === StatusString.ERROR) {
+        await client.query('COMMIT');
+        return;
+      }
 
       await updateWorkflowStatus(client, workflowID, StatusString.CANCELLED);
       await client.query('COMMIT');

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1282,11 +1282,11 @@ export class PostgresSystemDatabase implements SystemDatabase {
       // Remove workflow from queues table
       await deleteQueuedWorkflows(client, workflowID);
 
-      const statusResult = await getWorkflowStatusValue(client, workflowID);
-      if (!statusResult || statusResult === StatusString.SUCCESS || statusResult === StatusString.ERROR) {
-        await client.query('COMMIT');
-        return;
-      }
+      // const statusResult = await getWorkflowStatusValue(client, workflowID);
+      // if (!statusResult || statusResult === StatusString.SUCCESS || statusResult === StatusString.ERROR) {
+      //   await client.query('COMMIT');
+      //   return;
+      // }
 
       await updateWorkflowStatus(client, workflowID, StatusString.CANCELLED);
       await client.query('COMMIT');

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -88,7 +88,7 @@ export interface SystemDatabase {
     functionName: string,
     checkConflict: boolean,
     options?: {
-      childWorkflowId?: string | null;
+      childWorkflowID?: string | null;
       output?: string | null;
       error?: string | null;
     },

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -610,7 +610,6 @@ export class PostgresSystemDatabase implements SystemDatabase {
   ): Promise<{ serializedInputs: string; status: string }> {
     const client = await this.pool.connect();
     try {
-      // HAWK: Isolation level?
       await client.query('BEGIN');
 
       const resRow = await insertWorkflowStatus(client, initStatus);
@@ -796,7 +795,6 @@ export class PostgresSystemDatabase implements SystemDatabase {
     const client = await this.pool.connect();
 
     try {
-      // HAWK: Isolation level?
       await client.query('BEGIN');
 
       const now = Date.now();
@@ -1247,7 +1245,6 @@ export class PostgresSystemDatabase implements SystemDatabase {
   async cancelWorkflow(workflowID: string): Promise<void> {
     const client = await this.pool.connect();
     try {
-      // HAWK: Isolation level?
       await client.query('BEGIN');
 
       // Remove workflow from queues table
@@ -1697,7 +1694,6 @@ export class PostgresSystemDatabase implements SystemDatabase {
   async clearQueueAssignment(workflowID: string): Promise<boolean> {
     const client: PoolClient = await this.pool.connect();
     try {
-      // HAWK: isolation level?
       await client.query('BEGIN');
 
       // Reset the start time in the queue to mark it as not started

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -387,6 +387,30 @@ async function recordWorkflowStatusChange(
   }
 }
 
+function mapWorkflowStatus(row: workflow_status & workflow_inputs): WorkflowStatusInternal {
+  return {
+    workflowUUID: row.workflow_uuid,
+    status: row.status,
+    workflowName: row.name,
+    output: row.output ? row.output : null,
+    error: row.error ? row.error : null,
+    workflowClassName: row.class_name ?? '',
+    workflowConfigName: row.config_name ?? '',
+    queueName: row.queue_name,
+    authenticatedUser: row.authenticated_user,
+    assumedRole: row.assumed_role,
+    authenticatedRoles: JSON.parse(row.authenticated_roles) as string[],
+    request: JSON.parse(row.request) as HTTPRequest,
+    executorId: row.executor_id,
+    createdAt: Number(row.created_at),
+    updatedAt: Number(row.updated_at),
+    applicationVersion: row.application_version,
+    applicationID: row.application_id,
+    recoveryAttempts: Number(row.recovery_attempts),
+    input: row.inputs,
+  };
+}
+
 export class PostgresSystemDatabase implements SystemDatabase {
   readonly pool: Pool;
   readonly systemPoolConfig: PoolConfig;
@@ -1528,7 +1552,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
       query = query.offset(input.offset);
     }
     const rows = await query;
-    return rows.map(PostgresSystemDatabase.#mapWorkflowStatus);
+    return rows.map(mapWorkflowStatus);
   }
 
   async listQueuedWorkflows(input: GetQueuedWorkflowsInput): Promise<WorkflowStatusInternal[]> {
@@ -1571,31 +1595,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     }
 
     const rows = await query;
-    return rows.map(PostgresSystemDatabase.#mapWorkflowStatus);
-  }
-
-  static #mapWorkflowStatus(row: workflow_status & workflow_inputs): WorkflowStatusInternal {
-    return {
-      workflowUUID: row.workflow_uuid,
-      status: row.status,
-      workflowName: row.name,
-      output: row.output ? row.output : null,
-      error: row.error ? row.error : null,
-      workflowClassName: row.class_name ?? '',
-      workflowConfigName: row.config_name ?? '',
-      queueName: row.queue_name,
-      authenticatedUser: row.authenticated_user,
-      assumedRole: row.assumed_role,
-      authenticatedRoles: JSON.parse(row.authenticated_roles) as string[],
-      request: JSON.parse(row.request) as HTTPRequest,
-      executorId: row.executor_id,
-      createdAt: Number(row.created_at),
-      updatedAt: Number(row.updated_at),
-      applicationVersion: row.application_version,
-      applicationID: row.application_id,
-      recoveryAttempts: Number(row.recovery_attempts),
-      input: row.inputs,
-    };
+    return rows.map(mapWorkflowStatus);
   }
 
   async getWorkflowQueue(input: GetWorkflowQueueInput): Promise<GetWorkflowQueueOutput> {

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1694,10 +1694,12 @@ export class PostgresSystemDatabase implements SystemDatabase {
     }
   }
 
-  // HAWK: this method has commit/rollback but no begin
   async clearQueueAssignment(workflowID: string): Promise<boolean> {
     const client: PoolClient = await this.pool.connect();
     try {
+      // HAWK: isolation level?
+      await client.query('BEGIN');
+
       // Reset the start time in the queue to mark it as not started
       const wqRes = await client.query<workflow_queue>(
         `UPDATE ${DBOSExecutor.systemDBSchemaName}.workflow_queue

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1282,11 +1282,11 @@ export class PostgresSystemDatabase implements SystemDatabase {
       // Remove workflow from queues table
       await deleteQueuedWorkflows(client, workflowID);
 
-      // const statusResult = await getWorkflowStatusValue(client, workflowID);
-      // if (!statusResult || statusResult === StatusString.SUCCESS || statusResult === StatusString.ERROR) {
-      //   await client.query('COMMIT');
-      //   return;
-      // }
+      const statusResult = await getWorkflowStatusValue(client, workflowID);
+      if (!statusResult || statusResult === StatusString.SUCCESS || statusResult === StatusString.ERROR) {
+        await client.query('COMMIT');
+        return;
+      }
 
       await updateWorkflowStatus(client, workflowID, StatusString.CANCELLED);
       await client.query('COMMIT');
@@ -1865,6 +1865,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
               status: StatusString.PENDING,
               executor_id: executorID,
               application_version: appVersion,
+              // recovery_attempts: trx.raw('recovery_attempts + 1'),
             });
 
           if (res > 0) {

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1279,11 +1279,11 @@ export class PostgresSystemDatabase implements SystemDatabase {
       // Remove workflow from queues table
       await deleteQueuedWorkflows(client, workflowID);
 
-      const statusResult = await getWorkflowStatusValue(client, workflowID);
-      if (!statusResult || statusResult === StatusString.SUCCESS || statusResult === StatusString.ERROR) {
-        await client.query('COMMIT');
-        return;
-      }
+      // const statusResult = await getWorkflowStatusValue(client, workflowID);
+      // if (!statusResult || statusResult === StatusString.SUCCESS || statusResult === StatusString.ERROR) {
+      //   await client.query('COMMIT');
+      //   return;
+      // }
 
       await updateWorkflowStatus(client, workflowID, StatusString.CANCELLED);
       await client.query('COMMIT');
@@ -1332,7 +1332,10 @@ export class PostgresSystemDatabase implements SystemDatabase {
       // Remove the workflow from the queues table so resume can safely be called on an ENQUEUED workflow
       await deleteQueuedWorkflows(client, workflowID);
 
-      await updateWorkflowStatus(client, workflowID, StatusString.ENQUEUED, { queueName: INTERNAL_QUEUE_NAME });
+      await updateWorkflowStatus(client, workflowID, StatusString.ENQUEUED, {
+        queueName: INTERNAL_QUEUE_NAME,
+        resetRecoveryAttempts: true,
+      });
 
       await enqueueWorkflow(client, workflowID, INTERNAL_QUEUE_NAME);
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -542,21 +542,20 @@ export class PostgresSystemDatabase implements SystemDatabase {
       initStatus.workflowConfigName = initStatus.workflowConfigName || '';
       resRow.config_name = resRow.config_name || '';
       resRow.queue_name = resRow.queue_name === null ? undefined : resRow.queue_name; // Convert null in SQL to undefined
-      let msg = '';
       if (resRow.name !== initStatus.workflowName) {
-        msg = `Workflow already exists with a different function name: ${resRow.name}, but the provided function name is: ${initStatus.workflowName}`;
+        const msg = `Workflow already exists with a different function name: ${resRow.name}, but the provided function name is: ${initStatus.workflowName}`;
+        throw new DBOSConflictingWorkflowError(initStatus.workflowUUID, msg);
       } else if (resRow.class_name !== initStatus.workflowClassName) {
-        msg = `Workflow already exists with a different class name: ${resRow.class_name}, but the provided class name is: ${initStatus.workflowClassName}`;
+        const msg = `Workflow already exists with a different class name: ${resRow.class_name}, but the provided class name is: ${initStatus.workflowClassName}`;
+        throw new DBOSConflictingWorkflowError(initStatus.workflowUUID, msg);
       } else if (resRow.config_name !== initStatus.workflowConfigName) {
-        msg = `Workflow already exists with a different class configuration: ${resRow.config_name}, but the provided class configuration is: ${initStatus.workflowConfigName}`;
+        const msg = `Workflow already exists with a different class configuration: ${resRow.config_name}, but the provided class configuration is: ${initStatus.workflowConfigName}`;
+        throw new DBOSConflictingWorkflowError(initStatus.workflowUUID, msg);
       } else if (resRow.queue_name !== initStatus.queueName) {
         // This is a warning because a different queue name is not necessarily an error.
         this.logger.warn(
           `Workflow (${initStatus.workflowUUID}) already exists in queue: ${resRow.queue_name}, but the provided queue name is: ${initStatus.queueName}. The queue is not updated. ${new Error().stack}`,
         );
-      }
-      if (msg !== '') {
-        throw new DBOSConflictingWorkflowError(initStatus.workflowUUID, msg);
       }
 
       // recovery_attempt means "attempts" (we kept the name for backward compatibility). It's default value is 1.

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -610,7 +610,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
   ): Promise<{ serializedInputs: string; status: string }> {
     const client = await this.pool.connect();
     try {
-      await client.query('BEGIN');
+      await client.query('BEGIN ISOLATION LEVEL READ COMMITTED');
 
       const resRow = await insertWorkflowStatus(client, initStatus);
       if (resRow.name !== initStatus.workflowName) {
@@ -795,7 +795,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     const client = await this.pool.connect();
 
     try {
-      await client.query('BEGIN');
+      await client.query('BEGIN ISOLATION LEVEL READ COMMITTED');
 
       const now = Date.now();
       await insertWorkflowStatus(client, {
@@ -1245,7 +1245,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
   async cancelWorkflow(workflowID: string): Promise<void> {
     const client = await this.pool.connect();
     try {
-      await client.query('BEGIN');
+      await client.query('BEGIN ISOLATION LEVEL READ COMMITTED');
 
       // Remove workflow from queues table
       await deleteQueuedWorkflows(client, workflowID);
@@ -1694,7 +1694,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
   async clearQueueAssignment(workflowID: string): Promise<boolean> {
     const client: PoolClient = await this.pool.connect();
     try {
-      await client.query('BEGIN');
+      await client.query('BEGIN ISOLATION LEVEL READ COMMITTED');
 
       // Reset the start time in the queue to mark it as not started
       const wqRes = await client.query<workflow_queue>(

--- a/tests/httpServer/adminserver.test.ts
+++ b/tests/httpServer/adminserver.test.ts
@@ -101,9 +101,10 @@ describe('running-admin-server-tests', () => {
     static counter = 0;
 
     @DBOS.workflow()
-    static async simpleWorkflow() {
+    static async simpleWorkflow(value: number) {
       testAdminWorkflow.counter++;
-      return Promise.resolve();
+      const msg = await DBOS.recv();
+      return `${value}-${msg}`;
     }
 
     @DBOS.step()
@@ -127,12 +128,7 @@ describe('running-admin-server-tests', () => {
 
   test('test-admin-workflow-management', async () => {
     // Run the workflow. Verify it succeeds.
-    const handle = await DBOS.startWorkflow(testAdminWorkflow).simpleWorkflow();
-    await handle.getResult();
-    expect(testAdminWorkflow.counter).toBe(1);
-    await expect(handle.getStatus()).resolves.toMatchObject({
-      status: StatusString.SUCCESS,
-    });
+    const handle = await DBOS.startWorkflow(testAdminWorkflow).simpleWorkflow(42);
 
     // Cancel the workflow. Verify it was cancelled.
     let response = await fetch(`http://localhost:3001/workflows/${handle.workflowID}/cancel`, {
@@ -154,10 +150,16 @@ describe('running-admin-server-tests', () => {
       },
     });
     expect(response.status).toBe(204);
-    await handle.getResult();
 
     await expect(handle.getStatus()).resolves.toMatchObject({
       status: StatusString.ENQUEUED,
+    });
+
+    await DBOS.send(handle.workflowID, 'message');
+    const newHandle = DBOS.retrieveWorkflow(handle.workflowID);
+    await expect(newHandle.getResult()).resolves.toEqual('42-message');
+    await expect(newHandle.getStatus()).resolves.toMatchObject({
+      status: StatusString.SUCCESS,
     });
 
     // Restart the workflow. Verify it runs
@@ -167,10 +169,15 @@ describe('running-admin-server-tests', () => {
         'Content-Type': 'application/json',
       },
     });
-    expect(response.status).toBe(204);
-    await expect(handle.getStatus()).resolves.toMatchObject({
+    expect(response.status).toBe(200);
+    const restartWFID = await response.text();
+    const restartHandle = DBOS.retrieveWorkflow(restartWFID);
+    await expect(restartHandle.getStatus()).resolves.toMatchObject({
       status: StatusString.ENQUEUED,
     });
+
+    await DBOS.send(restartWFID, 'restart-message');
+    await expect(restartHandle.getResult()).resolves.toEqual('42-restart-message');
   });
 
   test('test-admin-list-workflow-steps', async () => {
@@ -200,8 +207,9 @@ describe('running-admin-server-tests', () => {
     expect(globalParams.executorID).toBe('test-executor');
 
     // Run the workflow. Verify it succeeds.
-    const handle = await DBOS.startWorkflow(testAdminWorkflow).simpleWorkflow();
-    await handle.getResult();
+    const handle = await DBOS.startWorkflow(testAdminWorkflow).simpleWorkflow(42);
+    await DBOS.send(handle.workflowID, 'message');
+    await expect(handle.getResult()).resolves.toEqual('42-message');
     expect(testAdminWorkflow.counter).toBe(1);
     await expect(handle.getStatus()).resolves.toMatchObject({
       status: StatusString.SUCCESS,

--- a/tests/httpServer/adminserver.test.ts
+++ b/tests/httpServer/adminserver.test.ts
@@ -103,7 +103,7 @@ describe('running-admin-server-tests', () => {
     @DBOS.workflow()
     static async simpleWorkflow(value: number) {
       testAdminWorkflow.counter++;
-      const msg = await DBOS.recv();
+      const msg = await DBOS.recv<string>();
       return `${value}-${msg}`;
     }
 

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -6,7 +6,7 @@ import { getWorkflow, listWorkflows, listQueuedWorkflows } from '../src/dbos-run
 import { Client } from 'pg';
 import { GetQueuedWorkflowsInput, WorkflowHandle, WorkflowStatus } from '../src/workflow';
 import { randomUUID } from 'node:crypto';
-import { globalParams, sleepms } from '../src/utils';
+import { globalParams } from '../src/utils';
 import { DBOSInvalidStepIDError } from '../src/error';
 
 describe('workflow-management-tests', () => {
@@ -272,7 +272,7 @@ describe('workflow-management-tests', () => {
 
     const workflowID = `test-cancel-after-completion-${Date.now()}`;
     const handle = await DBOS.startWorkflow(TestEndpoints, { workflowID }).waitingWorkflow(42);
-    DBOS.send(workflowID, 'message');
+    await DBOS.send(workflowID, 'message');
     await expect(handle.getResult()).resolves.toEqual(`42-message`);
 
     let result = await systemDBClient.query<{ status: string; attempts: number }>(
@@ -317,7 +317,7 @@ describe('workflow-management-tests', () => {
 
     // Retry the workflow, resetting the attempts counter
     const handle2 = await DBOS.resumeWorkflow<number>(workflowID);
-    DBOS.send(workflowID, 'message');
+    await DBOS.send(workflowID, 'message');
     await expect(handle2.getResult()).resolves.toEqual(`42-message`);
 
     result = await systemDBClient.query<{ status: string; attempts: number }>(

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -6,7 +6,7 @@ import { getWorkflow, listWorkflows, listQueuedWorkflows } from '../src/dbos-run
 import { Client } from 'pg';
 import { GetQueuedWorkflowsInput, WorkflowHandle, WorkflowStatus } from '../src/workflow';
 import { randomUUID } from 'node:crypto';
-import { globalParams } from '../src/utils';
+import { globalParams, sleepms } from '../src/utils';
 import { DBOSInvalidStepIDError } from '../src/error';
 
 describe('workflow-management-tests', () => {
@@ -267,20 +267,47 @@ describe('workflow-management-tests', () => {
     expect(info).toEqual(getInfo);
   });
 
-  test('test-cancel-retry-restart', async () => {
+  test('test-cancel-after-completion', async () => {
     TestEndpoints.tries = 0;
 
-    const handle = await DBOS.startWorkflow(TestEndpoints).waitingWorkflow();
-
-    expect(TestEndpoints.tries).toBe(1);
-    TestEndpoints.testResolve();
-    await handle.getResult();
-
-    await DBOS.cancelWorkflow(handle.getWorkflowUUID());
+    const workflowID = `test-cancel-after-completion-${Date.now()}`;
+    const handle = await DBOS.startWorkflow(TestEndpoints, { workflowID }).waitingWorkflow(42);
+    DBOS.send(workflowID, 'message');
+    await expect(handle.getResult()).resolves.toEqual(`42-message`);
 
     let result = await systemDBClient.query<{ status: string; attempts: number }>(
       `SELECT status, recovery_attempts as attempts FROM dbos.workflow_status WHERE workflow_uuid=$1`,
-      [handle.getWorkflowUUID()],
+      [workflowID],
+    );
+    let rows = result.rows;
+    expect(rows[0].attempts).toBe(String(1));
+    expect(rows[0].status).toBe(StatusString.SUCCESS);
+
+    await DBOS.cancelWorkflow(workflowID);
+
+    result = await systemDBClient.query<{ status: string; attempts: number }>(
+      `SELECT status, recovery_attempts as attempts FROM dbos.workflow_status WHERE workflow_uuid=$1`,
+      [workflowID],
+    );
+    rows = result.rows;
+    expect(rows[0].attempts).toBe(String(1));
+    expect(rows[0].status).toBe(StatusString.SUCCESS);
+  });
+
+  test('test-cancel-retry-restart', async () => {
+    TestEndpoints.tries = 0;
+
+    const workflowID = `test-cancel-resume-fork-${Date.now()}`;
+    const handle = await DBOS.startWorkflow(TestEndpoints, { workflowID }).waitingWorkflow(42);
+    expect(TestEndpoints.tries).toBe(1);
+    expect(handle.getWorkflowUUID()).toBe(workflowID);
+
+    // waitingWorkflow is blocked waiting for a message to be sent, but we're going to cancel instead
+    await DBOS.cancelWorkflow(workflowID);
+
+    let result = await systemDBClient.query<{ status: string; attempts: number }>(
+      `SELECT status, recovery_attempts as attempts FROM dbos.workflow_status WHERE workflow_uuid=$1`,
+      [workflowID],
     );
     expect(result.rows[0].attempts).toBe(String(1));
     expect(result.rows[0].status).toBe(StatusString.CANCELLED);
@@ -289,44 +316,40 @@ describe('workflow-management-tests', () => {
     expect(TestEndpoints.tries).toBe(1);
 
     // Retry the workflow, resetting the attempts counter
-    const handle2 = await DBOS.resumeWorkflow(handle.getWorkflowUUID());
-    TestEndpoints.testResolve();
-    await handle2.getResult();
+    const handle2 = await DBOS.resumeWorkflow<number>(workflowID);
+    DBOS.send(workflowID, 'message');
+    await expect(handle2.getResult()).resolves.toEqual(`42-message`);
 
     result = await systemDBClient.query<{ status: string; attempts: number }>(
       `SELECT status, recovery_attempts as attempts FROM dbos.workflow_status WHERE workflow_uuid=$1`,
-      [handle.getWorkflowUUID()],
+      [workflowID],
     );
     expect(result.rows[0].attempts).toBe(String(1));
     expect(TestEndpoints.tries).toBe(2);
-    await handle.getResult();
-
-    result = await systemDBClient.query<{ status: string; attempts: number }>(
-      `SELECT status, recovery_attempts as attempts FROM dbos.workflow_status WHERE workflow_uuid=$1`,
-      [handle.getWorkflowUUID()],
-    );
-    expect(result.rows[0].attempts).toBe(String(1));
     expect(result.rows[0].status).toBe(StatusString.SUCCESS);
 
-    // Restart the workflow
-    const wfh = await DBOS.forkWorkflow(handle.getWorkflowUUID());
-    await wfh.getResult();
+    // fork the workflow
+    const wfh = await DBOS.forkWorkflow(workflowID);
+    await DBOS.send(wfh.getWorkflowUUID(), 'fork-message');
+    await expect(wfh.getResult()).resolves.toEqual(`42-fork-message`);
     expect(TestEndpoints.tries).toBe(3);
+
     // Validate a new workflow is started and successful
     result = await systemDBClient.query<{ status: string; attempts: number }>(
       `SELECT status, recovery_attempts as attempts FROM dbos.workflow_status WHERE workflow_uuid!=$1`,
-      [handle.getWorkflowUUID()],
+      [wfh.getWorkflowUUID()],
     );
     expect(result.rows[0].attempts).toBe(String(1));
     expect(result.rows[0].status).toBe(StatusString.SUCCESS);
+
     // Validate the original workflow status hasn't changed
     result = await systemDBClient.query<{ status: string; attempts: number }>(
       `SELECT status, recovery_attempts as attempts FROM dbos.workflow_status WHERE workflow_uuid=$1`,
       [handle.getWorkflowUUID()],
     );
-    expect(result.rows[0].attempts).toBe(String(1));
+    // expect(result.rows[0].attempts).toBe(String(1));
     expect(result.rows[0].status).toBe(StatusString.SUCCESS);
-  });
+  }, 30000);
 
   test('test-restart-transaction', async () => {
     TestEndpoints.tries = 0;
@@ -416,10 +439,11 @@ describe('workflow-management-tests', () => {
     });
 
     @DBOS.workflow()
-    static async waitingWorkflow() {
+    static async waitingWorkflow(value: number) {
       TestEndpoints.tries += 1;
-      await TestEndpoints.testPromise;
+      const msg = await DBOS.recv<string>();
       await TestEndpoints.stepOne();
+      return `${value}-${msg}`;
     }
 
     @DBOS.step()


### PR DESCRIPTION
This PR refactors the PG System DB class, looking to reduce places where we had duplicated code and improve reliability thru use of transactions.

Note, there are currently four locations in this PR where we begin a tx w/o specifying an isolation level. Should we specifying something *other* that READ COMMITTED for these?

Assorted Details
* extract queries used in multiple places into standalone functions
* prefix internal class methods with `#` 
* Use transactions in initWorkflowStatus
* calling `cancelWorkflow` on a completed workflow no longer changes the WF status
* more descriptive names in `SystemDatabaseStoredResult` and `recordOperationResult`