### PR TITLE
Faster Queues

### DIFF
--- a/migrations/20252528000000_consolidate_queues.js
+++ b/migrations/20252528000000_consolidate_queues.js
@@ -1,0 +1,30 @@
+// Due to a naming issue, this migration is named "20252528000000_consolidate_queues.js" instead of "20250528000000_consolidate_queues.js".
+// Please see the 20252101000000_workflow_queues_executor_id migration for more details.
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.withSchema('dbos').table('workflow_status', function (table) {
+    table.bigInteger('started_at_epoch_ms').nullable();
+    table.text('deduplication_id').nullable();
+    table.integer('priority').notNullable().defaultTo(0);
+    table.unique(['queue_name', 'deduplication_id'], { indexName: 'uq_workflow_status_queue_name_dedup_id' });
+    table.index(['status'], 'workflow_status_status_index');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.withSchema('dbos').table('workflow_status', function (table) {
+    table.dropIndex(['status'], 'workflow_status_status_index');
+    table.dropUnique(['queue_name', 'deduplication_id'], 'uq_workflow_status_queue_name_dedup_id');
+    table.dropColumn('priority');
+    table.dropColumn('deduplication_id');
+    table.dropColumn('started_at_epoch_ms');
+  });
+};

--- a/schemas/system_db_schema.ts
+++ b/schemas/system_db_schema.ts
@@ -20,6 +20,9 @@ export interface workflow_status {
   workflow_timeout_ms: number | null;
   workflow_deadline_epoch_ms: number | null;
   inputs: string;
+  started_at_epoch_ms?: number;
+  deduplication_id?: string; // ID used to identify enqueued workflows for de-duplication.
+  priority?: number; // Optional priority for the workflow.
 }
 
 export interface notifications {
@@ -53,15 +56,6 @@ export interface event_dispatch_kv {
   value?: string;
   update_time?: number; // Timestamp of record (for upsert)
   update_seq?: bigint; // Sequence number of record (for upsert)
-}
-
-export interface workflow_queue {
-  workflow_uuid: string;
-  queue_name: string;
-  executor_id: string;
-  created_at_epoch_ms: number; // This time is provided by the database
-  started_at_epoch_ms?: number; // This time is provided by the client
-  completed_at_epoch_ms?: number; // This time is provided by the client
 }
 
 // This is the deserialized version of operation_outputs

--- a/src/client.ts
+++ b/src/client.ts
@@ -148,13 +148,12 @@ export class DBOSClient {
       timeoutMS: options.workflowTimeoutMS,
       deadlineEpochMS: undefined,
       input: DBOSJSON.stringify(args),
+      deduplicationID: options.deduplicationID,
+      priority: options.priority ?? 0,
     };
 
     await this.systemDatabase.initWorkflowStatus(internalStatus);
 
-    await this.systemDatabase.enqueueWorkflow(workflowUUID, queueName, {
-      deduplicationID: options.deduplicationID,
-    });
     return new RetrievedHandle<Awaited<ReturnType<T>>>(this.systemDatabase, workflowUUID);
   }
 
@@ -184,6 +183,8 @@ export class DBOSClient {
       applicationID: '',
       createdAt: Date.now(),
       input: DBOSJSON.stringify([destinationID, message, topic]),
+      deduplicationID: undefined,
+      priority: 0,
     };
     await this.systemDatabase.initWorkflowStatus(internalStatus);
     await this.systemDatabase.send(internalStatus.workflowUUID, 0, destinationID, DBOSJSON.stringify(message), topic);

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -736,6 +736,16 @@ export class DBOSExecutor implements DBOSExecutorContext {
       throw new DBOSInvalidQueuePriorityError(priority, DBOS_QUEUE_MIN_PRIORITY, DBOS_QUEUE_MAX_PRIORITY);
     }
 
+    // If the workflow is called on a queue with a priority but the queue is not configured with a priority, print a warning.
+    if (params.queueName) {
+      const wfqueue = this.#getQueueByName(params.queueName);
+      if (!wfqueue.priorityEnabled && priority !== undefined) {
+        this.logger.warn(
+          `Priority is not enabled for queue ${params.queueName}. Setting priority will not have any effect.`,
+        );
+      }
+    }
+
     const wInfo = this.getWorkflowInfo(wf as Workflow<unknown[], unknown>);
     if (wInfo === undefined) {
       throw new DBOSNotRegisteredError(wf.name);

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -22,8 +22,6 @@ import {
 import { Tracer } from './telemetry/traces';
 import {
   GetQueuedWorkflowsInput,
-  GetWorkflowQueueInput,
-  GetWorkflowQueueOutput,
   GetWorkflowsInput,
   GetWorkflowsOutput,
   StepInfo,
@@ -1025,16 +1023,6 @@ export class DBOS {
     }, 'DBOS.forkWorkflow');
 
     return this.retrieveWorkflow(forkedID);
-  }
-
-  /**
-   * Retrieve the contents of a workflow queue.
-   * @param input - Filter predicate, containing the queue name and other criteria
-   */
-  static async getWorkflowQueue(input: GetWorkflowQueueInput): Promise<GetWorkflowQueueOutput> {
-    return await DBOS.#runAsWorkflowStep(async () => {
-      return await DBOS.#executor.getWorkflowQueue(input);
-    }, 'DBOS.getWorkflowQueue');
   }
 
   /**

--- a/src/eventreceiver.ts
+++ b/src/eventreceiver.ts
@@ -2,8 +2,6 @@ import { Tracer } from './telemetry/traces';
 import { GlobalLogger as Logger } from './telemetry/logs';
 import type {
   GetQueuedWorkflowsInput,
-  GetWorkflowQueueInput,
-  GetWorkflowQueueOutput,
   GetWorkflowsInput,
   StepInfo,
   WorkflowFunction,
@@ -115,8 +113,6 @@ export interface DBOSExecutorContext {
   listQueuedWorkflows(input: GetQueuedWorkflowsInput): Promise<WorkflowStatus[]>;
   /** @deprecated Use functions on `DBOS` */
   listWorkflowSteps(workflowID: string): Promise<StepInfo[] | undefined>;
-  /** @deprecated Use functions on `DBOS` */
-  getWorkflowQueue(input: GetWorkflowQueueInput): Promise<GetWorkflowQueueOutput>;
   /** @deprecated Use functions on `DBOS` */
   cancelWorkflow(workflowID: string): Promise<void>;
   /** @deprecated Use functions on `DBOS` */

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,8 @@ export {
   WorkflowFunction,
   StatusString,
   GetWorkflowsInput,
-  GetWorkflowsOutput,
+  GetQueuedWorkflowsInput,
+  WorkflowStatus,
 } from './workflow';
 
 export {

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1700,10 +1700,13 @@ export class PostgresSystemDatabase implements SystemDatabase {
           .andWhere((b) => {
             b.whereNull('application_version').orWhere('application_version', appVersion);
           })
-          .orderBy('priority', 'asc') // TODO (Qian): only enable this if priority is supported
-          .orderBy('created_at', 'asc')
           .forUpdate()
           .noWait();
+        if (queue.priorityEnabled) {
+          query = query.orderBy('priority', 'asc').orderBy('created_at', 'asc');
+        } else {
+          query = query.orderBy('created_at', 'asc');
+        }
         if (maxTasks !== Infinity) {
           query = query.limit(maxTasks);
         }

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1590,10 +1590,10 @@ export class PostgresSystemDatabase implements SystemDatabase {
     const schemaName = DBOSExecutor.systemDBSchemaName;
 
     const sortDesc = input.sortDesc ?? false; // By default, sort in ascending order
-    let query = this.knexDB<workflow_status>(`${schemaName}.workflow_status`).orderBy(
-      `${schemaName}.workflow_status.created_at`,
-      sortDesc ? 'desc' : 'asc',
-    );
+    let query = this.knexDB<workflow_status>(`${schemaName}.workflow_status`)
+      .whereNotNull(`${schemaName}.workflow_status.queue_name`)
+      .whereIn(`${schemaName}.workflow_status.status`, [StatusString.ENQUEUED, StatusString.PENDING])
+      .orderBy(`${schemaName}.workflow_status.created_at`, sortDesc ? 'desc' : 'asc');
 
     if (input.workflowName) {
       query = query.where(`${schemaName}.workflow_status.name`, input.workflowName);

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -47,7 +47,7 @@ export async function createTestingRuntime(
       database: dbosConfig.poolConfig.database,
     });
     await pgSystemClient.connect();
-    await pgSystemClient.query(`DROP DATABASE IF EXISTS ${dbosConfig.system_database};`);
+    await pgSystemClient.query(`DROP DATABASE IF EXISTS ${dbosConfig.system_database} WITH (FORCE);`);
     await pgSystemClient.end();
   }
 

--- a/src/wfqueue.ts
+++ b/src/wfqueue.ts
@@ -27,6 +27,8 @@ export interface QueueParameters {
   concurrency?: number;
   /** If set, this limits the rate at which queued workflows are started */
   rateLimit?: QueueRateLimit;
+  /** If set, this queue supports priority */
+  priorityEnabled?: boolean;
 }
 
 /**
@@ -40,6 +42,7 @@ export class WorkflowQueue {
   readonly concurrency?: number;
   readonly rateLimit?: QueueRateLimit;
   readonly workerConcurrency?: number;
+  readonly priorityEnabled: boolean = false;
 
   constructor(name: string);
 
@@ -67,6 +70,7 @@ export class WorkflowQueue {
       this.concurrency = arg2.concurrency;
       this.rateLimit = arg2.rateLimit;
       this.workerConcurrency = arg2.workerConcurrency;
+      this.priorityEnabled = arg2.priorityEnabled ?? false;
     } else {
       // Handle the case where the second argument is a number
       this.concurrency = arg2;

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -122,24 +122,6 @@ export interface GetWorkflowsOutput {
   workflowUUIDs: string[];
 }
 
-export interface GetWorkflowQueueInput {
-  queueName?: string; // The name of the workflow queue
-  startTime?: string; // Timestamp in ISO 8601 format
-  endTime?: string; // Timestamp in ISO 8601 format
-  limit?: number; // Return up to this many workflows IDs. IDs are ordered by workflow creation time.
-}
-
-export interface GetWorkflowQueueOutput {
-  workflows: {
-    workflowID: string; // Workflow ID
-    executorID?: string; // Workflow executor ID
-    queueName: string; // Workflow queue name
-    createdAt: number; // Time that queue entry was created
-    startedAt?: number; // Time that workflow was started, if started
-    completedAt?: number; // Time that workflow completed, if complete
-  }[];
-}
-
 export interface GetPendingWorkflowsOutput {
   workflowUUID: string;
   queueName?: string;

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -408,7 +408,8 @@ describe('DBOSClient', () => {
       expect(result1).toBe('abc');
       expect(result2).toBe('def');
       expect(result3).toBe('ghi');
-      expect(ClientTest.inorder_results).toEqual(['abc', 'def', 'ghi']);
+      // They should be processed in order of priority
+      expect(ClientTest.inorder_results).toEqual(['abc', 'ghi', 'def']);
     } finally {
       await client.destroy();
     }

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -7,7 +7,7 @@ import { spawnSync } from 'child_process';
 import { DBOSQueueDuplicatedError, DBOSAwaitedWorkflowCancelledError } from '../src/error';
 import { randomUUID } from 'crypto';
 
-const _queue = new WorkflowQueue('testQueue');
+const _queue = new WorkflowQueue('testQueue', { priorityEnabled: true });
 
 class ClientTest {
   static inorder_results: string[] = [];

--- a/tests/contextfreeapi.test.ts
+++ b/tests/contextfreeapi.test.ts
@@ -392,7 +392,6 @@ async function main5() {
   expect(res).toBe('done');
 
   const wfs = await DBOS.listWorkflows({ workflowName: 'doWorkflow' });
-  expect(wfs.length).toBeGreaterThanOrEqual(1);
   expect(wfs.length).toBe(1);
   const wfstat = await DBOS.getWorkflowStatus(wfs[0].workflowID);
   expect(wfstat?.queueName).toBe('wfq');

--- a/tests/contextfreeapi.test.ts
+++ b/tests/contextfreeapi.test.ts
@@ -411,9 +411,9 @@ async function main5() {
   expect(wfstatsw?.queueName).toBe('wfq');
 
   // Validate that it had the queue
-  const wfqcontent = await DBOS.getWorkflowQueue({ queueName: wfq.name });
-  expect(wfqcontent.workflows.length).toBe(1);
-  expect(wfqcontent.workflows[0].workflowID).toBe('waitPromiseWF');
+  const wfqcontent = await DBOS.listQueuedWorkflows({ queueName: wfq.name });
+  expect(wfqcontent.length).toBe(1);
+  expect(wfqcontent[0].workflowID).toBe('waitPromiseWF');
 
   resolve(); // Let WF finish
   await wfhq.getResult();

--- a/tests/contextfreeinst.test.ts
+++ b/tests/contextfreeinst.test.ts
@@ -230,9 +230,9 @@ async function main5() {
   expect(wfstatsw?.queueName).toBe('wfq');
 
   // Validate that it had the queue
-  const wfqcontent = await DBOS.getWorkflowQueue({ queueName: wfq.name });
-  expect(wfqcontent.workflows.length).toBe(1);
-  expect(wfqcontent.workflows[0].workflowID).toBe('waitPromiseWFI');
+  const wfqcontent = await DBOS.listQueuedWorkflows({ queueName: wfq.name });
+  expect(wfqcontent.length).toBe(1);
+  expect(wfqcontent[0].workflowID).toBe('waitPromiseWFI');
 
   resolve(); // Let WF finish
   await wfhq.getResult();

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -132,8 +132,9 @@ export async function queueEntriesAreCleanedUp() {
   let maxTries = 10;
   let success = false;
   while (maxTries > 0) {
-    const r = await DBOS.listQueuedWorkflows({});
-    if (r.length === 0) {
+    const enqueued_tasks = await DBOS.listQueuedWorkflows({ status: 'ENQUEUED' });
+    const pending_tasks = await DBOS.listQueuedWorkflows({ status: 'PENDING' });
+    if (enqueued_tasks.length === 0 && pending_tasks.length === 0) {
       success = true;
       break;
     }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -132,8 +132,8 @@ export async function queueEntriesAreCleanedUp() {
   let maxTries = 10;
   let success = false;
   while (maxTries > 0) {
-    const r = await DBOS.getWorkflowQueue({});
-    if (r.workflows.length === 0) {
+    const r = await DBOS.listQueuedWorkflows({});
+    if (r.length === 0) {
       success = true;
       break;
     }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -73,9 +73,9 @@ export async function setUpDBOSTestDb(cfg: DBOSConfig) {
   });
   try {
     await pgSystemClient.connect();
-    await pgSystemClient.query(`DROP DATABASE IF EXISTS ${config.poolConfig.database};`);
+    await pgSystemClient.query(`DROP DATABASE IF EXISTS ${config.poolConfig.database} WITH (FORCE);`);
     await pgSystemClient.query(`CREATE DATABASE ${config.poolConfig.database};`);
-    await pgSystemClient.query(`DROP DATABASE IF EXISTS ${config.system_database};`);
+    await pgSystemClient.query(`DROP DATABASE IF EXISTS ${config.system_database} WITH (FORCE);`);
     await pgSystemClient.end();
   } catch (e) {
     if (e instanceof AggregateError) {
@@ -132,9 +132,8 @@ export async function queueEntriesAreCleanedUp() {
   let maxTries = 10;
   let success = false;
   while (maxTries > 0) {
-    const enqueued_tasks = await DBOS.listQueuedWorkflows({ status: 'ENQUEUED' });
-    const pending_tasks = await DBOS.listQueuedWorkflows({ status: 'PENDING' });
-    if (enqueued_tasks.length === 0 && pending_tasks.length === 0) {
+    const qtasks = await DBOS.listQueuedWorkflows({});
+    if (qtasks.length === 0) {
       success = true;
       break;
     }

--- a/tests/stored-proc.test.ts
+++ b/tests/stored-proc.test.ts
@@ -21,8 +21,8 @@ describe('stored-proc-tests', () => {
 
     const [config] = parseConfigFile();
     await runSql({ ...config.poolConfig, database: 'postgres', connectionString: undefined }, async (client) => {
-      await client.query(`DROP DATABASE IF EXISTS ${config.poolConfig.database};`);
-      await client.query(`DROP DATABASE IF EXISTS ${config.system_database};`);
+      await client.query(`DROP DATABASE IF EXISTS ${config.poolConfig.database} WITH (FORCE);`);
+      await client.query(`DROP DATABASE IF EXISTS ${config.system_database} WITH (FORCE);`);
       await client.query(`CREATE DATABASE ${config.poolConfig.database};`);
     });
 

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -1139,7 +1139,7 @@ describe('enqueue-options', () => {
 
     static wfPriorityList: number[] = [];
 
-    static queue = new WorkflowQueue('test_queue_prority', { concurrency: 1 });
+    static queue = new WorkflowQueue('test_queue_prority', { concurrency: 1, priorityEnabled: true });
     static childqueue = new WorkflowQueue('child_queue', { concurrency: 1 });
 
     @DBOS.workflow()

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -499,16 +499,16 @@ describe('queued-wf-tests-simple', () => {
     }
     expect(TestQueueRecovery.cnt).toBe(2);
 
-    const workflows = await DBOS.getWorkflowQueue({ queueName: recoveryQueue.name });
-    expect(workflows.workflows.length).toBe(3);
-    expect(workflows.workflows[2].workflowID).toBe(wfid1);
-    expect(workflows.workflows[2].executorID).toBe('local');
+    const workflows = await DBOS.listQueuedWorkflows({ queueName: recoveryQueue.name });
+    expect(workflows.length).toBe(3);
+    expect(workflows[2].workflowID).toBe(wfid1);
+    expect(workflows[2].executorId).toBe('local');
     expect((await wfh1.getStatus())?.status).toBe(StatusString.PENDING);
-    expect(workflows.workflows[1].workflowID).toBe(wfid2);
-    expect(workflows.workflows[1].executorID).toBe('local');
+    expect(workflows[1].workflowID).toBe(wfid2);
+    expect(workflows[1].executorId).toBe('local');
     expect((await wfh2.getStatus())?.status).toBe(StatusString.PENDING);
-    expect(workflows.workflows[0].workflowID).toBe(wfid3);
-    expect(workflows.workflows[0].executorID).toBe('local');
+    expect(workflows[0].workflowID).toBe(wfid3);
+    expect(workflows[0].executorId).toBe('local');
     expect((await wfh3.getStatus())?.status).toBe(StatusString.ENQUEUED);
 
     // Manually update the database to pretend wf3 is PENDING and comes from a different executor

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -135,8 +135,8 @@ describe('queued-wf-tests-simple', () => {
 
     // Verify that the gap between "waves" is ~equal to the period
     for (let wave = 1; wave < numWaves; ++wave) {
-      expect(times[qlimit * wave] - times[qlimit * wave - 1]).toBeGreaterThan(qperiod * 1000 - 200);
-      expect(times[qlimit * wave] - times[qlimit * wave - 1]).toBeLessThan(qperiod * 1000 + 300);
+      expect(times[qlimit * wave] - times[qlimit * wave - 1]).toBeGreaterThan(qperiod * 1000 - 300);
+      expect(times[qlimit * wave] - times[qlimit * wave - 1]).toBeLessThan(qperiod * 1000 + 500);
     }
 
     for (const h of handles) {
@@ -185,8 +185,8 @@ describe('queued-wf-tests-simple', () => {
 
     // Verify that the gap between "waves" is ~equal to the period
     for (let wave = 1; wave < numWaves; ++wave) {
-      expect(times[qlimit * wave] - times[qlimit * wave - 1]).toBeGreaterThan(qperiod * 1000 - 200);
-      expect(times[qlimit * wave] - times[qlimit * wave - 1]).toBeLessThan(qperiod * 1000 + 300);
+      expect(times[qlimit * wave] - times[qlimit * wave - 1]).toBeGreaterThan(qperiod * 1000 - 300);
+      expect(times[qlimit * wave] - times[qlimit * wave - 1]).toBeLessThan(qperiod * 1000 + 500);
     }
 
     for (const h of handles) {
@@ -501,14 +501,14 @@ describe('queued-wf-tests-simple', () => {
 
     const workflows = await DBOS.listQueuedWorkflows({ queueName: recoveryQueue.name });
     expect(workflows.length).toBe(3);
-    expect(workflows[2].workflowID).toBe(wfid1);
-    expect(workflows[2].executorId).toBe('local');
+    expect(workflows[0].workflowID).toBe(wfid1);
+    expect(workflows[0].executorId).toBe('local');
     expect((await wfh1.getStatus())?.status).toBe(StatusString.PENDING);
     expect(workflows[1].workflowID).toBe(wfid2);
     expect(workflows[1].executorId).toBe('local');
     expect((await wfh2.getStatus())?.status).toBe(StatusString.PENDING);
-    expect(workflows[0].workflowID).toBe(wfid3);
-    expect(workflows[0].executorId).toBe('local');
+    expect(workflows[2].workflowID).toBe(wfid3);
+    expect(workflows[2].executorId).toBe('local');
     expect((await wfh3.getStatus())?.status).toBe(StatusString.ENQUEUED);
 
     // Manually update the database to pretend wf3 is PENDING and comes from a different executor

--- a/tests/wfqueue.test.ts
+++ b/tests/wfqueue.test.ts
@@ -208,7 +208,7 @@ describe('queued-wf-tests-simple', () => {
 
     // Verify all queue entries eventually get cleaned up.
     expect(await queueEntriesAreCleanedUp()).toBe(true);
-  }, 10000);
+  }, 15000);
 
   test('test_one_at_a_time_with_crash', async () => {
     let wfqRes: () => void = () => {};


### PR DESCRIPTION
Move all functionality of the `workflow_queues` table to the `workflow_status` table. Optimize queries and add indexes.

Other changes:

- As priority-based sorting is expensive, disable it unless specifically requested.
- Fix an issue where priority was not implemented correctly for client.
- Remove `getWorkflowQueue` and always use `listQueuedWorkflows`
- Fix the issue where `EnqueueOptions` was defined twice.

Next step: Use DBOS library version to compute app version.