### PR TITLE
Support fork in Conductor

### DIFF
--- a/src/conductor/conductor.ts
+++ b/src/conductor/conductor.ts
@@ -175,6 +175,22 @@ export class Conductor {
             const restartResp = new protocol.RestartResponse(baseMsg.request_id, restartSuccess, errorMsg);
             this.websocket!.send(DBOSJSON.stringify(restartResp));
             break;
+          case protocol.MessageType.FORK_WORKFLOW:
+            const forkMsg = baseMsg as protocol.ForkWorkflowRequest;
+            let newWorkflowID = forkMsg.body.new_workflow_id;
+            try {
+              newWorkflowID = await this.dbosExec.forkWorkflow(forkMsg.body.workflow_id, forkMsg.body.start_step, {
+                newWorkflowID: newWorkflowID,
+                applicationVersion: forkMsg.body.application_version,
+              });
+            } catch (e) {
+              errorMsg = `Exception encountered when forking workflow ${forkMsg.body.workflow_id} to new workflow ${newWorkflowID} on step ${forkMsg.body.start_step}, app version ${forkMsg.body.application_version}: ${(e as Error).message}`;
+              this.dbosExec.logger.error(errorMsg);
+              newWorkflowID = undefined;
+            }
+            const forkResp = new protocol.ForkWorkflowResponse(baseMsg.request_id, newWorkflowID, errorMsg);
+            this.websocket!.send(DBOSJSON.stringify(forkResp));
+            break;
           case protocol.MessageType.LIST_WORKFLOWS:
             const listWFMsg = baseMsg as protocol.ListWorkflowsRequest;
             const body = listWFMsg.body;

--- a/src/conductor/protocol.ts
+++ b/src/conductor/protocol.ts
@@ -13,6 +13,7 @@ export enum MessageType {
   GET_WORKFLOW = 'get_workflow',
   EXIST_PENDING_WORKFLOWS = 'exist_pending_workflows',
   LIST_STEPS = 'list_steps',
+  FORK_WORKFLOW = 'fork_workflow',
 }
 
 export interface BaseMessage {
@@ -292,5 +293,30 @@ export class ListStepsResponse extends BaseResponse {
   constructor(request_id: string, output?: WorkflowSteps[], error_message?: string) {
     super(MessageType.LIST_STEPS, request_id, error_message);
     this.output = output;
+  }
+}
+
+export interface ForkWorkflowBody {
+  workflow_id: string;
+  start_step: number;
+  application_version?: string;
+  new_workflow_id?: string;
+}
+
+export class ForkWorkflowRequest implements BaseMessage {
+  type = MessageType.FORK_WORKFLOW;
+  request_id: string;
+  body: ForkWorkflowBody;
+  constructor(request_id: string, body: ForkWorkflowBody) {
+    this.request_id = request_id;
+    this.body = body;
+  }
+}
+
+export class ForkWorkflowResponse extends BaseResponse {
+  new_workflow_id?: string;
+  constructor(request_id: string, new_workflow_id?: string, error_message?: string) {
+    super(MessageType.FORK_WORKFLOW, request_id, error_message);
+    this.new_workflow_id = new_workflow_id;
   }
 }

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -278,7 +278,22 @@ export class DBOSHttpServer {
     const workflowResumeHandler = async (koaCtxt: Koa.Context) => {
       const workflowId = (koaCtxt.params as { workflow_id: string }).workflow_id;
       dbosExec.logger.info(`Resuming workflow with ID: ${workflowId}`);
-      await dbosExec.resumeWorkflow(workflowId);
+      try {
+        await dbosExec.resumeWorkflow(workflowId);
+      } catch (e) {
+        let errorMessage = '';
+        if (e instanceof DBOSError) {
+          errorMessage = e.message;
+        } else {
+          errorMessage = `Unknown error`;
+        }
+        dbosExec.logger.error(`Error resuming workflow ${workflowId}: ${errorMessage}`);
+        koaCtxt.status = 500;
+        koaCtxt.body = {
+          error: `Error resuming workflow ${workflowId}: ${errorMessage}`,
+        };
+        return;
+      }
       koaCtxt.status = 204;
     };
     router.post(workflowResumeUrl, workflowResumeHandler);

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1242,7 +1242,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     }
   }
 
-  // public done
+  // TODO: make cancel throw an error if the workflow doesn't exist.
   async cancelWorkflow(workflowID: string): Promise<void> {
     const client = await this.pool.connect();
     try {
@@ -1299,6 +1299,11 @@ export class PostgresSystemDatabase implements SystemDatabase {
       const statusResult = await getWorkflowStatusValue(client, workflowID);
       if (!statusResult || statusResult === StatusString.SUCCESS || statusResult === StatusString.ERROR) {
         await client.query('ROLLBACK');
+        if (!statusResult) {
+          if (statusResult === undefined) {
+            throw new DBOSNonExistentWorkflowError(`Workflow ${workflowID} does not exist`);
+          }
+        }
         return;
       }
 

--- a/tests/httpServer/adminserver.test.ts
+++ b/tests/httpServer/adminserver.test.ts
@@ -151,6 +151,15 @@ describe('running-admin-server-tests', () => {
     });
     expect(response.status).toBe(204);
 
+    // Resume a non-existent workflow should fail
+    response = await fetch(`http://localhost:3001/workflows/invalid-workflow-id/resume`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    expect(response.status).toBe(500);
+
     await expect(handle.getStatus()).resolves.toMatchObject({
       status: StatusString.ENQUEUED,
     });

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -9,7 +9,7 @@ import { globalParams } from '../src/utils';
 import { PostgresSystemDatabase } from '../src/system_database';
 import { GlobalLogger as Logger } from '../src/telemetry/logs';
 import { getWorkflow, listQueuedWorkflows, listWorkflows } from '../src/dbos-runtime/workflow_management';
-import { DBOSInvalidStepIDError } from '../src/error';
+import { DBOSInvalidStepIDError, DBOSNonExistentWorkflowError } from '../src/error';
 
 describe('workflow-management-tests', () => {
   const testTableName = 'dbos_test_kv';
@@ -338,6 +338,11 @@ describe('workflow-management-tests', () => {
     expect(result.rows[0].attempts).toBe(String(1));
     expect(TestEndpoints.tries).toBe(2);
     expect(result.rows[0].status).toBe(StatusString.SUCCESS);
+
+    // Resume a non-existant workflow should throw an error
+    await expect(DBOS.resumeWorkflow('fake-workflow')).rejects.toThrow(
+      new DBOSNonExistentWorkflowError(`Workflow fake-workflow does not exist`),
+    );
 
     // fork the workflow
     const wfh = await DBOS.forkWorkflow(workflowID, 0);


### PR DESCRIPTION
- Support `forkWorkflow` in conductor mode.
- Make resume throws `DBOSNonExistentWorkflowError` if the workflow doesn't exist.