### PR TITLE
Trivial changes (taken from TSv3 branch)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dbos-inc/dbos-transact"
+    "url": "https://github.com/dbos-inc/dbos-transact-ts"
   },
   "homepage": "https://docs.dbos.dev/",
   "main": "dist/src/index.js",

--- a/packages/aws-config/package.json
+++ b/packages/aws-config/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dbos-inc/dbos-transact",
+    "url": "https://github.com/dbos-inc/dbos-transact-ts",
     "directory": "packages/aws-config"
   },
   "homepage": "https://docs.dbos.dev/",

--- a/packages/communicator-bcrypt/README.md
+++ b/packages/communicator-bcrypt/README.md
@@ -30,4 +30,4 @@ const isValid = await BcryptStep.bcryptCompare(password, hashedPassword);
 
 - To start a DBOS app from a template, visit our [quickstart](https://docs.dbos.dev/quickstart).
 - For DBOS programming tutorials, check out our [programming guide](https://docs.dbos.dev/typescript/programming-guide).
-- To learn more about DBOS, take a look at [our documentation](https://docs.dbos.dev/) or our [source code](https://github.com/dbos-inc/dbos-transact).
+- To learn more about DBOS, take a look at [our documentation](https://docs.dbos.dev/) or our [source code](https://github.com/dbos-inc/dbos-transact-ts).

--- a/packages/communicator-bcrypt/package.json
+++ b/packages/communicator-bcrypt/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dbos-inc/dbos-transact",
+    "url": "https://github.com/dbos-inc/dbos-transact-ts",
     "directory": "packages/communicator-bcrypt"
   },
   "homepage": "https://docs.dbos.dev/",

--- a/packages/communicator-datetime/README.md
+++ b/packages/communicator-datetime/README.md
@@ -18,4 +18,4 @@ This function returns a `number` of milliseconds since January 1, 1970, UTC, in 
 
 - To start a DBOS app from a template, visit our [quickstart](https://docs.dbos.dev/quickstart).
 - For DBOS programming tutorials, check out our [programming guide](https://docs.dbos.dev/typescript/programming-guide).
-- To learn more about DBOS, take a look at [our documentation](https://docs.dbos.dev/) or our [source code](https://github.com/dbos-inc/dbos-transact).
+- To learn more about DBOS, take a look at [our documentation](https://docs.dbos.dev/) or our [source code](https://github.com/dbos-inc/dbos-transact-ts).

--- a/packages/communicator-datetime/package.json
+++ b/packages/communicator-datetime/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dbos-inc/dbos-transact",
+    "url": "https://github.com/dbos-inc/dbos-transact-ts",
     "directory": "packages/communicator-datetime"
   },
   "homepage": "https://docs.dbos.dev/",

--- a/packages/communicator-email-ses/README.md
+++ b/packages/communicator-email-ses/README.md
@@ -106,4 +106,4 @@ While some email services allow setting of a [`Message-ID`](https://en.wikipedia
 
 - To start a DBOS app from a template, visit our [quickstart](https://docs.dbos.dev/quickstart).
 - For DBOS programming tutorials, check out our [programming guide](https://docs.dbos.dev/typescript/programming-guide).
-- To learn more about DBOS, take a look at [our documentation](https://docs.dbos.dev/) or our [source code](https://github.com/dbos-inc/dbos-transact).
+- To learn more about DBOS, take a look at [our documentation](https://docs.dbos.dev/) or our [source code](https://github.com/dbos-inc/dbos-transact-ts).

--- a/packages/communicator-email-ses/package.json
+++ b/packages/communicator-email-ses/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dbos-inc/dbos-transact",
+    "url": "https://github.com/dbos-inc/dbos-transact-ts",
     "directory": "packages/communicator-email-ses"
   },
   "homepage": "https://docs.dbos.dev/",

--- a/packages/communicator-random/README.md
+++ b/packages/communicator-random/README.md
@@ -14,4 +14,4 @@ The reason that random number generation should be wrapped in a `@DBOS.step` is 
 
 - To start a DBOS app from a template, visit our [quickstart](https://docs.dbos.dev/quickstart).
 - For DBOS programming tutorials, check out our [programming guide](https://docs.dbos.dev/typescript/programming-guide).
-- To learn more about DBOS, take a look at [our documentation](https://docs.dbos.dev/) or our [source code](https://github.com/dbos-inc/dbos-transact).
+- To learn more about DBOS, take a look at [our documentation](https://docs.dbos.dev/) or our [source code](https://github.com/dbos-inc/dbos-transact-ts).

--- a/packages/communicator-random/package.json
+++ b/packages/communicator-random/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dbos-inc/dbos-transact",
+    "url": "https://github.com/dbos-inc/dbos-transact-ts",
     "directory": "packages/communicator-random"
   },
   "homepage": "https://docs.dbos.dev/",

--- a/packages/component-aws-s3/README.md
+++ b/packages/component-aws-s3/README.md
@@ -278,4 +278,4 @@ The `s3_utils.test.ts` file included in the source repository can be used to upl
 
 - To start a DBOS app from a template, visit our [quickstart](https://docs.dbos.dev/quickstart).
 - For DBOS programming tutorials, check out our [programming guide](https://docs.dbos.dev/typescript/programming-guide).
-- To learn more about DBOS, take a look at [our documentation](https://docs.dbos.dev/) or our [source code](https://github.com/dbos-inc/dbos-transact).
+- To learn more about DBOS, take a look at [our documentation](https://docs.dbos.dev/) or our [source code](https://github.com/dbos-inc/dbos-transact-ts).

--- a/packages/component-aws-s3/package.json
+++ b/packages/component-aws-s3/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dbos-inc/dbos-transact",
+    "url": "https://github.com/dbos-inc/dbos-transact-ts",
     "directory": "packages/component-aws-s3"
   },
   "homepage": "https://docs.dbos.dev/",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dbos-inc/dbos-transact",
+    "url": "https://github.com/dbos-inc/dbos-transact-ts",
     "directory": "packages/create"
   },
   "homepage": "https://docs.dbos.dev/",

--- a/packages/dbos-cloud/package.json
+++ b/packages/dbos-cloud/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dbos-inc/dbos-transact",
+    "url": "https://github.com/dbos-inc/dbos-transact-ts",
     "directory": "packages/dbos-cloud"
   },
   "homepage": "https://docs.dbos.dev/",

--- a/packages/dbos-compiler/package.json
+++ b/packages/dbos-compiler/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dbos-inc/dbos-transact",
+    "url": "https://github.com/dbos-inc/dbos-transact-ts",
     "directory": "packages/dbos-compiler"
   },
   "homepage": "https://docs.dbos.dev/",

--- a/packages/dbos-confluent-kafka/README.md
+++ b/packages/dbos-confluent-kafka/README.md
@@ -65,4 +65,4 @@ The `confluent-kafkajs.test.ts` file included in the source repository demonstra
 
 - To start a DBOS app from a template, visit our [quickstart](https://docs.dbos.dev/quickstart).
 - For DBOS programming tutorials, check out our [programming guide](https://docs.dbos.dev/typescript/programming-guide).
-- To learn more about DBOS, take a look at [our documentation](https://docs.dbos.dev/) or our [source code](https://github.com/dbos-inc/dbos-transact).
+- To learn more about DBOS, take a look at [our documentation](https://docs.dbos.dev/) or our [source code](https://github.com/dbos-inc/dbos-transact-ts).

--- a/packages/dbos-confluent-kafka/package.json
+++ b/packages/dbos-confluent-kafka/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dbos-inc/dbos-transact",
+    "url": "https://github.com/dbos-inc/dbos-transact-ts",
     "directory": "packages/dbos-confluent-kafka"
   },
   "homepage": "https://docs.dbos.dev/",

--- a/packages/dbos-kafkajs/README.md
+++ b/packages/dbos-kafkajs/README.md
@@ -67,4 +67,4 @@ The `kafkajs.test.ts` file included in the source repository demonstrates sendin
 
 - To start a DBOS app from a template, visit our [quickstart](https://docs.dbos.dev/quickstart).
 - For DBOS programming tutorials, check out our [programming guide](https://docs.dbos.dev/typescript/programming-guide).
-- To learn more about DBOS, take a look at [our documentation](https://docs.dbos.dev/) or our [source code](https://github.com/dbos-inc/dbos-transact).
+- To learn more about DBOS, take a look at [our documentation](https://docs.dbos.dev/) or our [source code](https://github.com/dbos-inc/dbos-transact-ts).

--- a/packages/dbos-kafkajs/package.json
+++ b/packages/dbos-kafkajs/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dbos-inc/dbos-transact",
+    "url": "https://github.com/dbos-inc/dbos-transact-ts",
     "directory": "packages/dbos-kafkajs"
   },
   "homepage": "https://docs.dbos.dev/",

--- a/packages/dbos-sqs/README.md
+++ b/packages/dbos-sqs/README.md
@@ -151,4 +151,4 @@ The `sqs.test.ts` file included in the source repository demonstrates sending an
 
 - To start a DBOS app from a template, visit our [quickstart](https://docs.dbos.dev/quickstart).
 - For DBOS programming tutorials, check out our [programming guide](https://docs.dbos.dev/typescript/programming-guide).
-- To learn more about DBOS, take a look at [our documentation](https://docs.dbos.dev/) or our [source code](https://github.com/dbos-inc/dbos-transact).
+- To learn more about DBOS, take a look at [our documentation](https://docs.dbos.dev/) or our [source code](https://github.com/dbos-inc/dbos-transact-ts).

--- a/packages/dbos-sqs/package.json
+++ b/packages/dbos-sqs/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dbos-inc/dbos-transact",
+    "url": "https://github.com/dbos-inc/dbos-transact-ts",
     "directory": "packages/dbos-sqs"
   },
   "homepage": "https://docs.dbos.dev/",

--- a/src/eventreceiver.ts
+++ b/src/eventreceiver.ts
@@ -95,7 +95,8 @@ export interface DBOSExecutorContext {
   procedure<T extends unknown[], R>(proc: StoredProcedure<T, R>, params: WorkflowParams, ...args: T): Promise<R>;
 
   /**
-   * Send a messsage to workflow with a given ID.  Note that `DBOS.send` can be used instead.
+   * Send a messsage to workflow with a given ID.
+   * @deprecated `DBOS.send` can be used instead.
    * @param destinationID - ID of workflow to receive the message
    * @param message - Message
    * @param topic - Topic for message
@@ -103,9 +104,15 @@ export interface DBOSExecutorContext {
    * @template T - Type of object to send
    */
   send<T>(destinationID: string, message: T, topic?: string, idempotencyKey?: string): Promise<void>;
-  /** Get an event set by a workflow.  Note that `DBOS.getEvent` can be used instead. */
+  /**
+   * Get an event set by a workflow.
+   * @deprecated Note that `DBOS.getEvent` can be used instead.
+   */
   getEvent<T>(workflowID: string, key: string, timeoutSeconds?: number): Promise<T | null>;
-  /** Retrieve a workflow handle given the workflow ID.  Note that `DBOS.retrieveWorkflow` can be used instead */
+  /**
+   * Retrieve a workflow handle given the workflow ID.
+   * @deprecated Note that `DBOS.retrieveWorkflow` can be used instead
+   */
   retrieveWorkflow<R>(workflowID: string): WorkflowHandle<R>;
   /** @deprecated Use functions on `DBOS` */
   getWorkflowStatus(workflowID: string, callerID?: string, callerFN?: number): Promise<WorkflowStatus | null>;
@@ -129,14 +136,14 @@ export interface DBOSExecutorContext {
   ): Promise<string>;
 
   // Event receiver state queries / updates
-  /** @see DBOS.getEventDispatchState */
+  /** @deprecated see DBOS.getEventDispatchState */
   getEventDispatchState(
     service: string,
     workflowFnName: string,
     key: string,
   ): Promise<DBOSEventReceiverState | undefined>;
 
-  /** @see DBOS.upsertEventDispatchState */
+  /** @deprecated see DBOS.upsertEventDispatchState */
   upsertEventDispatchState(state: DBOSEventReceiverState): Promise<DBOSEventReceiverState>;
 
   /** @deprecated Use `DBOS.queryUserDB` */

--- a/tests/httpServer/classdec.test.ts
+++ b/tests/httpServer/classdec.test.ts
@@ -128,6 +128,7 @@ describe('httpserver-defsec-tests', () => {
 
   let middlewareCounter2 = 0;
   const testMiddleware2: Middleware = async (ctx, next) => {
+    // This is not a typo.  This is testing that middleware goes left to right
     middlewareCounter2 = middlewareCounter + 1;
     await next();
   };


### PR DESCRIPTION
Every little bit helps cut down the diff size w/ TSv3 branch:

- Mark parts of v1 event receiver interface as deprecated (use `DBOS.` instead)
- Comments
- Update repo URLs in packages