### PR TITLE
Devhawk/decorator-free

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -38,8 +38,14 @@ interface ClientEnqueueOptions {
   workflowName: string;
   /**
    * The name of the class containing the method that will be invoked when the workflow runs.
+   * If not provided, an empty string will be used as the class name.
    */
-  workflowClassName: string;
+  workflowClassName?: string;
+  /**
+   * The name of the ConfiguredInstance containing the method that will be invoked when the workflow runs.
+   * If not provided, an empty string will be used as the configured instance name.
+   */
+  workflowConfigName?: string;
   /**
    * An optional identifier for the workflow to ensure idempotency.
    * If not provided, a new UUID will be generated.
@@ -125,15 +131,15 @@ export class DBOSClient {
     options: ClientEnqueueOptions,
     ...args: Parameters<T>
   ): Promise<WorkflowHandle<Awaited<ReturnType<T>>>> {
-    const { workflowName, workflowClassName, queueName, appVersion } = options;
+    const { workflowName, workflowClassName, workflowConfigName, queueName, appVersion } = options;
     const workflowUUID = options.workflowID ?? randomUUID();
 
     const internalStatus: WorkflowStatusInternal = {
       workflowUUID: workflowUUID,
       status: StatusString.ENQUEUED,
       workflowName: workflowName,
-      workflowClassName: workflowClassName,
-      workflowConfigName: '',
+      workflowClassName: workflowClassName ?? '',
+      workflowConfigName: workflowConfigName ?? '',
       queueName: queueName,
       authenticatedUser: '',
       output: null,

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1724,15 +1724,15 @@ export class DBOS {
 
   static registerWorkflow<This, Args extends unknown[], Return>(
     func: (this: This, ...args: Args) => Promise<Return>,
-    target: {
+    name: string,
+    options: {
       classOrInst?: object;
       className?: string;
-      name: string;
       config?: WorkflowConfig;
-    },
+    } = {},
   ): (this: This, ...args: Args) => Promise<Return> {
-    const { registration } = registerAndWrapDBOSFunctionByName(target.classOrInst, target.className, target.name, func);
-    return DBOS.#getWorkflowInvokeWrapper(registration, target.config);
+    const { registration } = registerAndWrapDBOSFunctionByName(options.classOrInst, options.className, name, func);
+    return DBOS.#getWorkflowInvokeWrapper(registration, options.config);
   }
 
   static #getWorkflowInvokeWrapper<This, Args extends unknown[], Return>(

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1712,9 +1712,7 @@ export class DBOS {
       inDescriptor: TypedPropertyDescriptor<(this: This, ...args: Args) => Promise<Return>>,
     ) {
       const { descriptor, registration } = registerAndWrapDBOSFunction(target, propertyKey, inDescriptor);
-      registration.setWorkflowConfig(config);
-
-      const invokeWrapper = DBOS.#getWorkflowInvokeWrapper(registration);
+      const invokeWrapper = DBOS.#getWorkflowInvokeWrapper(registration, config);
 
       descriptor.value = invokeWrapper;
       registration.wrappedFunction = invokeWrapper;
@@ -1734,14 +1732,14 @@ export class DBOS {
     },
   ): (this: This, ...args: Args) => Promise<Return> {
     const { registration } = registerAndWrapDBOSFunctionByName(target.classOrInst, target.className, target.name, func);
-    registration.setWorkflowConfig(target.config ?? {});
-
-    return DBOS.#getWorkflowInvokeWrapper(registration);
+    return DBOS.#getWorkflowInvokeWrapper(registration, target.config);
   }
 
   static #getWorkflowInvokeWrapper<This, Args extends unknown[], Return>(
     registration: MethodRegistration<This, Args, Return>,
+    config: WorkflowConfig | undefined,
   ): (this: This, ...args: Args) => Promise<Return> {
+    registration.setWorkflowConfig(config ?? {});
     const invokeWrapper = async function (this: This, ...rawArgs: Args): Promise<Return> {
       const pctx = getCurrentContextStore();
       let inst: ConfiguredInstance | undefined = undefined;

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -240,13 +240,10 @@ export function runInternalStep<T>(callback: () => Promise<T>, funcName: string,
       return callback();
     } else if (DBOS.isInWorkflow()) {
       const wfctx = assertCurrentWorkflowContext();
-      if (DBOS.workflowID === undefined) {
-        throw new Error();
-      }
       return DBOSExecutor.globalInstance!.runInternalStep<T>(
         callback,
         funcName,
-        DBOS.workflowID,
+        DBOS.workflowID!, // assume DBOS.workflowID is defined because of assertCurrentWorkflowContext call above
         wfctx.functionIDGetIncrement(),
         childWFID,
       );

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -2150,11 +2150,11 @@ export class DBOS {
     return invokeWrapper;
   }
 
-  static runAsStep<Return>(func: () => Promise<Return>, config: StepConfig & { name?: string } = {}): Promise<Return> {
+  static runStep<Return>(func: () => Promise<Return>, config: StepConfig & { name?: string } = {}): Promise<Return> {
     const name = config.name ?? func.name;
     if (DBOS.isWithinWorkflow()) {
       if (DBOS.isInTransaction()) {
-        throw new DBOSInvalidWorkflowTransitionError('Invalid call to a runAsStep from within a `transaction`');
+        throw new DBOSInvalidWorkflowTransitionError('Invalid call to a runStep from within a `transaction`');
       }
       if (DBOS.isInStep()) {
         // There should probably be checks here about the compatibility of the StepConfig...

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -9,7 +9,7 @@ import { StoredProcedure, StoredProcedureContext } from './procedure';
 import { InvokeFuncsInst } from './httpServer/handler';
 import { WorkflowQueue } from './wfqueue';
 import { DBOSJSON } from './utils';
-import { DBOS, runAsWorkflowStep } from './dbos';
+import { DBOS, runInternalStep } from './dbos';
 import { EnqueueOptions } from './system_database';
 
 /** @deprecated */
@@ -571,7 +571,7 @@ export class InvokedHandle<R> implements WorkflowHandle<R> {
   }
 
   async getResult(): Promise<R> {
-    return await runAsWorkflowStep(
+    return await runInternalStep(
       async () => {
         return await this.workflowPromise;
       },

--- a/tests/decorator-free.test.ts
+++ b/tests/decorator-free.test.ts
@@ -172,6 +172,8 @@ describe('decorator-free-tests', () => {
     expect(steps[0].output).toEqual(1000);
     expect(steps[0].error).toBeNull();
     expect(steps[0].childWorkflowID).toBeNull();
+
+    await client.destroy();
   });
 
   test('wf-free-step-run', async () => {
@@ -349,7 +351,7 @@ describe('decorator-free-tests', () => {
 });
 
 describe('registerWorkflow-tests', () => {
-  test('dont-allow-duplicate-workflow-registration', async () => {
+  test('dont-allow-duplicate-workflow-registration', () => {
     function workflow1(value: number) {
       return DBOS.runStep(() => stepTest(value), { name: 'stepTest-runStep' });
     }

--- a/tests/decorator-free.test.ts
+++ b/tests/decorator-free.test.ts
@@ -25,7 +25,7 @@ function wfRegStep(value: number) {
 }
 
 function wfRunStep(value: number) {
-  return DBOS.runAsStep(() => stepTest(value), { name: 'stepTest-runAsStep' });
+  return DBOS.runStep(() => stepTest(value), { name: 'stepTest-runStep' });
 }
 
 function wfRegRetry(value: number) {
@@ -57,7 +57,7 @@ class TestClass extends ConfiguredInstance {
   }
 
   static wfRunStep(value: number) {
-    return DBOS.runAsStep(() => stepTest(value), { name: 'stepTest-runAsStep' });
+    return DBOS.runStep(() => stepTest(value), { name: 'stepTest-runStep' });
   }
 
   static wfRegRetry(value: number) {
@@ -84,7 +84,7 @@ class TestClass extends ConfiguredInstance {
   }
 
   wfRunStep(value: number) {
-    return DBOS.runAsStep(() => stepTest(value), { name: 'stepTest-runAsStep' });
+    return DBOS.runStep(() => stepTest(value), { name: 'stepTest-runStep' });
   }
 
   wfRegRetry(value: number) {
@@ -160,7 +160,7 @@ describe('decorator-free-tests', () => {
     const steps = (await DBOS.listWorkflowSteps(wfid))!;
     expect(steps.length).toBe(1);
     expect(steps[0].functionID).toBe(0);
-    expect(steps[0].name).toBe('stepTest-runAsStep');
+    expect(steps[0].name).toBe('stepTest-runStep');
     expect(steps[0].output).toEqual(1000);
     expect(steps[0].error).toBeNull();
     expect(steps[0].childWorkflowID).toBeNull();
@@ -225,7 +225,7 @@ describe('decorator-free-tests', () => {
     const steps = (await DBOS.listWorkflowSteps(wfid))!;
     expect(steps.length).toBe(1);
     expect(steps[0].functionID).toBe(0);
-    expect(steps[0].name).toBe('stepTest-runAsStep');
+    expect(steps[0].name).toBe('stepTest-runStep');
     expect(steps[0].output).toEqual(1000);
     expect(steps[0].error).toBeNull();
     expect(steps[0].childWorkflowID).toBeNull();
@@ -288,7 +288,7 @@ describe('decorator-free-tests', () => {
     const steps = (await DBOS.listWorkflowSteps(wfid))!;
     expect(steps.length).toBe(1);
     expect(steps[0].functionID).toBe(0);
-    expect(steps[0].name).toBe('stepTest-runAsStep');
+    expect(steps[0].name).toBe('stepTest-runStep');
     expect(steps[0].output).toEqual(1000);
     expect(steps[0].error).toBeNull();
     expect(steps[0].childWorkflowID).toBeNull();

--- a/tests/decorator-free.test.ts
+++ b/tests/decorator-free.test.ts
@@ -1,0 +1,153 @@
+import { WorkflowHandle, DBOSInitializer, InitContext, DBOS } from '../src/';
+import { generateDBOSTestConfig, setUpDBOSTestDb, TestKvTable } from './helpers';
+import { randomUUID } from 'node:crypto';
+
+class DecoratorFreeTest {
+  @DBOS.workflow()
+  static async testFreeStep(value: number) {
+    return await regFreeStep(value);
+  }
+
+  @DBOS.workflow()
+  static async testFreeStepRetries(value: number) {
+    return await regFreeStepRetries(value);
+  }
+
+  @DBOS.workflow()
+  static async testRunAsStep(value: number) {
+    return DBOS.runAsStep(
+      async () => {
+        return value * 10;
+      },
+      { name: 'testRunStep' },
+    );
+  }
+
+  static runAsStepRetriesAttempts = Array<boolean>(5).fill(false);
+
+  @DBOS.workflow()
+  static async testRunAsStepRetries(value: number) {
+    return DBOS.runAsStep(
+      async () => {
+        expect(DBOS.stepStatus).toBeDefined();
+        expect(DBOS.stepStatus!.currentAttempt).toBeDefined();
+        const currentAttempt = DBOS.stepStatus!.currentAttempt!;
+        DecoratorFreeTest.runAsStepRetriesAttempts[currentAttempt - 1] = true;
+        if (currentAttempt < 3) {
+          throw new Error('Test error');
+        }
+
+        return value * 10;
+      },
+      { name: 'testRunStep', retriesAllowed: true },
+    );
+  }
+}
+
+async function freeStep(value: number): Promise<number> {
+  return value * 100;
+}
+
+const regFreeStep = DBOS.registerStep(freeStep);
+
+const freeStepRetriesAttempts = Array<boolean>(5).fill(false);
+async function freeStepRetries(value: number): Promise<number> {
+  expect(DBOS.stepStatus).toBeDefined();
+  expect(DBOS.stepStatus!.currentAttempt).toBeDefined();
+  const currentAttempt = DBOS.stepStatus!.currentAttempt!;
+  freeStepRetriesAttempts[currentAttempt - 1] = true;
+  if (currentAttempt < 3) {
+    throw new Error('Test error');
+  }
+  return value * 100;
+}
+const regFreeStepRetries = DBOS.registerStep(freeStepRetries, { retriesAllowed: true });
+
+describe('decorator-free-tests', () => {
+  const config = generateDBOSTestConfig();
+
+  beforeAll(async () => {
+    await setUpDBOSTestDb(config);
+    DBOS.setConfig(config);
+  });
+
+  beforeEach(async () => {
+    await DBOS.launch();
+  });
+
+  afterEach(async () => {
+    await DBOS.shutdown();
+  });
+
+  test('wf-free-step', async () => {
+    const wfid = randomUUID();
+
+    await DBOS.withNextWorkflowID(wfid, async () => {
+      const res = await DecoratorFreeTest.testFreeStep(10);
+      expect(res).toBe(1000);
+    });
+
+    const wfsteps = (await DBOS.listWorkflowSteps(wfid))!;
+    expect(wfsteps.length).toBe(1);
+    expect(wfsteps[0].functionID).toBe(0);
+    expect(wfsteps[0].name).toBe('freeStep');
+    expect(wfsteps[0].output).toEqual(1000);
+    expect(wfsteps[0].error).toBeNull();
+    expect(wfsteps[0].childWorkflowID).toBeNull();
+  });
+
+  test('wf-free-step-retries', async () => {
+    const wfid = randomUUID();
+
+    await DBOS.withNextWorkflowID(wfid, async () => {
+      const res = await DecoratorFreeTest.testFreeStepRetries(10);
+      expect(res).toBe(1000);
+    });
+
+    const wfsteps = (await DBOS.listWorkflowSteps(wfid))!;
+    expect(wfsteps.length).toBe(1);
+    expect(wfsteps[0].functionID).toBe(0);
+    expect(wfsteps[0].name).toBe('freeStepRetries');
+    expect(wfsteps[0].output).toEqual(1000);
+    expect(wfsteps[0].error).toBeNull();
+    expect(wfsteps[0].childWorkflowID).toBeNull();
+
+    expect(freeStepRetriesAttempts).toEqual([true, true, true, false, false]);
+  });
+
+  test('wf-run-as-step', async () => {
+    const wfid = randomUUID();
+
+    await DBOS.withNextWorkflowID(wfid, async () => {
+      const res = await DecoratorFreeTest.testRunAsStep(10);
+      expect(res).toBe(100);
+    });
+
+    const wfsteps = (await DBOS.listWorkflowSteps(wfid))!;
+    expect(wfsteps.length).toBe(1);
+    expect(wfsteps[0].functionID).toBe(0);
+    expect(wfsteps[0].name).toBe('testRunStep');
+    expect(wfsteps[0].output).toEqual(100);
+    expect(wfsteps[0].error).toBeNull();
+    expect(wfsteps[0].childWorkflowID).toBeNull();
+  });
+
+  test('wf-run-as-step-retries', async () => {
+    const wfid = randomUUID();
+
+    await DBOS.withNextWorkflowID(wfid, async () => {
+      const res = await DecoratorFreeTest.testRunAsStepRetries(10);
+      expect(res).toBe(100);
+    });
+
+    const wfsteps = (await DBOS.listWorkflowSteps(wfid))!;
+    expect(wfsteps.length).toBe(1);
+    expect(wfsteps[0].functionID).toBe(0);
+    expect(wfsteps[0].name).toBe('testRunStep');
+    expect(wfsteps[0].output).toEqual(100);
+    expect(wfsteps[0].error).toBeNull();
+    expect(wfsteps[0].childWorkflowID).toBeNull();
+
+    expect(DecoratorFreeTest.runAsStepRetriesAttempts).toEqual([true, true, true, false, false]);
+  });
+});

--- a/tests/decorator-free.test.ts
+++ b/tests/decorator-free.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 import { ConfiguredInstance, DBOS } from '../src/';
 import { generateDBOSTestConfig, setUpDBOSTestDb } from './helpers';
 import { randomUUID } from 'node:crypto';

--- a/tests/decorator-free.test.ts
+++ b/tests/decorator-free.test.ts
@@ -21,8 +21,8 @@ class DecoratorFreeTest {
   @DBOS.workflow()
   static async testRunAsStep(value: number) {
     return DBOS.runAsStep(
-      async () => {
-        return value * 10;
+      () => {
+        return Promise.resolve(value * 10);
       },
       { name: 'testRunStep' },
     );
@@ -33,6 +33,7 @@ class DecoratorFreeTest {
   @DBOS.workflow()
   static async testRunAsStepRetries(value: number) {
     return DBOS.runAsStep(
+      //eslint-disable-next-line @typescript-eslint/require-await
       async () => {
         expect(DBOS.stepStatus).toBeDefined();
         expect(DBOS.stepStatus!.currentAttempt).toBeDefined();
@@ -41,27 +42,28 @@ class DecoratorFreeTest {
         if (currentAttempt < 3) {
           throw new Error('Test error');
         }
-
         return value * 10;
       },
       { name: 'testRunStep', retriesAllowed: true },
     );
   }
 
-  static async staticStep(value: number): Promise<number> {
-    return value * 1000;
+  static staticStep(value: number): Promise<number> {
+    return Promise.resolve(value * 1000);
   }
 }
 
 DecoratorFreeTest.staticStep = DBOS.registerStep(DecoratorFreeTest.staticStep);
 
-async function freeStep(value: number): Promise<number> {
-  return value * 100;
+function freeStep(value: number): Promise<number> {
+  return Promise.resolve(value * 100);
 }
 
 const regFreeStep = DBOS.registerStep(freeStep);
 
 const freeStepRetriesAttempts = Array<boolean>(5).fill(false);
+
+//eslint-disable-next-line @typescript-eslint/require-await
 async function freeStepRetries(value: number): Promise<number> {
   expect(DBOS.stepStatus).toBeDefined();
   expect(DBOS.stepStatus!.currentAttempt).toBeDefined();

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -36,6 +36,7 @@ export function generateDBOSTestConfig(dbClient?: UserDatabaseName): DBOSConfigI
   const poolConfig = constructPoolConfig(configFile, { silent: true });
 
   const dbosTestConfig: DBOSConfigInternal = {
+    databaseUrl,
     poolConfig,
     application: configFile.application,
     telemetry: configFile.telemetry!,


### PR DESCRIPTION
Adds `DBOS.registerWorkflow`, `DBOS.registerStep` and `DBOS.runStep` to enable support creating DBOS workflows and steps w/o needing to use the `@DBOS` decorators.

The `registerWorkflow` and `registerStep` functions work like their decorator counterparts. Pass a function (free function, static method or instance method) along w/ the name and config object and it returns the original function wrapped in the specified DBOS functionality. `DBOS.runStep` allows you to run an arbitrary lambda as a step. 