### PR TITLE
update registerDataSource

### DIFF
--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -905,6 +905,7 @@ export class DBOS {
    * @param name - Name of step to record, this will be used in traces and introspection
    * @returns - result (either obtained from invoking function, or retrieved if run before)
    */
+  // TODO: shouldn't this have a StepConfig param?
   static async runAsWorkflowStep<T>(callback: () => Promise<T>, name: string): Promise<T> {
     return await runAsWorkflowStep(callback, name);
   }

--- a/src/transactionsource.ts
+++ b/src/transactionsource.ts
@@ -2,8 +2,8 @@ import { MethodRegistration } from './decorators';
 
 // Data source implementation (to be moved to DBOS core)
 export interface DBOSTransactionalDataSource {
-  name: string;
-  get dsType(): string;
+  readonly name: string;
+  readonly dsType: string;
 
   /**
    * Will be called by DBOS during launch.

--- a/tests/datasourceextensions.test.ts
+++ b/tests/datasourceextensions.test.ts
@@ -388,7 +388,7 @@ const wfFunction = DBOS.registerWorkflow(wfFunctionGuts, {
 
 // Intentionally initialize DS after we've already tried to register a transaction to it
 const dsa = new DBOSKnexDS('knexA', config.poolConfig);
-DBOS.registerDataSource('knexA', dsa);
+DBOS.registerDataSource(dsa);
 
 // Decoratory example
 class DBWFI {


### PR DESCRIPTION
* remove redundant name param from DBOS.registerDataSource
* make DBOSTransactionalDataSource name and dsType fields readonly
  * Note, when implementing, a readonly field can be implemented as a normal field, a readonly field or a get method