### PR TITLE
remove undocumented parts of DBOS public surface area

### DIFF
--- a/src/dbos-runtime/runtime.ts
+++ b/src/dbos-runtime/runtime.ts
@@ -38,7 +38,7 @@ export class DBOSRuntime {
   ) {
     // Initialize workflow executor.
     this.dbosConfig = dbosConfig;
-    DBOS.dbosConfig = dbosConfig;
+    DBOS.setConfig(dbosConfig);
   }
 
   /**

--- a/src/dbos-runtime/runtime.ts
+++ b/src/dbos-runtime/runtime.ts
@@ -50,7 +50,6 @@ export class DBOSRuntime {
         throw new Error('DBOS pool configuration is not initialized');
       }
       this.dbosExec = new DBOSExecutor(this.dbosConfig);
-      DBOS.globalLogger = this.dbosExec.logger;
       this.dbosExec.logger.debug(`Loading classes from entrypoints ${JSON.stringify(this.runtimeConfig.entrypoints)}`);
       await DBOSRuntime.loadClasses(this.runtimeConfig.entrypoints);
       await this.dbosExec.init();

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -372,7 +372,6 @@ export class DBOS {
     });
 
     const executor: DBOSExecutor = DBOSExecutor.globalInstance;
-    DBOS.globalLogger = executor.logger;
     await executor.init();
 
     const debugWorkflowId = process.env.DBOS_DEBUG_WORKFLOW_ID;
@@ -575,7 +574,6 @@ export class DBOS {
   //////
   // Globals
   //////
-  static globalLogger?: DLogger;
   static dbosConfig?: DBOSConfig;
   static #runtimeConfig?: DBOSRuntimeConfig = undefined;
   static #invokeWrappers: Map<unknown, unknown> = new Map();

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -517,9 +517,7 @@ export class DBOS {
     return DBOSExecutor.globalInstance?.initEventReceivers();
   }
 
-  /**
-   * Global DBOS executor instance
-   */
+  // Global DBOS executor instance
   static get #executor() {
     return getExecutor();
   }

--- a/src/httpServer/middleware.ts
+++ b/src/httpServer/middleware.ts
@@ -7,7 +7,7 @@ import { DBOSUndefinedDecoratorInputError } from '../error';
 import { Logger as DBOSLogger } from '../telemetry/logs';
 import { UserDatabaseClient } from '../user_database';
 import { OperationType } from '../dbos-executor';
-import { DBOS } from '../dbos';
+import { DBOS, getExecutor } from '../dbos';
 import { HTTPRequest } from '../context';
 import { Context as HonoContext, Next as HonoNext } from 'hono';
 
@@ -189,10 +189,10 @@ export function createHTTPSpan(request: HTTPRequest, httpTracer: W3CTraceContext
   };
   if (extractedSpanContext === undefined) {
     // request.url should be defined by now. Let's cast it to string
-    span = DBOS.executor.tracer.startSpan(request.url as string, spanAttributes);
+    span = getExecutor().tracer.startSpan(request.url as string, spanAttributes);
   } else {
     extractedSpanContext.isRemote = true;
-    span = DBOS.executor.tracer.startSpanWithContext(extractedSpanContext, request.url as string, spanAttributes);
+    span = getExecutor().tracer.startSpanWithContext(extractedSpanContext, request.url as string, spanAttributes);
   }
   return span;
 }
@@ -229,7 +229,7 @@ export async function koaTracingMiddleware(ctx: Koa.Context, next: Koa.Next) {
     }
     throw e;
   } finally {
-    DBOS.executor.tracer.endSpan(span);
+    getExecutor().tracer.endSpan(span);
   }
 }
 
@@ -269,7 +269,7 @@ export async function expressTracingMiddleware(req: Request, res: Response, next
     }
     throw e;
   } finally {
-    DBOS.executor.tracer.endSpan(span);
+    getExecutor().tracer.endSpan(span);
   }
 }
 
@@ -310,6 +310,6 @@ export async function honoTracingMiddleware(ctx: HonoContext, next: HonoNext) {
     }
     throw e;
   } finally {
-    DBOS.executor.tracer.endSpan(span);
+    getExecutor().tracer.endSpan(span);
   }
 }

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -151,7 +151,7 @@ export class TestingRuntimeImpl implements TestingRuntime {
    */
   async init(userClasses?: object[], testConfig?: DBOSConfigInternal, options: DBOSExecutorOptions = {}) {
     const dbosConfig = testConfig ? [testConfig] : parseConfigFile();
-    DBOS.dbosConfig = dbosConfig[0];
+    DBOS.setConfig(dbosConfig[0]);
     this.#dbosExec = new DBOSExecutor(dbosConfig[0], options);
     this.#applicationConfig = this.#dbosExec.config.application ?? {};
     await this.#dbosExec.init(userClasses);

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -154,7 +154,6 @@ export class TestingRuntimeImpl implements TestingRuntime {
     DBOS.dbosConfig = dbosConfig[0];
     this.#dbosExec = new DBOSExecutor(dbosConfig[0], options);
     this.#applicationConfig = this.#dbosExec.config.application ?? {};
-    DBOS.globalLogger = this.#dbosExec.logger;
     await this.#dbosExec.init(userClasses);
     this.#server = new DBOSHttpServer(this.#dbosExec);
     await this.initEventReceivers();

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -9,7 +9,7 @@ import { StoredProcedure, StoredProcedureContext } from './procedure';
 import { InvokeFuncsInst } from './httpServer/handler';
 import { WorkflowQueue } from './wfqueue';
 import { DBOSJSON } from './utils';
-import { DBOS } from './dbos';
+import { DBOS, runAsWorkflowStep } from './dbos';
 import { EnqueueOptions } from './system_database';
 
 /** @deprecated */
@@ -589,7 +589,7 @@ export class InvokedHandle<R> implements WorkflowHandle<R> {
   }
 
   async getResult(): Promise<R> {
-    return await DBOS.runAsWorkflowStep(
+    return await runAsWorkflowStep(
       async () => {
         return await this.workflowPromise;
       },

--- a/tests/drizzle.test.ts
+++ b/tests/drizzle.test.ts
@@ -12,7 +12,7 @@ import {
   Transaction,
   TransactionContext,
 } from '../src';
-import { DBOSConfig, DBOSConfigInternal } from '../src/dbos-executor';
+import { DBOSConfig } from '../src/dbos-executor';
 import { UserDatabaseName } from '../src/user_database';
 import { generateDBOSTestConfig, setUpDBOSTestDb } from './helpers';
 import { pgTable, serial, text } from 'drizzle-orm/pg-core';
@@ -213,10 +213,10 @@ describe('drizzle-auth-tests', () => {
 class TestEngine {
   @DBOS.transaction()
   static async testEngine() {
-    const pc = (DBOS.dbosConfig as DBOSConfigInternal).poolConfig;
+    const pc = DBOS.dbosConfig?.poolConfig;
     const ds = DBOS.drizzleClient;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((ds as any).session.client._connectionTimeoutMillis).toEqual(pc.connectionTimeoutMillis);
+    expect((ds as any).session.client._connectionTimeoutMillis).toEqual(pc?.connectionTimeoutMillis);
     // Drizzle doesn't expose the pool directly
     await Promise.resolve();
   }

--- a/tests/httpServer/classdec.test.ts
+++ b/tests/httpServer/classdec.test.ts
@@ -147,7 +147,6 @@ describe('httpserver-defsec-tests', () => {
   let middlewareCounterG = 0;
   const testMiddlewareG: Middleware = async (ctx, next) => {
     middlewareCounterG = middlewareCounterG + 1;
-    expect(DBOS.globalLogger).toBeDefined();
     await next();
   };
 

--- a/tests/knex.test.ts
+++ b/tests/knex.test.ts
@@ -2,7 +2,7 @@ import request from 'supertest';
 
 import { DBOS, Authentication, MiddlewareContext } from '../src';
 import { DBOSInvalidWorkflowTransitionError, DBOSNotAuthorizedError } from '../src/error';
-import { DBOSConfig, DBOSConfigInternal } from '../src/dbos-executor';
+import { DBOSConfig } from '../src/dbos-executor';
 import { UserDatabaseName } from '../src/user_database';
 import { TestKvTable, generateDBOSTestConfig, setUpDBOSTestDb } from './helpers';
 import { randomUUID } from 'node:crypto';
@@ -191,14 +191,14 @@ describe('knex-auth-tests', () => {
 class TestEngine {
   @DBOS.transaction()
   static async testEngine() {
-    const pc = (DBOS.dbosConfig as DBOSConfigInternal).poolConfig;
+    const pc = DBOS.dbosConfig?.poolConfig;
     const ds = DBOS.knexClient;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((ds as any).context.client.connectionSettings.connectionString).toEqual(pc.connectionString);
+    expect((ds as any).context.client.connectionSettings.connectionString).toEqual(pc?.connectionString);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((ds as any).context.client.config.pool.max).toEqual(pc.max);
+    expect((ds as any).context.client.config.pool.max).toEqual(pc?.max);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((ds as any).context.client.connectionSettings.connectionTimeoutMillis).toBe(pc.connectionTimeoutMillis);
+    expect((ds as any).context.client.connectionSettings.connectionTimeoutMillis).toBe(pc?.connectionTimeoutMillis);
     await Promise.resolve();
   }
 }

--- a/tests/pgnode.test.ts
+++ b/tests/pgnode.test.ts
@@ -1,6 +1,6 @@
 import { DBOS } from '../src';
 import { getExecutor } from '../src/dbos';
-import { DBOSExecutor, DBOSConfigInternal } from '../src/dbos-executor';
+import { DBOSExecutor } from '../src/dbos-executor';
 import { PostgresSystemDatabase } from '../src/system_database';
 import { UserDatabaseName } from '../src/user_database';
 import { setUpDBOSTestDb } from './helpers';
@@ -8,10 +8,10 @@ import { setUpDBOSTestDb } from './helpers';
 class TestEngine {
   @DBOS.transaction()
   static async testEngine() {
-    const pc = (DBOS.dbosConfig as DBOSConfigInternal).poolConfig;
+    const pc = DBOS.dbosConfig?.poolConfig;
     const ds = DBOS.pgClient;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((ds as any)._connectionTimeoutMillis).toEqual(pc.connectionTimeoutMillis);
+    expect((ds as any)._connectionTimeoutMillis).toEqual(pc?.connectionTimeoutMillis);
     // PG doesn't expose the pool directly
     await Promise.resolve();
   }

--- a/tests/pgnode.test.ts
+++ b/tests/pgnode.test.ts
@@ -1,4 +1,5 @@
 import { DBOS } from '../src';
+import { getExecutor } from '../src/dbos';
 import { DBOSExecutor, DBOSConfigInternal } from '../src/dbos-executor';
 import { PostgresSystemDatabase } from '../src/system_database';
 import { UserDatabaseName } from '../src/user_database';
@@ -28,7 +29,7 @@ describe('pgnode-engine-config-tests', () => {
     DBOS.setConfig(config);
     await DBOS.launch();
     try {
-      const sysDbClient = ((DBOS.executor as DBOSExecutor).systemDatabase as PostgresSystemDatabase).knexDB;
+      const sysDbClient = ((getExecutor() as DBOSExecutor).systemDatabase as PostgresSystemDatabase).knexDB;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
       expect((sysDbClient as any).context.client.config.pool.max).toEqual(42);
       await TestEngine.testEngine();

--- a/tests/prisma.test.ts
+++ b/tests/prisma.test.ts
@@ -19,7 +19,7 @@ import { randomUUID } from 'node:crypto';
 import { sleepms } from '../src/utils';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { UserDatabaseName } from '../src/user_database';
-import { DBOSConfig, DBOSConfigInternal } from '../src/dbos-executor';
+import { DBOSConfig } from '../src/dbos-executor';
 
 interface PrismaPGError {
   code: string;
@@ -240,9 +240,9 @@ describe('prisma-auth-tests', () => {
 class TestEngine {
   @DBOS.transaction()
   static async testEngine() {
-    const pc = (DBOS.dbosConfig as DBOSConfigInternal).poolConfig;
+    const pc = DBOS.dbosConfig?.poolConfig;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((DBOS.prismaClient as any)._engineConfig.overrideDatasources.db.url).toBe(pc.connectionString);
+    expect((DBOS.prismaClient as any)._engineConfig.overrideDatasources.db.url).toBe(pc?.connectionString);
     const r = await DBOS.prismaClient.$queryRawUnsafe('SELECT 1');
     expect(r.length).toBe(1);
     await Promise.resolve();

--- a/tests/typeorm.test.ts
+++ b/tests/typeorm.test.ts
@@ -5,7 +5,7 @@ import { EntityManager, Unique } from 'typeorm';
 
 import { generateDBOSTestConfig, setUpDBOSTestDb } from './helpers';
 import { OrmEntities, Authentication, MiddlewareContext, DBOS } from '../src';
-import { DBOSConfig, DBOSConfigInternal } from '../src/dbos-executor';
+import { DBOSConfig } from '../src/dbos-executor';
 import { randomUUID } from 'node:crypto';
 import { UserDatabaseName } from '../src/user_database';
 import { DBOSInvalidWorkflowTransitionError, DBOSNotAuthorizedError } from '../src/error';
@@ -214,14 +214,14 @@ describe('typeorm-auth-tests', () => {
 class TestEngine {
   @DBOS.transaction()
   static async testEngine() {
-    const pc = (DBOS.dbosConfig as DBOSConfigInternal).poolConfig;
+    const pc = DBOS.dbosConfig?.poolConfig;
     const ds = DBOS.typeORMClient;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((ds as any).connection.driver.master.options.connectionString).toBe(pc.connectionString);
+    expect((ds as any).connection.driver.master.options.connectionString).toBe(pc?.connectionString);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((ds as any).connection.driver.master.options.max).toBe(pc.max);
+    expect((ds as any).connection.driver.master.options.max).toBe(pc?.max);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    expect((ds as any).queryRunner.databaseConnection._connectionTimeoutMillis).toBe(pc.connectionTimeoutMillis);
+    expect((ds as any).queryRunner.databaseConnection._connectionTimeoutMillis).toBe(pc?.connectionTimeoutMillis);
     await Promise.resolve();
   }
 }

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -681,7 +681,11 @@ describe('queued-wf-tests-simple', () => {
   }
 
   test('test-concurrency-across-versions', async () => {
-    const client = await DBOSClient.create(DBOS.dbosConfig?.poolConfig?.connectionString as string);
+    const connectionString = DBOS.dbosConfig?.poolConfig?.connectionString;
+    if (!connectionString) {
+      throw new Error('DBOS is not configured with a connection string');
+    }
+    const client = await DBOSClient.create(connectionString);
 
     const other_version = 'other_version';
     const other_version_handle = await client.enqueue({


### PR DESCRIPTION
This PR makes the following DBOS static's private by prepending a `#`:

* #executor
* #runtimeConfig
* #invokeWrappers
* #runAsWorkflowStep
* #dbosConfig

Additional changes:
* removed `DBOS.globalLogger`. This was set in a couple places but was never read. the `DBOS.logger` property reads the logger from context, from executor or constructs a new GlobalLogger instance.
* added `DBOS.dbosConfig` getter. A couple places were setting this field - those have been updated to call `DBOS.setConfig`.
* added an exported functions `runAsWorkflowStep` and `getExecutor` to `dbos.ts` that can be used from other DBOS modules. Note, those exported functions are not part of the public API surface area exposed in `index.ts`.