### PR TITLE
Fix recovery deadlines

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -39,7 +39,7 @@ export interface DBOSLocalCtx {
   request?: HTTPRequest;
   operationType?: string; // A custom helper for users to set a operation type of their choice. Intended for functions setting a pctx to run DBOS operations from.
   operationCaller?: string; // This is made to pass through the operationName to DBOS contexts, and potentially the caller span name.
-  workflowTimeoutMS?: number;
+  workflowTimeoutMS?: number | null;
 }
 
 export function isWithinWorkflowCtx(ctx: DBOSLocalCtx) {

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -934,11 +934,11 @@ export class DBOSExecutor implements DBOSExecutorContext {
             throw err;
           } else {
             const e = new DBOSAwaitedWorkflowCancelledError(err.workflowID);
-            await handleWorkflowError(e as Error);
+            await handleWorkflowError(e as Error, this);
             throw e;
           }
         } else {
-          await handleWorkflowError(err as Error);
+          await handleWorkflowError(err as Error, this);
           throw err;
         }
       } finally {

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -937,7 +937,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
             this.logger.info(`Cancelled workflow ${workflowID}`);
             throw err;
           } else {
-            const e = new DBOSAwaitedWorkflowCancelledError(workflowID);
+            const e = new DBOSAwaitedWorkflowCancelledError(err.workflowID);
             await handleWorkflowError(e as Error);
             throw e;
           }

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -931,10 +931,6 @@ export class DBOSExecutor implements DBOSExecutorContext {
           internalStatus.error = err.message;
           if (err.workflowID === workflowID) {
             internalStatus.status = StatusString.CANCELLED;
-            if (!this.isDebugging) {
-              await this.systemDatabase.cancelWorkflow(workflowID);
-            }
-            this.logger.info(`Cancelled workflow ${workflowID}`);
             throw err;
           } else {
             const e = new DBOSAwaitedWorkflowCancelledError(err.workflowID);

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -39,7 +39,7 @@ import {
   DBOSExecutorNotInitializedError,
   DBOSInvalidWorkflowTransitionError,
   DBOSNotRegisteredError,
-  DBOSTargetWorkflowCancelledError,
+  DBOSAwaitedWorkflowCancelledError,
 } from './error';
 import { parseConfigFile, translatePublicDBOSconfig, overwrite_config } from './dbos-runtime/config';
 import { DBOSRuntime, DBOSRuntimeConfig } from './dbos-runtime/runtime';
@@ -908,7 +908,7 @@ export class DBOS {
           timerFuncID,
         );
         if (!rres) return null;
-        if (rres?.cancelled) throw new DBOSTargetWorkflowCancelledError(workflowID); // TODO: Make semantically meaningful
+        if (rres?.cancelled) throw new DBOSAwaitedWorkflowCancelledError(workflowID); // TODO: Make semantically meaningful
         return DBOSExecutor.reviveResultOrError<T>(rres);
       },
       'DBOS.getResult',

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -908,7 +908,9 @@ export class DBOS {
           timerFuncID,
         );
         if (!rres) return null;
-        if (rres?.cancelled) throw new DBOSAwaitedWorkflowCancelledError(workflowID); // TODO: Make semantically meaningful
+        if (rres?.cancelled) {
+          throw new DBOSAwaitedWorkflowCancelledError(DBOS.workflowID ? DBOS.workflowID : workflowID);
+        }
         return DBOSExecutor.reviveResultOrError<T>(rres);
       },
       'DBOS.getResult',

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -909,7 +909,7 @@ export class DBOS {
         );
         if (!rres) return null;
         if (rres?.cancelled) {
-          throw new DBOSAwaitedWorkflowCancelledError(DBOS.workflowID ? DBOS.workflowID : workflowID);
+          throw new DBOSAwaitedWorkflowCancelledError(workflowID);
         }
         return DBOSExecutor.reviveResultOrError<T>(rres);
       },

--- a/src/error.ts
+++ b/src/error.ts
@@ -271,7 +271,7 @@ export class DBOSUnexpectedStepError extends DBOSError {
 }
 
 const TargetWorkFlowCancelled = 27;
-export class DBOSTargetWorkflowCancelledError extends DBOSError {
+export class DBOSAwaitedWorkflowCancelledError extends DBOSError {
   constructor(readonly workflowID: string) {
     super(`Workflow ${workflowID} has been cancelled`, TargetWorkFlowCancelled);
   }

--- a/src/error.ts
+++ b/src/error.ts
@@ -273,7 +273,7 @@ export class DBOSUnexpectedStepError extends DBOSError {
 const TargetWorkFlowCancelled = 27;
 export class DBOSAwaitedWorkflowCancelledError extends DBOSError {
   constructor(readonly workflowID: string) {
-    super(`Workflow ${workflowID} has been cancelled`, TargetWorkFlowCancelled);
+    super(`Workflow ${workflowID} awaited a workflow which was cancelled`, TargetWorkFlowCancelled);
   }
 }
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -273,7 +273,7 @@ export class DBOSUnexpectedStepError extends DBOSError {
 const TargetWorkFlowCancelled = 27;
 export class DBOSAwaitedWorkflowCancelledError extends DBOSError {
   constructor(readonly workflowID: string) {
-    super(`Workflow ${workflowID} awaited a workflow which was cancelled`, TargetWorkFlowCancelled);
+    super(`Awaited ${workflowID} was cancelled`, TargetWorkFlowCancelled);
   }
 }
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -203,7 +203,7 @@ export interface WorkflowStatusInternal {
   createdAt: number;
   updatedAt?: number;
   recoveryAttempts?: number;
-  timeoutMS?: number;
+  timeoutMS?: number | null;
   deadlineEpochMS?: number;
 }
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1884,7 +1884,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
               executor_id: executorID,
               application_version: appVersion,
               workflow_deadline_epoch_ms: trx.raw(
-                'CASE WHEN workflow_timeout_ms IS NULL THEN NULL ELSE (EXTRACT(epoch FROM now()) * 1000)::bigint + workflow_timeout_ms END',
+                'CASE WHEN workflow_timeout_ms IS NOT NULL AND workflow_deadline_epoch_ms IS NULL THEN (EXTRACT(epoch FROM now()) * 1000)::bigint + workflow_timeout_ms ELSE workflow_deadline_epoch_ms END',
               ),
             });
 

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -11,6 +11,7 @@ import { WorkflowQueue } from './wfqueue';
 import { DBOSJSON } from './utils';
 import { DBOS, runAsWorkflowStep } from './dbos';
 import { EnqueueOptions } from './system_database';
+import { DBOSWorkflowCancelledError, DBOSAwaitedWorkflowCancelledError } from './error';
 
 /** @deprecated */
 export type Workflow<T extends unknown[], R> = (ctxt: WorkflowContext, ...args: T) => Promise<R>;

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -11,7 +11,6 @@ import { WorkflowQueue } from './wfqueue';
 import { DBOSJSON } from './utils';
 import { DBOS, runAsWorkflowStep } from './dbos';
 import { EnqueueOptions } from './system_database';
-import { DBOSWorkflowCancelledError, DBOSAwaitedWorkflowCancelledError } from './error';
 
 /** @deprecated */
 export type Workflow<T extends unknown[], R> = (ctxt: WorkflowContext, ...args: T) => Promise<R>;

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -51,7 +51,7 @@ export interface WorkflowParams {
   configuredInstance?: ConfiguredInstance | null;
   queueName?: string;
   executeWorkflow?: boolean; // If queueName is set, this will not be run unless executeWorkflow is true.
-  timeoutMS?: number;
+  timeoutMS?: number | null;
   deadlineEpochMS?: number;
   enqueueOptions?: EnqueueOptions; // Options for the workflow queue
 }
@@ -89,7 +89,7 @@ export interface WorkflowStatus {
   readonly createdAt: number;
   readonly updatedAt?: number;
 
-  readonly timeoutMS?: number;
+  readonly timeoutMS?: number | null;
   readonly deadlineEpochMS?: number;
 }
 
@@ -250,7 +250,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
     readonly workflowConfig: WorkflowConfig,
     workflowName: string,
     readonly presetUUID: boolean,
-    readonly timeoutMS: number | undefined,
+    readonly timeoutMS: number | undefined | null,
     readonly deadlineEpochMS: number | undefined,
     readonly tempWfOperationType: string = '', // "transaction", "procedure", "external", or "send"
     readonly tempWfOperationName: string = '', // Name for the temporary workflow operation

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -370,7 +370,7 @@ describe('dbos-tests', () => {
       const workflowID = randomUUID();
       const childID = `${workflowID}-0`;
       const handle = await DBOS.startWorkflow(DBOSTimeoutTestClass, { workflowID }).timeoutParentStartWF(100);
-      await expect(handle.getResult()).rejects.toThrow(new DBOSAwaitedWorkflowCancelledError(workflowID));
+      await expect(handle.getResult()).rejects.toThrow(new DBOSAwaitedWorkflowCancelledError(childID));
       const status = await DBOS.getWorkflowStatus(workflowID);
       expect(status?.status).toBe(StatusString.ERROR);
       const childStatus = await DBOS.getWorkflowStatus(childID);
@@ -385,7 +385,7 @@ describe('dbos-tests', () => {
         workflowID,
         timeoutMS: 1000,
       }).timeoutParentStartWF(100);
-      await expect(handle.getResult()).rejects.toThrow(new DBOSAwaitedWorkflowCancelledError(workflowID));
+      await expect(handle.getResult()).rejects.toThrow(new DBOSAwaitedWorkflowCancelledError(childID));
       const status = await DBOS.getWorkflowStatus(workflowID);
       expect(status?.status).toBe(StatusString.ERROR);
       const childStatus = await DBOS.getWorkflowStatus(childID);

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -505,14 +505,14 @@ class DBOSTimeoutTestClass {
 
   @DBOS.workflow()
   static async timeoutParentStartDetachedChild(duration: number) {
-    await DBOS.startWorkflow(DBOSTimeoutTestClass, { timeoutMS: undefined })
+    await DBOS.startWorkflow(DBOSTimeoutTestClass, { timeoutMS: null })
       .sleepingWorkflow(duration * 2)
       .then((h) => h.getResult());
   }
 
   @DBOS.workflow()
   static async timeoutParentStartDetachedChildWithSyntax(duration: number) {
-    await DBOS.withWorkflowTimeout(undefined, async () => {
+    await DBOS.withWorkflowTimeout(null, async () => {
       await DBOSTimeoutTestClass.sleepingWorkflow(duration * 2);
     });
   }

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -291,6 +291,7 @@ describe('dbos-tests', () => {
         });
       });
       const status = await DBOS.getWorkflowStatus(workflowID);
+      expect(status?.status).toBe(StatusString.CANCELLED);
     });
 
     test('workflow-timeout-startWorkflow-params', async () => {
@@ -311,7 +312,7 @@ describe('dbos-tests', () => {
           const expected2 = new DBOSWorkflowCancelledError(workflowID);
           await expect(DBOSTimeoutTestClass.blockingParentStartWF()).rejects.toEqual(
             expect.objectContaining({
-              message: expect.stringMatching(`^${expected1.message}$|^${expected2.message}$`),
+              message: expect.stringMatching(`^${expected1.message}$|^${expected2.message}$`) as string,
               workflowID: workflowID,
             }),
           );
@@ -335,7 +336,7 @@ describe('dbos-tests', () => {
       const expected2 = new DBOSWorkflowCancelledError(workflowID);
       await expect(handle.getResult()).rejects.toEqual(
         expect.objectContaining({
-          message: expect.stringMatching(`^${expected1.message}$|^${expected2.message}$`),
+          message: expect.stringMatching(`^${expected1.message}$|^${expected2.message}$`) as string,
           workflowID: workflowID,
         }),
       );
@@ -355,7 +356,7 @@ describe('dbos-tests', () => {
           const expected2 = new DBOSWorkflowCancelledError(workflowID);
           await expect(DBOSTimeoutTestClass.blockingParentDirect()).rejects.toEqual(
             expect.objectContaining({
-              message: expect.stringMatching(`^${expected1.message}$|^${expected2.message}$`),
+              message: expect.stringMatching(`^${expected1.message}$|^${expected2.message}$`) as string,
               workflowID: workflowID,
             }),
           );
@@ -379,7 +380,7 @@ describe('dbos-tests', () => {
       const expected2 = new DBOSWorkflowCancelledError(workflowID);
       await expect(handle.getResult()).rejects.toEqual(
         expect.objectContaining({
-          message: expect.stringMatching(`^${expected1.message}$|^${expected2.message}$`),
+          message: expect.stringMatching(`^${expected1.message}$|^${expected2.message}$`) as string,
           workflowID: workflowID,
         }),
       );

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -307,19 +307,13 @@ describe('dbos-tests', () => {
       const childID = `${workflowID}-0`;
       await DBOS.withNextWorkflowID(workflowID, async () => {
         await DBOS.withWorkflowTimeout(100, async () => {
-          // The parent may or may not be cancelled
-          const expected1 = new DBOSAwaitedWorkflowCancelledError(workflowID);
-          const expected2 = new DBOSWorkflowCancelledError(workflowID);
-          await expect(DBOSTimeoutTestClass.blockingParentStartWF()).rejects.toEqual(
-            expect.objectContaining({
-              message: expect.stringMatching(`^${expected1.message}$|^${expected2.message}$`) as string,
-              workflowID: workflowID,
-            }),
+          await expect(DBOSTimeoutTestClass.blockingParentStartWF()).rejects.toThrow(
+            new DBOSWorkflowCancelledError(workflowID),
           );
         });
       });
       const status = await DBOS.getWorkflowStatus(workflowID);
-      expect([StatusString.ERROR, StatusString.CANCELLED]).toContain(status?.status);
+      expect(status?.status).toBe(StatusString.CANCELLED);
       const childStatus = await DBOS.getWorkflowStatus(childID);
       expect(childStatus?.status).toBe(StatusString.CANCELLED);
       expect(status?.deadlineEpochMS).toBe(childStatus?.deadlineEpochMS);
@@ -332,16 +326,9 @@ describe('dbos-tests', () => {
         workflowID,
         timeoutMS: 100,
       }).blockingParentStartWF();
-      const expected1 = new DBOSAwaitedWorkflowCancelledError(workflowID);
-      const expected2 = new DBOSWorkflowCancelledError(workflowID);
-      await expect(handle.getResult()).rejects.toEqual(
-        expect.objectContaining({
-          message: expect.stringMatching(`^${expected1.message}$|^${expected2.message}$`) as string,
-          workflowID: workflowID,
-        }),
-      );
+      await expect(handle.getResult()).rejects.toThrow(new DBOSWorkflowCancelledError(workflowID));
       const status = await DBOS.getWorkflowStatus(workflowID);
-      expect([StatusString.ERROR, StatusString.CANCELLED]).toContain(status?.status);
+      expect(status?.status).toBe(StatusString.CANCELLED);
       const childStatus = await DBOS.getWorkflowStatus(childID);
       expect(childStatus?.status).toBe(StatusString.CANCELLED);
       expect(status?.deadlineEpochMS).toBe(childStatus?.deadlineEpochMS);
@@ -352,18 +339,13 @@ describe('dbos-tests', () => {
       const childID = `${workflowID}-0`;
       await DBOS.withNextWorkflowID(workflowID, async () => {
         await DBOS.withWorkflowTimeout(100, async () => {
-          const expected1 = new DBOSAwaitedWorkflowCancelledError(workflowID);
-          const expected2 = new DBOSWorkflowCancelledError(workflowID);
-          await expect(DBOSTimeoutTestClass.blockingParentDirect()).rejects.toEqual(
-            expect.objectContaining({
-              message: expect.stringMatching(`^${expected1.message}$|^${expected2.message}$`) as string,
-              workflowID: workflowID,
-            }),
+          await expect(DBOSTimeoutTestClass.blockingParentDirect()).rejects.toThrow(
+            new DBOSWorkflowCancelledError(workflowID),
           );
         });
       });
       const status = await DBOS.getWorkflowStatus(workflowID);
-      expect([StatusString.ERROR, StatusString.CANCELLED]).toContain(status?.status);
+      expect(status?.status).toBe(StatusString.CANCELLED);
       const childStatus = await DBOS.getWorkflowStatus(childID);
       expect(childStatus?.status).toBe(StatusString.CANCELLED);
       expect(status?.deadlineEpochMS).toBe(childStatus?.deadlineEpochMS);
@@ -376,16 +358,9 @@ describe('dbos-tests', () => {
         workflowID,
         timeoutMS: 100,
       }).blockingParentDirect();
-      const expected1 = new DBOSAwaitedWorkflowCancelledError(workflowID);
-      const expected2 = new DBOSWorkflowCancelledError(workflowID);
-      await expect(handle.getResult()).rejects.toEqual(
-        expect.objectContaining({
-          message: expect.stringMatching(`^${expected1.message}$|^${expected2.message}$`) as string,
-          workflowID: workflowID,
-        }),
-      );
+      await expect(handle.getResult()).rejects.toThrow(new DBOSWorkflowCancelledError(workflowID));
       const status = await DBOS.getWorkflowStatus(workflowID);
-      expect([StatusString.ERROR, StatusString.CANCELLED]).toContain(status?.status);
+      expect(status?.status).toBe(StatusString.CANCELLED);
       const childStatus = await DBOS.getWorkflowStatus(childID);
       expect(childStatus?.status).toBe(StatusString.CANCELLED);
       expect(status?.deadlineEpochMS).toBe(childStatus?.deadlineEpochMS);

--- a/tests/wfcancel.test.ts
+++ b/tests/wfcancel.test.ts
@@ -1,6 +1,6 @@
 import { StatusString, DBOS } from '../src';
 import { DBOSConfig } from '../src/dbos-executor';
-import { DBOSTargetWorkflowCancelledError, DBOSWorkflowCancelledError } from '../src/error';
+import { DBOSAwaitedWorkflowCancelledError, DBOSWorkflowCancelledError } from '../src/error';
 import { generateDBOSTestConfig, setUpDBOSTestDb } from './helpers';
 import { randomUUID } from 'node:crypto';
 
@@ -122,7 +122,7 @@ describe('wf-cancel-tests', () => {
     await expect(DBOS.getResult(wfh.workflowID, 0.2)).resolves.toBeNull();
     await DBOS.cancelWorkflow(wfid);
 
-    await expect(DBOS.getResult(wfh.workflowID)).rejects.toThrow(DBOSTargetWorkflowCancelledError);
+    await expect(DBOS.getResult(wfh.workflowID)).rejects.toThrow(DBOSAwaitedWorkflowCancelledError);
     await expect(wfh.getResult()).rejects.toThrow(DBOSWorkflowCancelledError);
   });
 
@@ -133,7 +133,7 @@ describe('wf-cancel-tests', () => {
     await expect(DBOS.getResult(wfh.workflowID, 0.2)).resolves.toBeNull();
     await DBOS.cancelWorkflow(wfid);
 
-    await expect(DBOS.getResult(wfh.workflowID)).rejects.toThrow(DBOSTargetWorkflowCancelledError);
+    await expect(DBOS.getResult(wfh.workflowID)).rejects.toThrow(DBOSAwaitedWorkflowCancelledError);
     await expect(wfh.getResult()).rejects.toThrow(DBOSWorkflowCancelledError);
   });
 
@@ -144,7 +144,7 @@ describe('wf-cancel-tests', () => {
     await expect(DBOS.getResult(wfh.workflowID, 0.2)).resolves.toBeNull();
     await DBOS.cancelWorkflow(wfid);
 
-    await expect(DBOS.getResult(wfh.workflowID)).rejects.toThrow(DBOSTargetWorkflowCancelledError);
+    await expect(DBOS.getResult(wfh.workflowID)).rejects.toThrow(DBOSAwaitedWorkflowCancelledError);
     await expect(wfh.getResult()).rejects.toThrow(DBOSWorkflowCancelledError);
   });
 
@@ -155,7 +155,7 @@ describe('wf-cancel-tests', () => {
     await expect(DBOS.getResult(wfh.workflowID, 0.2)).resolves.toBeNull();
     await DBOS.cancelWorkflow(wfid);
 
-    await expect(DBOS.getResult(wfh.workflowID)).rejects.toThrow(DBOSTargetWorkflowCancelledError);
+    await expect(DBOS.getResult(wfh.workflowID)).rejects.toThrow(DBOSAwaitedWorkflowCancelledError);
     await expect(wfh.getResult()).rejects.toThrow(DBOSWorkflowCancelledError);
   });
 

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -1254,21 +1254,21 @@ describe('queue-time-outs', () => {
 
     @DBOS.workflow()
     static async timeoutParentStartDetachedChild(duration: number) {
-      await DBOS.startWorkflow(DBOSTimeoutTestClass, { timeoutMS: undefined })
+      await DBOS.startWorkflow(DBOSTimeoutTestClass, { timeoutMS: null })
         .sleepingWorkflow(duration * 2)
         .then((h) => h.getResult());
     }
 
     @DBOS.workflow()
     static async timeoutParentStartDetachedChildWithSyntax(duration: number) {
-      await DBOS.withWorkflowTimeout(undefined, async () => {
+      await DBOS.withWorkflowTimeout(null, async () => {
         await DBOSTimeoutTestClass.sleepingWorkflow(duration * 2);
       });
     }
 
     @DBOS.workflow()
     static async timeoutParentEnqueueDetached(duration: number) {
-      await DBOS.startWorkflow(DBOSTimeoutTestClass, { timeoutMS: undefined, queueName: queue.name })
+      await DBOS.startWorkflow(DBOSTimeoutTestClass, { timeoutMS: null, queueName: queue.name })
         .sleepingWorkflow(duration * 2)
         .then((h) => h.getResult());
     }

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -23,7 +23,6 @@ import { promisify } from 'util';
 import { Client } from 'pg';
 import {
   DBOSInvalidQueuePriorityError,
-  DBOSWorkflowCancelledError,
   DBOSConflictingWorkflowError,
   DBOSQueueDuplicatedError,
   DBOSAwaitedWorkflowCancelledError,

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -1309,7 +1309,7 @@ describe('queue-time-outs', () => {
       workflowID,
       queueName: queue.name,
     }).timeoutParentStartWF(100);
-    await expect(handle.getResult()).rejects.toThrow(new DBOSAwaitedWorkflowCancelledError(workflowID));
+    await expect(handle.getResult()).rejects.toThrow(new DBOSAwaitedWorkflowCancelledError(childID));
     await expect(handle.getStatus()).resolves.toMatchObject({
       status: StatusString.ERROR,
     });

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -1354,7 +1354,7 @@ describe('queue-time-outs', () => {
       timeoutMS: 2000, // allow a dequeue interval to pass
     }).timeoutParentEnqueueWF(100);
     await events_map.get(childID)?.wait();
-    await expect(handle.getResult()).rejects.toThrow(new DBOSAwaitedWorkflowCancelledError(workflowID));
+    await expect(handle.getResult()).rejects.toThrow(new DBOSAwaitedWorkflowCancelledError(childID));
     await expect(handle.getStatus()).resolves.toMatchObject({
       status: StatusString.ERROR,
     });

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -613,7 +613,7 @@ describe('queued-wf-tests-simple', () => {
 
     // Complete the blocked workflow
     TestCancelQueues.blockingEvent.set();
-    await expect(blockedHandle.getResult()).rejects.toThrow(DBOSTargetWorkflowCancelledError);
+    await expect(blockedHandle.getResult()).rejects.toThrow(DBOSAwaitedWorkflowCancelledError);
 
     // Verify all queue entries eventually get cleaned up
     expect(await queueEntriesAreCleanedUp()).toBe(true);


### PR DESCRIPTION
- Fix detaching children from parent timeout
- Fix recovery deadline overwrite
- `DBOSTargetWorkflowCancelledError` --> `DBOSAwaitedWorkflowCancelledError`