### PR TITLE
add DBOS.listWorkflowSteps

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -212,7 +212,7 @@ export class DBOSClient {
     return listQueuedWorkflows(this.systemDatabase, input);
   }
 
-  listWorkflowSteps(workflowID: string): Promise<StepInfo[]> {
+  listWorkflowSteps(workflowID: string): Promise<StepInfo[] | undefined> {
     return listWorkflowSteps(this.systemDatabase, this.userDatabase, workflowID);
   }
 }

--- a/src/conductor/conductor.ts
+++ b/src/conductor/conductor.ts
@@ -269,7 +269,7 @@ export class Conductor {
             let workflowSteps: protocol.WorkflowSteps[] | undefined = undefined;
             try {
               const stepsInfo = await this.dbosExec.listWorkflowSteps(listStepsMessage.workflow_id);
-              workflowSteps = stepsInfo.map((i) => new protocol.WorkflowSteps(i));
+              workflowSteps = stepsInfo?.map((i) => new protocol.WorkflowSteps(i));
             } catch (e) {
               errorMsg = `Exception encountered when listing steps ${listStepsMessage.workflow_id}: ${(e as Error).message}`;
               this.dbosExec.logger.error(errorMsg);

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -1879,7 +1879,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
     return listQueuedWorkflows(this.systemDatabase, input);
   }
 
-  async listWorkflowSteps(workflowID: string): Promise<StepInfo[]> {
+  async listWorkflowSteps(workflowID: string): Promise<StepInfo[] | undefined> {
     return listWorkflowSteps(this.systemDatabase, this.userDatabase, workflowID);
   }
 

--- a/src/dbos-runtime/workflow_management.ts
+++ b/src/dbos-runtime/workflow_management.ts
@@ -28,7 +28,12 @@ export async function listWorkflowSteps(
   sysdb: SystemDatabase,
   userdb: UserDatabase,
   workflowID: string,
-): Promise<StepInfo[]> {
+): Promise<StepInfo[] | undefined> {
+  const status = await sysdb.getWorkflowStatus(workflowID);
+  if (!status) {
+    return undefined;
+  }
+
   type TxOutputs = Pick<transaction_outputs, 'function_id' | 'function_name' | 'output' | 'error'>;
   const [$steps, $txs] = await Promise.all([
     sysdb.getAllOperationResults(workflowID),

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -25,6 +25,7 @@ import {
   GetWorkflowQueueOutput,
   GetWorkflowsInput,
   GetWorkflowsOutput,
+  StepInfo,
   WorkflowConfig,
   WorkflowFunction,
   WorkflowParams,
@@ -953,13 +954,20 @@ export class DBOS {
       return await DBOS.executor.listQueuedWorkflows(input);
     }, 'DBOS.listQueuedWorkflows');
   }
+
+  static async listWorkflowSteps(workflowID: string): Promise<StepInfo[]> {
+    return await DBOS.runAsWorkflowStep(async () => {
+      return await DBOS.executor.listWorkflowSteps(workflowID);
+    }, 'DBOS.listWorkflowSteps');
+  }
+
   /**
    * Cancel a workflow given its ID.
    * If the workflow is currently running, `DBOSWorkflowCancelledError` will be
    *   thrown from its next DBOS call.
    * @param workflowID - ID of the workflow
    */
-  static async cancelWorkflow(workflowID: string) {
+  static async cancelWorkflow(workflowID: string): Promise<void> {
     return await DBOS.runAsWorkflowStep(async () => {
       return await DBOS.executor.cancelWorkflow(workflowID);
     }, 'DBOS.cancelWorkflow');

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -941,7 +941,7 @@ export class DBOS {
   /**
    * Query the system database for all workflows matching the provided predicate
    * @param input - `GetWorkflowsInput` predicate for filtering returned workflows
-   * @returns `GetWorkflowsOutput` listing the workflow IDs of matching workflows
+   * @returns `WorkflowStatus` array containing details of the matching workflows
    */
   static async listWorkflows(input: GetWorkflowsInput): Promise<WorkflowStatus[]> {
     return await DBOS.runAsWorkflowStep(async () => {
@@ -949,12 +949,22 @@ export class DBOS {
     }, 'DBOS.listWorkflows');
   }
 
+  /**
+   * Query the system database for all queued workflows matching the provided predicate
+   * @param input - `GetQueuedWorkflowsInput` predicate for filtering returned workflows
+   * @returns `WorkflowStatus` array containing details of the matching workflows
+   */
   static async listQueuedWorkflows(input: GetQueuedWorkflowsInput): Promise<WorkflowStatus[]> {
     return await DBOS.runAsWorkflowStep(async () => {
       return await DBOS.executor.listQueuedWorkflows(input);
     }, 'DBOS.listQueuedWorkflows');
   }
 
+  /**
+   * Retrieve the steps of a workflow
+   * @param workflowID - ID of the workflow
+   * @returns `StepInfo` array listing the executed steps of the workflow
+   */
   static async listWorkflowSteps(workflowID: string): Promise<StepInfo[]> {
     return await DBOS.runAsWorkflowStep(async () => {
       return await DBOS.executor.listWorkflowSteps(workflowID);

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -965,7 +965,7 @@ export class DBOS {
    * @param workflowID - ID of the workflow
    * @returns `StepInfo` array listing the executed steps of the workflow
    */
-  static async listWorkflowSteps(workflowID: string): Promise<StepInfo[]> {
+  static async listWorkflowSteps(workflowID: string): Promise<StepInfo[] | undefined> {
     return await DBOS.runAsWorkflowStep(async () => {
       return await DBOS.executor.listWorkflowSteps(workflowID);
     }, 'DBOS.listWorkflowSteps');

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -963,7 +963,7 @@ export class DBOS {
   /**
    * Retrieve the steps of a workflow
    * @param workflowID - ID of the workflow
-   * @returns `StepInfo` array listing the executed steps of the workflow
+   * @returns `StepInfo` array listing the executed steps of the workflow. If the workflow is not found, `undefined` is returned.
    */
   static async listWorkflowSteps(workflowID: string): Promise<StepInfo[] | undefined> {
     return await DBOS.runAsWorkflowStep(async () => {

--- a/src/eventreceiver.ts
+++ b/src/eventreceiver.ts
@@ -113,8 +113,8 @@ export interface DBOSExecutorContext {
   listWorkflows(input: GetWorkflowsInput): Promise<WorkflowStatus[]>;
   /** @deprecated Use functions on `DBOS` */
   listQueuedWorkflows(input: GetQueuedWorkflowsInput): Promise<WorkflowStatus[]>;
-
-  listWorkflowSteps(workflowID: string): Promise<StepInfo[]>;
+  /** @deprecated Use functions on `DBOS` */
+  listWorkflowSteps(workflowID: string): Promise<StepInfo[] | undefined>;
   /** @deprecated Use functions on `DBOS` */
   getWorkflowQueue(input: GetWorkflowQueueInput): Promise<GetWorkflowQueueOutput>;
   /** @deprecated Use functions on `DBOS` */

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -361,7 +361,7 @@ export class DBOSHttpServer {
     const workflowStepsHandler = async (koaCtxt: Koa.Context) => {
       const workflowId = (koaCtxt.params as { workflow_id: string }).workflow_id;
       const steps = await dbosExec.listWorkflowSteps(workflowId);
-      koaCtxt.body = steps.map((step) => ({
+      koaCtxt.body = steps?.map((step) => ({
         function_name: step.name,
         function_id: step.functionID,
         output: step.output ? DBOSJSON.stringify(step.output) : undefined,

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -831,6 +831,9 @@ describe('test-list-steps', () => {
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).testWorkflow();
     await handle.getResult();
     const wfsteps = await DBOSExecutor.globalInstance!.listWorkflowSteps(wfid);
+    if (!wfsteps) {
+      throw new Error('wfsteps is undefined');
+    }
     expect(wfsteps.length).toBe(3);
     expect(wfsteps[0].functionID).toBe(0);
     expect(wfsteps[0].name).toBe('stepOne');
@@ -838,6 +841,14 @@ describe('test-list-steps', () => {
     expect(wfsteps[1].name).toBe('stepTwo');
     expect(wfsteps[2].functionID).toBe(2);
     expect(wfsteps[2].name).toBe('DBOS.sleep');
+  });
+
+  test('test-list-steps-invalid-wfid', async () => {
+    const wfid = randomUUID();
+    const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).testWorkflow();
+    await handle.getResult();
+    const wfsteps = await DBOSExecutor.globalInstance!.listWorkflowSteps(randomUUID());
+    expect(wfsteps).toBeUndefined();
   });
 
   test('test-send-recv', async () => {
@@ -849,11 +860,17 @@ describe('test-list-steps', () => {
 
     await handle.getResult();
     const wfsteps = await DBOSExecutor.globalInstance!.listWorkflowSteps(wfid1);
+    if (!wfsteps) {
+      throw new Error('wfsteps is undefined');
+    }
     expect(wfsteps.length).toBe(2);
     expect(wfsteps[1].name).toBe('DBOS.sleep');
     expect(wfsteps[0].name).toBe('DBOS.recv');
 
     const wfsteps2 = await DBOSExecutor.globalInstance!.listWorkflowSteps(wfid2);
+    if (!wfsteps2) {
+      throw new Error('wfsteps2 is undefined');
+    }
     expect(wfsteps2[0].functionID).toBe(0);
     expect(wfsteps2[0].name).toBe('DBOS.send');
   });
@@ -863,6 +880,9 @@ describe('test-list-steps', () => {
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).setEventWorkflow();
     await handle.getResult();
     const wfsteps = await DBOSExecutor.globalInstance!.listWorkflowSteps(wfid);
+    if (!wfsteps) {
+      throw new Error('wfsteps is undefined');
+    }
     expect(wfsteps.length).toBe(3);
     expect(wfsteps[0].name).toBe('DBOS.setEvent');
     expect(wfsteps[1].name).toBe('DBOS.getEvent');
@@ -873,6 +893,9 @@ describe('test-list-steps', () => {
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).callChildWorkflowfirst();
     const childID = await handle.getResult();
     const wfsteps = await DBOSExecutor.globalInstance!.listWorkflowSteps(wfid);
+    if (!wfsteps) {
+      throw new Error('wfsteps is undefined');
+    }
     expect(wfsteps.length).toBe(5);
     expect(wfsteps[0].name).toBe('testWorkflow');
     expect(wfsteps[0].functionID).toBe(0);
@@ -902,6 +925,9 @@ describe('test-list-steps', () => {
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).callChildWorkflowMiddle();
     await handle.getResult();
     const wfsteps = await DBOSExecutor.globalInstance!.listWorkflowSteps(wfid);
+    if (!wfsteps) {
+      throw new Error('wfsteps is undefined');
+    }
     expect(wfsteps.length).toBe(5);
     expect(wfsteps[0].name).toBe('stepOne');
     expect(wfsteps[1].name).toBe('testWorkflow');
@@ -915,6 +941,9 @@ describe('test-list-steps', () => {
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).callChildWorkflowLast();
     await handle.getResult();
     const wfsteps = await DBOSExecutor.globalInstance!.listWorkflowSteps(wfid);
+    if (!wfsteps) {
+      throw new Error('wfsteps is undefined');
+    }
     expect(wfsteps.length).toBe(5);
     expect(wfsteps[0].name).toBe('stepOne');
     expect(wfsteps[1].name).toBe('stepTwo');
@@ -928,6 +957,9 @@ describe('test-list-steps', () => {
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).enqueueChildWorkflowFirst();
     const childID = await handle.getResult();
     const wfsteps = await DBOSExecutor.globalInstance!.listWorkflowSteps(wfid);
+    if (!wfsteps) {
+      throw new Error('wfsteps is undefined');
+    }
     expect(wfsteps.length).toBe(5);
     expect(wfsteps[0].name).toBe('testWorkflow');
     expect(wfsteps[0].functionID).toBe(0);
@@ -949,6 +981,9 @@ describe('test-list-steps', () => {
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).enqueueChildWorkflowMiddle();
     await handle.getResult();
     const wfsteps = await DBOSExecutor.globalInstance!.listWorkflowSteps(wfid);
+    if (!wfsteps) {
+      throw new Error('wfsteps is undefined');
+    }
     expect(wfsteps.length).toBe(5);
     expect(wfsteps[0].name).toBe('stepOne');
     expect(wfsteps[1].name).toBe('testWorkflow');
@@ -962,6 +997,9 @@ describe('test-list-steps', () => {
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).enqueueChildWorkflowLast();
     await handle.getResult();
     const wfsteps = await DBOSExecutor.globalInstance!.listWorkflowSteps(wfid);
+    if (!wfsteps) {
+      throw new Error('wfsteps is undefined');
+    }
     expect(wfsteps.length).toBe(5);
     expect(wfsteps[0].name).toBe('stepOne');
     expect(wfsteps[1].name).toBe('stepTwo');
@@ -975,6 +1013,9 @@ describe('test-list-steps', () => {
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).directCallWorkflow();
     const childID = await handle.getResult();
     const wfsteps = await DBOSExecutor.globalInstance!.listWorkflowSteps(wfid);
+    if (!wfsteps) {
+      throw new Error('wfsteps is undefined');
+    }
     expect(wfsteps.length).toBe(4);
     expect(wfsteps[0].name).toBe('testWorkflow');
     expect(wfsteps[0].functionID).toBe(0);
@@ -996,6 +1037,9 @@ describe('test-list-steps', () => {
     let handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).callFailingStep();
     await expect(handle.getResult()).rejects.toThrow(new Error('fail'));
     let wfsteps = await DBOSExecutor.globalInstance!.listWorkflowSteps(wfid);
+    if (!wfsteps) {
+      throw new Error('wfsteps is undefined');
+    }
     expect(wfsteps.length).toBe(1);
     expect(wfsteps[0].name).toBe('failingStep');
     expect(wfsteps[0].output).toBe(null);
@@ -1006,6 +1050,9 @@ describe('test-list-steps', () => {
     handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).startFailingStep();
     await expect(handle.getResult()).rejects.toThrow(new Error('fail'));
     wfsteps = await DBOSExecutor.globalInstance!.listWorkflowSteps(wfid);
+    if (!wfsteps) {
+      throw new Error('wfsteps is undefined');
+    }
     expect(wfsteps.length).toBe(2);
     expect(wfsteps[0].name).toBe('temp_workflow-step-failingStep');
     expect(wfsteps[0].output).toBe(null);
@@ -1021,7 +1068,9 @@ describe('test-list-steps', () => {
     await expect(handle.getResult()).rejects.toThrow(new Error('fail'));
 
     wfsteps = await DBOSExecutor.globalInstance!.listWorkflowSteps(wfid);
-
+    if (!wfsteps) {
+      throw new Error('wfsteps is undefined');
+    }
     expect(wfsteps.length).toBe(2);
     expect(wfsteps[0].name).toBe('temp_workflow-step-failingStep');
     expect(wfsteps[0].output).toBe(null);
@@ -1063,6 +1112,9 @@ describe('test-list-steps', () => {
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).workflowWithTransaction();
     await handle.getResult();
     const wfsteps = await DBOSExecutor.globalInstance!.listWorkflowSteps(wfid);
+    if (!wfsteps) {
+      throw new Error('wfsteps is undefined');
+    }
     expect(wfsteps.length).toBe(1);
     expect(wfsteps[0].name).toBe('transaction');
     expect(wfsteps[0].output).toBe(wfid);
@@ -1074,6 +1126,9 @@ describe('test-list-steps', () => {
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).workflowWithTransactionError();
     await handle.getResult();
     const wfsteps = await DBOSExecutor.globalInstance!.listWorkflowSteps(wfid);
+    if (!wfsteps) {
+      throw new Error('wfsteps is undefined');
+    }
     expect(wfsteps.length).toBe(1);
     expect(wfsteps[0].name).toBe('transactionWithError');
     expect(wfsteps[0].error).toBeInstanceOf(Error);
@@ -1085,6 +1140,9 @@ describe('test-list-steps', () => {
     const handle = await DBOS.startWorkflow(TestListSteps, { workflowID: wfid }).workflowWithTransactionAndSteps();
     await handle.getResult();
     const wfsteps = await DBOSExecutor.globalInstance!.listWorkflowSteps(wfid);
+    if (!wfsteps) {
+      throw new Error('wfsteps is undefined');
+    }
     expect(wfsteps.length).toBe(3);
     expect(wfsteps[0].name).toBe('stepOne');
     expect(wfsteps[1].name).toBe('transaction');


### PR DESCRIPTION
Also modified `listWorkflowSteps` to return `undefined` for invalid WFIDs instead of an empty array, allowing callers to differentiate between an invalid WF and a WF that hasn't started executing yet.