### PR TITLE
startWorkflowFunction

### DIFF
--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1861,98 +1861,92 @@ export class DBOS {
     return DBOS.#getWorkflowInvokeWrapper(registration, options.config);
   }
 
+  // TODO: better method name
+  static async #runDatWorkflow<This, Args extends unknown[], Return>(
+    $this: This,
+    func: WorkflowFunction<Args, Return>,
+    args: Args,
+  ): Promise<WorkflowHandle<Return>> {
+    const pctx = getCurrentContextStore();
+    const instance = $this === undefined || typeof $this === 'function' ? undefined : ($this as ConfiguredInstance);
+    if (instance && 'name' in instance === false) {
+      throw new DBOSInvalidWorkflowTransitionError(
+        'Attempt to call a `workflow` function on an object that is not a `ConfiguredInstance`',
+      );
+    }
+
+    let wfId = getNextWFID(undefined);
+
+    // If this is called from within a workflow, this is a child workflow,
+    //  For OAOO, we will need a consistent ID formed from the parent WF and call number
+    if (DBOS.isWithinWorkflow()) {
+      if (!DBOS.isInWorkflow()) {
+        throw new DBOSInvalidWorkflowTransitionError(
+          'Invalid call to a `workflow` function from within a `step` or `transaction`',
+        );
+      }
+
+      const wfctx = assertCurrentWorkflowContext();
+
+      const funcId = wfctx.functionIDGetIncrement();
+      wfId = wfId || wfctx.workflowUUID + '-' + funcId;
+      const params: WorkflowParams = {
+        workflowUUID: wfId,
+        parentCtx: wfctx,
+        configuredInstance: instance,
+        queueName: pctx?.queueAssignedForWorkflows,
+        timeoutMS: pctx?.workflowTimeoutMS,
+        deadlineEpochMS: wfctx.deadlineEpochMS,
+      };
+      // Detach child deadline if a null timeout is configured
+      if (pctx?.workflowTimeoutMS === null) {
+        params.deadlineEpochMS = undefined;
+      }
+
+      return await DBOSExecutor.globalInstance!.internalWorkflow(func, params, wfctx.workflowUUID, funcId, ...args);
+    }
+
+    // Else, we setup a parent context that includes all the potential metadata the application could have set in DBOSLocalCtx
+    let parentCtx: DBOSContextImpl | undefined = undefined;
+    if (pctx) {
+      // If pctx has no span, e.g., has not been setup through `withTracedContext`, set up a parent span for the workflow here.
+      let span = pctx.span;
+      if (!span) {
+        span = DBOS.#executor.tracer.startSpan(pctx.operationCaller || 'workflowCaller', {
+          operationUUID: wfId,
+          operationType: pctx.operationType,
+          authenticatedUser: pctx.authenticatedUser,
+          assumedRole: pctx.assumedRole,
+          authenticatedRoles: pctx.authenticatedRoles,
+        });
+      }
+      parentCtx = new DBOSContextImpl(pctx.operationCaller || 'workflowCaller', span, DBOS.logger as GlobalLogger);
+      parentCtx.request = pctx.request || {};
+      parentCtx.authenticatedUser = pctx.authenticatedUser || '';
+      parentCtx.assumedRole = pctx.assumedRole || '';
+      parentCtx.authenticatedRoles = pctx.authenticatedRoles || [];
+      parentCtx.workflowUUID = wfId || '';
+    }
+
+    const wfParams: InternalWorkflowParams = {
+      workflowUUID: wfId,
+      queueName: pctx?.queueAssignedForWorkflows,
+      configuredInstance: instance,
+      parentCtx,
+      timeoutMS: pctx?.workflowTimeoutMS,
+    };
+
+    return await DBOS.#executor.workflow(func, wfParams, ...args);
+  }
+
   static #getWorkflowInvokeWrapper<This, Args extends unknown[], Return>(
     registration: MethodRegistration<This, Args, Return>,
     config: WorkflowConfig | undefined,
   ): (this: This, ...args: Args) => Promise<Return> {
     registration.setWorkflowConfig(config ?? {});
     const invokeWrapper = async function (this: This, ...rawArgs: Args): Promise<Return> {
-      const pctx = getCurrentContextStore();
-      let inst: ConfiguredInstance | undefined = undefined;
-      if (this === undefined || typeof this === 'function') {
-        // This is static
-      } else {
-        inst = this as ConfiguredInstance;
-        if (!('name' in inst)) {
-          throw new DBOSInvalidWorkflowTransitionError(
-            'Attempt to call a `workflow` function on an object that is not a `ConfiguredInstance`',
-          );
-        }
-      }
-
-      let wfId = getNextWFID(undefined);
-
-      // If this is called from within a workflow, this is a child workflow,
-      //  For OAOO, we will need a consistent ID formed from the parent WF and call number
-      if (DBOS.isWithinWorkflow()) {
-        if (!DBOS.isInWorkflow()) {
-          throw new DBOSInvalidWorkflowTransitionError(
-            'Invalid call to a `workflow` function from within a `step` or `transaction`',
-          );
-        }
-
-        const wfctx = assertCurrentWorkflowContext();
-
-        const funcId = wfctx.functionIDGetIncrement();
-        wfId = wfId || wfctx.workflowUUID + '-' + funcId;
-        const params: WorkflowParams = {
-          workflowUUID: wfId,
-          parentCtx: wfctx,
-          configuredInstance: inst,
-          queueName: pctx?.queueAssignedForWorkflows,
-          timeoutMS: pctx?.workflowTimeoutMS,
-          deadlineEpochMS: wfctx.deadlineEpochMS,
-        };
-        // Detach child deadline if a null timeout is configured
-        if (pctx?.workflowTimeoutMS === null) {
-          params.deadlineEpochMS = undefined;
-        }
-
-        const cwfh = await DBOSExecutor.globalInstance!.internalWorkflow(
-          registration.registeredFunction as unknown as WorkflowFunction<Args, Return>,
-          params,
-          wfctx.workflowUUID,
-          funcId,
-          ...rawArgs,
-        );
-        return await cwfh.getResult();
-      }
-
-      // Else, we setup a parent context that includes all the potential metadata the application could have set in DBOSLocalCtx
-      let parentCtx: DBOSContextImpl | undefined = undefined;
-      if (pctx) {
-        // If pctx has no span, e.g., has not been setup through `withTracedContext`, set up a parent span for the workflow here.
-        let span = pctx.span;
-        if (!span) {
-          span = DBOS.#executor.tracer.startSpan(pctx.operationCaller || 'workflowCaller', {
-            operationUUID: wfId,
-            operationType: pctx.operationType,
-            authenticatedUser: pctx.authenticatedUser,
-            assumedRole: pctx.assumedRole,
-            authenticatedRoles: pctx.authenticatedRoles,
-          });
-        }
-        parentCtx = new DBOSContextImpl(pctx.operationCaller || 'workflowCaller', span, DBOS.logger as GlobalLogger);
-        parentCtx.request = pctx.request || {};
-        parentCtx.authenticatedUser = pctx.authenticatedUser || '';
-        parentCtx.assumedRole = pctx.assumedRole || '';
-        parentCtx.authenticatedRoles = pctx.authenticatedRoles || [];
-        parentCtx.workflowUUID = wfId || '';
-      }
-
-      const wfParams: InternalWorkflowParams = {
-        workflowUUID: wfId,
-        queueName: pctx?.queueAssignedForWorkflows,
-        configuredInstance: inst,
-        parentCtx,
-        timeoutMS: pctx?.workflowTimeoutMS,
-      };
-
-      const handle = await DBOS.#executor.workflow(
-        registration.registeredFunction as unknown as WorkflowFunction<Args, Return>,
-        wfParams,
-        ...rawArgs,
-      );
+      const func = registration.registeredFunction as unknown as WorkflowFunction<Args, Return>;
+      const handle = await DBOS.#runDatWorkflow(this, func, rawArgs);
       return await handle.getResult();
     };
     registerFunctionWrapper(invokeWrapper, registration as MethodRegistration<unknown, unknown[], unknown>);

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1264,11 +1264,8 @@ export class DBOS {
    */
   static startWorkflow<T extends object>(targetClass: T, params?: StartWorkflowParams): InvokeFunctionsAsync<T>;
   static startWorkflow<T extends object>(target: T, params?: StartWorkflowParams): InvokeFunctionsAsync<T> {
-    if (typeof target === 'function') {
-      return DBOS.#proxyInvokeWF(target, null, params) as unknown as InvokeFunctionsAsync<T>;
-    } else {
-      return DBOS.#proxyInvokeWF(target, target as ConfiguredInstance, params) as unknown as InvokeFunctionsAsync<T>;
-    }
+    const instance = typeof target === 'function' ? null : (target as ConfiguredInstance);
+    return DBOS.#proxyInvokeWF(target, instance, params) as unknown as InvokeFunctionsAsync<T>;
   }
 
   /**

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1289,136 +1289,19 @@ export class DBOS {
     return DBOS.#createStartWorkflowProxy(target, instance, params) as unknown as InvokeFunctionsAsync<T>;
   }
 
-  static #createStartWorkflowProxyMethod(
-    op: MethodRegistrationBase,
-    configuredInstance: ConfiguredInstance | null,
-    inParams?: StartWorkflowParams,
-  ) {
-    return (...args: unknown[]) => {
-      let wfId = getNextWFID(inParams?.workflowID);
-      const pctx = getCurrentContextStore();
-
-      // If this is called from within a workflow, this is a child workflow,
-      //  For OAOO, we will need a consistent ID formed from the parent WF and call number
-      if (DBOS.isWithinWorkflow()) {
-        if (!DBOS.isInWorkflow()) {
-          throw new DBOSInvalidWorkflowTransitionError(
-            'Invalid call to `DBOS.startWorkflow` from within a `step` or `transaction`',
-          );
-        }
-
-        const wfctx = assertCurrentWorkflowContext();
-
-        const funcId = wfctx.functionIDGetIncrement();
-        wfId = wfId || wfctx.workflowUUID + '-' + funcId;
-        const wfParams: WorkflowParams = {
-          workflowUUID: wfId,
-          parentCtx: wfctx,
-          configuredInstance,
-          queueName: inParams?.queueName ?? pctx?.queueAssignedForWorkflows,
-          timeoutMS: inParams?.timeoutMS ?? pctx?.workflowTimeoutMS,
-          deadlineEpochMS: wfctx.deadlineEpochMS,
-          enqueueOptions: inParams?.enqueueOptions,
-        };
-        // Detach child deadline if a null timeout is configured
-        // We must check the inParams but also pctx (if the workflow was called withWorkflowTimeout)
-        if (inParams?.timeoutMS === null || pctx?.workflowTimeoutMS === null) {
-          wfParams.deadlineEpochMS = undefined;
-        }
-
-        if (op.workflowConfig) {
-          return DBOSExecutor.globalInstance!.internalWorkflow(
-            op.registeredFunction as WorkflowFunction<unknown[], unknown>,
-            wfParams,
-            wfctx.workflowUUID,
-            funcId,
-            ...args,
-          );
-        } else if (op.txnConfig) {
-          const txn = op.registeredFunction as TransactionFunction<unknown[], unknown>;
-          return DBOSExecutor.globalInstance!.startTransactionTempWF(
-            txn,
-            wfParams,
-            wfctx.workflowUUID,
-            funcId,
-            ...args,
-          );
-        } else if (op.stepConfig) {
-          const step = op.registeredFunction as StepFunction<unknown[], unknown>;
-          return DBOSExecutor.globalInstance!.startStepTempWF(step, wfParams, wfctx.workflowUUID, funcId, ...args);
-        } else {
-          throw new DBOSNotRegisteredError(
-            op.name,
-            `${op.name} is not a registered DBOS workflow, step, or transaction function`,
-          );
-        }
-      }
-
-      // Else, we setup a parent context that includes all the potential metadata the application could have set in DBOSLocalCtx
-      let parentCtx: DBOSContextImpl | undefined = undefined;
-      if (pctx) {
-        // If pctx has no span, e.g., has not been setup through `withTracedContext`, set up a parent span for the workflow here.
-        let span = pctx.span;
-        if (!span) {
-          span = DBOS.#executor.tracer.startSpan(pctx.operationCaller || 'startWorkflow', {
-            operationUUID: wfId,
-            operationType: pctx.operationType,
-            authenticatedUser: pctx.authenticatedUser,
-            assumedRole: pctx.assumedRole,
-            authenticatedRoles: pctx.authenticatedRoles,
-          });
-        }
-        parentCtx = new DBOSContextImpl(pctx.operationCaller || 'startWorkflow', span, DBOS.logger as GlobalLogger);
-        parentCtx.request = pctx.request || {};
-        parentCtx.authenticatedUser = pctx.authenticatedUser || '';
-        parentCtx.assumedRole = pctx.assumedRole || '';
-        parentCtx.authenticatedRoles = pctx.authenticatedRoles || [];
-        parentCtx.workflowUUID = wfId || '';
-      }
-
-      const wfParams: InternalWorkflowParams = {
-        workflowUUID: wfId,
-        queueName: inParams?.queueName ?? pctx?.queueAssignedForWorkflows,
-        enqueueOptions: inParams?.enqueueOptions,
-        configuredInstance,
-        parentCtx,
-        timeoutMS: inParams?.timeoutMS ?? pctx?.workflowTimeoutMS,
-      };
-
-      if (op.workflowConfig) {
-        return DBOS.#executor.workflow(
-          op.registeredFunction as WorkflowFunction<unknown[], unknown>,
-          wfParams,
-          ...args,
-        );
-      } else if (op.txnConfig) {
-        const txn = op.registeredFunction as TransactionFunction<unknown[], unknown>;
-        return DBOSExecutor.globalInstance!.startTransactionTempWF(txn, wfParams, undefined, undefined, ...args);
-      } else if (op.stepConfig) {
-        const step = op.registeredFunction as StepFunction<unknown[], unknown>;
-        return DBOSExecutor.globalInstance!.startStepTempWF(step, wfParams, undefined, undefined, ...args);
-      } else {
-        throw new DBOSNotRegisteredError(
-          op.name,
-          `${op.name} is not a registered DBOS workflow, step, or transaction function`,
-        );
-      }
-    };
-  }
-
   static #createStartWorkflowProxy<T extends object>(
     object: T,
-    configuredInstance: ConfiguredInstance | null,
-    inParams?: StartWorkflowParams,
+    instance: ConfiguredInstance | null,
+    params?: StartWorkflowParams,
   ): InvokeFunctionsAsync<T> {
     const ops = getRegisteredOperations(object);
     const proxy: Record<string, unknown> = {};
 
     for (const op of ops) {
-      proxy[op.name] = DBOS.#createStartWorkflowProxyMethod(op, configuredInstance, inParams);
+      proxy[op.name] = (...args: unknown[]) => DBOS.#runDatWorkflow(instance, op, args, params);
     }
 
-    augmentProxy(configuredInstance ?? object, proxy);
+    augmentProxy(instance ?? object, proxy);
 
     return proxy as InvokeFunctionsAsync<T>;
   }

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1844,7 +1844,7 @@ export class DBOS {
         deadlineEpochMS: pctx?.workflowTimeoutMS === null ? undefined : wfctx.deadlineEpochMS,
       };
 
-      return await invokeOp(params, wfId, funcId);
+      return await invokeOp(params, wfctx.workflowUUID, funcId);
     } else {
       // Else, we setup a parent context that includes all the potential metadata the application could have set in DBOSLocalCtx
       let parentCtx: DBOSContextImpl | undefined = undefined;

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1253,8 +1253,12 @@ export class DBOS {
     func: (this: This, ...args: Args) => Promise<Return>,
     ...args: Args
   ): Promise<WorkflowHandle<Return>> {
-    const wfFunc = func as unknown as WorkflowFunction<Args, Return>;
-    return DBOS.#runDatWorkflow(params?.instance, wfFunc, args, params ?? {});
+    const op = getRegistrationForFunction(func);
+    if (!op) {
+      throw new DBOSNotRegisteredError(func.name, `${func.name} is not a registered DBOS workflow function`);
+    }
+    const wfFunc = op.registeredFunction as WorkflowFunction<Args, Return>;
+    return await DBOS.#runDatWorkflow(params?.instance, wfFunc, args, params ?? {});
   }
 
   /**

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1241,34 +1241,6 @@ export class DBOS {
   }
 
   /**
-   * Start a workflow in the background, returning a handle that can be used to check status, await a result,
-   *   or otherwise interact with the workflow.
-   * The full syntax is:
-   * `handle = await DBOS.startWorkflow(<target object>, <params>).<target method>(<args>);`
-   * @param target - Object (which must be a `ConfiguredInstance`) containing the instance method to invoke
-   * @param params - `StartWorkflowParams` which may specify the ID, queue, or other parameters for starting the workflow
-   * @returns - `WorkflowHandle` which can be used to interact with the workflow
-   */
-  static startWorkflow<T extends ConfiguredInstance>(
-    target: T,
-    params?: StartWorkflowParams,
-  ): InvokeFunctionsAsyncInst<T>;
-  /**
-   * Start a workflow in the background, returning a handle that can be used to check status, await a result,
-   *   or otherwise interact with the workflow.
-   * The full syntax is:
-   * `handle = await DBOS.startWorkflow(<target class>, <params>).<target method>(<args>);`
-   * @param target - Class containing the static method to invoke
-   * @param params - `StartWorkflowParams` which may specify the ID, queue, or other parameters for starting the workflow
-   * @returns - `WorkflowHandle` which can be used to interact with the workflow
-   */
-  static startWorkflow<T extends object>(targetClass: T, params?: StartWorkflowParams): InvokeFunctionsAsync<T>;
-  static startWorkflow<T extends object>(target: T, params?: StartWorkflowParams): InvokeFunctionsAsync<T> {
-    const instance = typeof target === 'function' ? null : (target as ConfiguredInstance);
-    return DBOS.#proxyInvokeWF(target, instance, params) as unknown as InvokeFunctionsAsync<T>;
-  }
-
-  /**
    * Start a workflow in the background, returning a handle that can be used to check status,
    *   await the result, or otherwise interact with the workflow.
    * @param func - The function to start.  If a class or instance method, supply `this` within `params`.
@@ -1370,7 +1342,35 @@ export class DBOS {
     )) as WorkflowHandle<Return>;
   }
 
-  static #proxyInvokeWF<T extends object>(
+  /**
+   * Start a workflow in the background, returning a handle that can be used to check status, await a result,
+   *   or otherwise interact with the workflow.
+   * The full syntax is:
+   * `handle = await DBOS.startWorkflow(<target object>, <params>).<target method>(<args>);`
+   * @param target - Object (which must be a `ConfiguredInstance`) containing the instance method to invoke
+   * @param params - `StartWorkflowParams` which may specify the ID, queue, or other parameters for starting the workflow
+   * @returns - `WorkflowHandle` which can be used to interact with the workflow
+   */
+  static startWorkflow<T extends ConfiguredInstance>(
+    target: T,
+    params?: StartWorkflowParams,
+  ): InvokeFunctionsAsyncInst<T>;
+  /**
+   * Start a workflow in the background, returning a handle that can be used to check status, await a result,
+   *   or otherwise interact with the workflow.
+   * The full syntax is:
+   * `handle = await DBOS.startWorkflow(<target class>, <params>).<target method>(<args>);`
+   * @param target - Class containing the static method to invoke
+   * @param params - `StartWorkflowParams` which may specify the ID, queue, or other parameters for starting the workflow
+   * @returns - `WorkflowHandle` which can be used to interact with the workflow
+   */
+  static startWorkflow<T extends object>(targetClass: T, params?: StartWorkflowParams): InvokeFunctionsAsync<T>;
+  static startWorkflow<T extends object>(target: T, params?: StartWorkflowParams): InvokeFunctionsAsync<T> {
+    const instance = typeof target === 'function' ? null : (target as ConfiguredInstance);
+    return DBOS.#createStartWorkflowProxy(target, instance, params) as unknown as InvokeFunctionsAsync<T>;
+  }
+
+  static #createStartWorkflowProxy<T extends object>(
     object: T,
     configuredInstance: ConfiguredInstance | null,
     inParams?: StartWorkflowParams,

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -2071,8 +2071,8 @@ export class DBOS {
   }
 
   /**
-   * Create a checkpointed DBOS step function from  a provided function
-   *   Simlar to the DBOS.step decorator, but without requiring a decorator
+   * Create a check pointed DBOS step function from  a provided function
+   *   Similar to the DBOS.step decorator, but without requiring a decorator
    *   A durable checkpoint will be made after the step completes
    *   This ensures "at least once" execution of the step, and that the step will not
    *    be executed again once the checkpoint is recorded

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1289,19 +1289,136 @@ export class DBOS {
     return DBOS.#createStartWorkflowProxy(target, instance, params) as unknown as InvokeFunctionsAsync<T>;
   }
 
+  static #createStartWorkflowProxyMethod(
+    op: MethodRegistrationBase,
+    configuredInstance: ConfiguredInstance | null,
+    inParams?: StartWorkflowParams,
+  ) {
+    return (...args: unknown[]) => {
+      let wfId = getNextWFID(inParams?.workflowID);
+      const pctx = getCurrentContextStore();
+
+      // If this is called from within a workflow, this is a child workflow,
+      //  For OAOO, we will need a consistent ID formed from the parent WF and call number
+      if (DBOS.isWithinWorkflow()) {
+        if (!DBOS.isInWorkflow()) {
+          throw new DBOSInvalidWorkflowTransitionError(
+            'Invalid call to `DBOS.startWorkflow` from within a `step` or `transaction`',
+          );
+        }
+
+        const wfctx = assertCurrentWorkflowContext();
+
+        const funcId = wfctx.functionIDGetIncrement();
+        wfId = wfId || wfctx.workflowUUID + '-' + funcId;
+        const wfParams: WorkflowParams = {
+          workflowUUID: wfId,
+          parentCtx: wfctx,
+          configuredInstance,
+          queueName: inParams?.queueName ?? pctx?.queueAssignedForWorkflows,
+          timeoutMS: inParams?.timeoutMS ?? pctx?.workflowTimeoutMS,
+          deadlineEpochMS: wfctx.deadlineEpochMS,
+          enqueueOptions: inParams?.enqueueOptions,
+        };
+        // Detach child deadline if a null timeout is configured
+        // We must check the inParams but also pctx (if the workflow was called withWorkflowTimeout)
+        if (inParams?.timeoutMS === null || pctx?.workflowTimeoutMS === null) {
+          wfParams.deadlineEpochMS = undefined;
+        }
+
+        if (op.workflowConfig) {
+          return DBOSExecutor.globalInstance!.internalWorkflow(
+            op.registeredFunction as WorkflowFunction<unknown[], unknown>,
+            wfParams,
+            wfctx.workflowUUID,
+            funcId,
+            ...args,
+          );
+        } else if (op.txnConfig) {
+          const txn = op.registeredFunction as TransactionFunction<unknown[], unknown>;
+          return DBOSExecutor.globalInstance!.startTransactionTempWF(
+            txn,
+            wfParams,
+            wfctx.workflowUUID,
+            funcId,
+            ...args,
+          );
+        } else if (op.stepConfig) {
+          const step = op.registeredFunction as StepFunction<unknown[], unknown>;
+          return DBOSExecutor.globalInstance!.startStepTempWF(step, wfParams, wfctx.workflowUUID, funcId, ...args);
+        } else {
+          throw new DBOSNotRegisteredError(
+            op.name,
+            `${op.name} is not a registered DBOS workflow, step, or transaction function`,
+          );
+        }
+      }
+
+      // Else, we setup a parent context that includes all the potential metadata the application could have set in DBOSLocalCtx
+      let parentCtx: DBOSContextImpl | undefined = undefined;
+      if (pctx) {
+        // If pctx has no span, e.g., has not been setup through `withTracedContext`, set up a parent span for the workflow here.
+        let span = pctx.span;
+        if (!span) {
+          span = DBOS.#executor.tracer.startSpan(pctx.operationCaller || 'startWorkflow', {
+            operationUUID: wfId,
+            operationType: pctx.operationType,
+            authenticatedUser: pctx.authenticatedUser,
+            assumedRole: pctx.assumedRole,
+            authenticatedRoles: pctx.authenticatedRoles,
+          });
+        }
+        parentCtx = new DBOSContextImpl(pctx.operationCaller || 'startWorkflow', span, DBOS.logger as GlobalLogger);
+        parentCtx.request = pctx.request || {};
+        parentCtx.authenticatedUser = pctx.authenticatedUser || '';
+        parentCtx.assumedRole = pctx.assumedRole || '';
+        parentCtx.authenticatedRoles = pctx.authenticatedRoles || [];
+        parentCtx.workflowUUID = wfId || '';
+      }
+
+      const wfParams: InternalWorkflowParams = {
+        workflowUUID: wfId,
+        queueName: inParams?.queueName ?? pctx?.queueAssignedForWorkflows,
+        enqueueOptions: inParams?.enqueueOptions,
+        configuredInstance,
+        parentCtx,
+        timeoutMS: inParams?.timeoutMS ?? pctx?.workflowTimeoutMS,
+      };
+
+      if (op.workflowConfig) {
+        return DBOS.#executor.workflow(
+          op.registeredFunction as WorkflowFunction<unknown[], unknown>,
+          wfParams,
+          ...args,
+        );
+      } else if (op.txnConfig) {
+        const txn = op.registeredFunction as TransactionFunction<unknown[], unknown>;
+        return DBOSExecutor.globalInstance!.startTransactionTempWF(txn, wfParams, undefined, undefined, ...args);
+      } else if (op.stepConfig) {
+        const step = op.registeredFunction as StepFunction<unknown[], unknown>;
+        return DBOSExecutor.globalInstance!.startStepTempWF(step, wfParams, undefined, undefined, ...args);
+      } else {
+        throw new DBOSNotRegisteredError(
+          op.name,
+          `${op.name} is not a registered DBOS workflow, step, or transaction function`,
+        );
+      }
+    };
+  }
+
   static #createStartWorkflowProxy<T extends object>(
     object: T,
-    instance: ConfiguredInstance | null,
-    params?: StartWorkflowParams,
+    configuredInstance: ConfiguredInstance | null,
+    inParams?: StartWorkflowParams,
   ): InvokeFunctionsAsync<T> {
     const ops = getRegisteredOperations(object);
     const proxy: Record<string, unknown> = {};
 
     for (const op of ops) {
-      proxy[op.name] = (...args: unknown[]) => DBOS.#runDatWorkflow(instance, op, args, params);
+      proxy[op.name] = DBOS.#createStartWorkflowProxyMethod(op, configuredInstance, inParams);
     }
 
-    augmentProxy(instance ?? object, proxy);
+    augmentProxy(configuredInstance ?? object, proxy);
 
     return proxy as InvokeFunctionsAsync<T>;
   }

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1657,7 +1657,6 @@ export class DBOS {
     return DBOS.#getWorkflowInvoker(registration, options.config);
   }
 
-  // TODO: better method name
   static async #invokeWorkflow<This, Args extends unknown[], Return>(
     $this: This,
     regOP: MethodRegistrationBase,

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -52,6 +52,7 @@ import {
   DBOS_AUTH,
   getLifecycleListeners,
   getRegisteredOperations,
+  getRegistrationForFunction,
   getRegistrationsForExternal,
   insertAllMiddleware,
   MethodAuth,
@@ -227,6 +228,10 @@ export interface StartWorkflowParams {
   queueName?: string;
   timeoutMS?: number | null;
   enqueueOptions?: EnqueueOptions;
+}
+
+export interface StartWorkflowFunctionParams<T> extends StartWorkflowParams {
+  instance?: T;
 }
 
 export function getExecutor() {
@@ -1256,6 +1261,108 @@ export class DBOS {
     } else {
       return DBOS.#proxyInvokeWF(target, target as ConfiguredInstance, params) as unknown as InvokeFunctionsAsync<T>;
     }
+  }
+
+  /**
+   * Start a workflow in the background, returning a handle that can be used to check status,
+   *   await the result, or otherwise interact with the workflow.
+   * @param func - The function to start.  If a class or instance method, supply `this` within `params`.
+   * @param params - `StartWorkflowFunctionParams` which may specify the ID, queue, `this`, or other parameters
+   * @param args - Arguments passed to `func`
+   * @returns `WorkflowHandle` which can be used to interact with the started workflow
+   */
+  static async startWorkflowFunction<This, Args extends unknown[], Return>(
+    params: StartWorkflowFunctionParams<This> | undefined,
+    func: (this: This, ...args: Args) => Promise<Return>,
+    ...args: Args
+  ): Promise<WorkflowHandle<Return>> {
+    let wfId = getNextWFID(params?.workflowID);
+    const pctx = getCurrentContextStore();
+
+    const target = params?.instance;
+    let configuredInstance: ConfiguredInstance | undefined = undefined;
+    if (target) {
+      if (typeof target === 'function') {
+        // This is static
+      } else {
+        configuredInstance = target as unknown as ConfiguredInstance;
+        if (!('name' in configuredInstance)) {
+          throw new DBOSInvalidWorkflowTransitionError(
+            'Attempt to call a `workflow` function on an object that is not a `ConfiguredInstance`',
+          );
+        }
+      }
+    }
+    DBOS.logger.warn(`Configured instance is set to ${configuredInstance?.name}`);
+
+    const op = getRegistrationForFunction(func);
+    if (!op) {
+      throw new DBOSNotRegisteredError(func.name, `${func.name} is not a registered DBOS workflow function`);
+    }
+
+    // If this is called from within a workflow, this is a child workflow,
+    //  For OAOO, we will need a consistent ID formed from the parent WF and call number
+    if (DBOS.isWithinWorkflow()) {
+      if (!DBOS.isInWorkflow()) {
+        throw new DBOSInvalidWorkflowTransitionError(
+          'Invalid call to `DBOS.startWorkflow` from within a `step` or `transaction`',
+        );
+      }
+
+      const wfctx = assertCurrentWorkflowContext();
+
+      const funcId = wfctx.functionIDGetIncrement();
+      wfId = wfId || wfctx.workflowUUID + '-' + funcId;
+      const wfParams: WorkflowParams = {
+        workflowUUID: wfId,
+        parentCtx: wfctx,
+        configuredInstance,
+        queueName: params?.queueName ?? pctx?.queueAssignedForWorkflows,
+      };
+
+      return (await DBOSExecutor.globalInstance!.internalWorkflow(
+        op.registeredFunction as WorkflowFunction<unknown[], unknown>,
+        wfParams,
+        wfctx.workflowUUID,
+        funcId,
+        ...args,
+      )) as WorkflowHandle<Return>;
+    }
+
+    // Else, we setup a parent context that includes all the potential metadata the application could have set in DBOSLocalCtx
+    let parentCtx: DBOSContextImpl | undefined = undefined;
+    if (pctx) {
+      // If pctx has no span, e.g., has not been setup through `withTracedContext`, set up a parent span for the workflow here.
+      let span = pctx.span;
+      if (!span) {
+        span = DBOS.#executor.tracer.startSpan(pctx.operationCaller || 'startWorkflow', {
+          operationUUID: wfId,
+          operationType: pctx.operationType,
+          authenticatedUser: pctx.authenticatedUser,
+          assumedRole: pctx.assumedRole,
+          authenticatedRoles: pctx.authenticatedRoles,
+        });
+      }
+      parentCtx = new DBOSContextImpl(pctx.operationCaller || 'startWorkflow', span, DBOS.logger as GlobalLogger);
+      parentCtx.request = pctx.request || {};
+      parentCtx.authenticatedUser = pctx.authenticatedUser || '';
+      parentCtx.assumedRole = pctx.assumedRole || '';
+      parentCtx.authenticatedRoles = pctx.authenticatedRoles || [];
+      parentCtx.workflowUUID = wfId || '';
+    }
+
+    const wfParams: InternalWorkflowParams = {
+      workflowUUID: wfId,
+      queueName: params?.queueName ?? pctx?.queueAssignedForWorkflows,
+      configuredInstance,
+      parentCtx,
+    };
+
+    return (await DBOS.#executor.workflow(
+      op.registeredFunction as WorkflowFunction<unknown[], unknown>,
+      wfParams,
+      ...args,
+    )) as WorkflowHandle<Return>;
   }
 
   static #proxyInvokeWF<T extends object>(

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -65,7 +65,6 @@ import {
   registerLifecycleCallback,
   transactionalDataSources,
   registerMiddlewareInstaller,
-  MethodRegistrationBase,
 } from './decorators';
 import { globalParams, sleepms } from './utils';
 import { DBOSHttpServer } from './httpServer/server';
@@ -265,13 +264,6 @@ export function runInternalStep<T>(callback: () => Promise<T>, funcName: string,
   }
   return callback();
 }
-
-type DatWorkflowFunction<Args extends unknown[], Return> = (
-  params: InternalWorkflowParams,
-  workflowID: string | undefined,
-  funcNum: number | undefined,
-  args: Args,
-) => Promise<WorkflowHandle<Return>>;
 
 export class DBOS {
   ///////
@@ -1265,8 +1257,8 @@ export class DBOS {
     if (!op) {
       throw new DBOSNotRegisteredError(func.name, `${func.name} is not a registered DBOS workflow function`);
     }
-    const datFunc = DBOS.#getDatWorkflowFunction<Args, Return>(op);
-    return await DBOS.#runDatWorkflow(params?.instance, datFunc, args, params ?? {});
+    const wfFunc = op.registeredFunction as WorkflowFunction<Args, Return>;
+    return await DBOS.#runDatWorkflow(params?.instance, wfFunc, args, params ?? {});
   }
 
   /**
@@ -1294,43 +1286,138 @@ export class DBOS {
   static startWorkflow<T extends object>(targetClass: T, params?: StartWorkflowParams): InvokeFunctionsAsync<T>;
   static startWorkflow<T extends object>(target: T, params?: StartWorkflowParams): InvokeFunctionsAsync<T> {
     const instance = typeof target === 'function' ? null : (target as ConfiguredInstance);
-    const ops = getRegisteredOperations(target);
-    const proxy: Record<string, unknown> = {};
-
-    for (const op of ops) {
-      const datFunc = DBOS.#getDatWorkflowFunction<unknown[], unknown>(op);
-      proxy[op.name] = (...args: unknown[]) => DBOS.#runDatWorkflow(instance, datFunc, args, params);
-    }
-
-    augmentProxy(instance ?? target, proxy);
-
-    return proxy as InvokeFunctionsAsync<T>;
+    return DBOS.#createStartWorkflowProxy(target, instance, params) as unknown as InvokeFunctionsAsync<T>;
   }
 
-  static #getDatWorkflowFunction<Args extends unknown[], Return>(
-    op: MethodRegistrationBase,
-  ): DatWorkflowFunction<Args, Return> {
-    if (op.workflowConfig) {
-      const func = op.registeredFunction as WorkflowFunction<Args, Return>;
-      return (params, workflowID, funcNum, args) =>
-        DBOSExecutor.globalInstance!.internalWorkflow<Args, Return>(func, params, workflowID, funcNum, ...args);
+  static #createStartWorkflowProxy<T extends object>(
+    object: T,
+    configuredInstance: ConfiguredInstance | null,
+    inParams?: StartWorkflowParams,
+  ): InvokeFunctionsAsync<T> {
+    const ops = getRegisteredOperations(object);
+    const proxy: Record<string, unknown> = {};
+
+    let wfId = getNextWFID(inParams?.workflowID);
+    const pctx = getCurrentContextStore();
+
+    // If this is called from within a workflow, this is a child workflow,
+    //  For OAOO, we will need a consistent ID formed from the parent WF and call number
+    if (DBOS.isWithinWorkflow()) {
+      if (!DBOS.isInWorkflow()) {
+        throw new DBOSInvalidWorkflowTransitionError(
+          'Invalid call to `DBOS.startWorkflow` from within a `step` or `transaction`',
+        );
+      }
+
+      const wfctx = assertCurrentWorkflowContext();
+
+      const funcId = wfctx.functionIDGetIncrement();
+      wfId = wfId || wfctx.workflowUUID + '-' + funcId;
+      const wfParams: WorkflowParams = {
+        workflowUUID: wfId,
+        parentCtx: wfctx,
+        configuredInstance,
+        queueName: inParams?.queueName ?? pctx?.queueAssignedForWorkflows,
+        timeoutMS: inParams?.timeoutMS ?? pctx?.workflowTimeoutMS,
+        deadlineEpochMS: wfctx.deadlineEpochMS,
+        enqueueOptions: inParams?.enqueueOptions,
+      };
+      // Detach child deadline if a null timeout is configured
+      // We must check the inParams but also pctx (if the workflow was called withWorkflowTimeout)
+      if (inParams?.timeoutMS === null || pctx?.workflowTimeoutMS === null) {
+        wfParams.deadlineEpochMS = undefined;
+      }
+
+      for (const op of ops) {
+        if (op.workflowConfig) {
+          proxy[op.name] = (...args: unknown[]) =>
+            DBOSExecutor.globalInstance!.internalWorkflow(
+              op.registeredFunction as WorkflowFunction<unknown[], unknown>,
+              wfParams,
+              wfctx.workflowUUID,
+              funcId,
+              ...args,
+            );
+        } else if (op.txnConfig) {
+          const txn = op.registeredFunction as TransactionFunction<unknown[], unknown>;
+          proxy[op.name] = (...args: unknown[]) =>
+            DBOSExecutor.globalInstance!.startTransactionTempWF(txn, wfParams, wfctx.workflowUUID, funcId, ...args);
+        } else if (op.stepConfig) {
+          const step = op.registeredFunction as StepFunction<unknown[], unknown>;
+          proxy[op.name] = (...args: unknown[]) => {
+            return DBOSExecutor.globalInstance!.startStepTempWF(step, wfParams, wfctx.workflowUUID, funcId, ...args);
+          };
+        } else {
+          proxy[op.name] = (..._args: unknown[]) => {
+            throw new DBOSNotRegisteredError(
+              op.name,
+              `${op.name} is not a registered DBOS workflow, step, or transaction function`,
+            );
+          };
+        }
+      }
+
+      augmentProxy(configuredInstance ?? object, proxy);
+
+      return proxy as InvokeFunctionsAsync<T>;
     }
-    if (op.txnConfig) {
-      const func = op.registeredFunction as TransactionFunction<Args, Return>;
-      return (params, workflowID, funcNum, args) =>
-        DBOSExecutor.globalInstance!.startTransactionTempWF<Args, Return>(func, params, workflowID, funcNum, ...args);
+
+    // Else, we setup a parent context that includes all the potential metadata the application could have set in DBOSLocalCtx
+    let parentCtx: DBOSContextImpl | undefined = undefined;
+    if (pctx) {
+      // If pctx has no span, e.g., has not been setup through `withTracedContext`, set up a parent span for the workflow here.
+      let span = pctx.span;
+      if (!span) {
+        span = DBOS.#executor.tracer.startSpan(pctx.operationCaller || 'startWorkflow', {
+          operationUUID: wfId,
+          operationType: pctx.operationType,
+          authenticatedUser: pctx.authenticatedUser,
+          assumedRole: pctx.assumedRole,
+          authenticatedRoles: pctx.authenticatedRoles,
+        });
+      }
+      parentCtx = new DBOSContextImpl(pctx.operationCaller || 'startWorkflow', span, DBOS.logger as GlobalLogger);
+      parentCtx.request = pctx.request || {};
+      parentCtx.authenticatedUser = pctx.authenticatedUser || '';
+      parentCtx.assumedRole = pctx.assumedRole || '';
+      parentCtx.authenticatedRoles = pctx.authenticatedRoles || [];
+      parentCtx.workflowUUID = wfId || '';
     }
-    if (op.stepConfig) {
-      const func = op.registeredFunction as StepFunction<Args, Return>;
-      return (params, workflowID, funcNum, args) =>
-        DBOSExecutor.globalInstance!.startStepTempWF<Args, Return>(func, params, workflowID, funcNum, ...args);
-    }
-    return (_p, _w, _f, _a) => {
-      throw new DBOSNotRegisteredError(
-        op.name,
-        `${op.name} is not a registered DBOS workflow, step, or transaction function`,
-      );
+
+    const wfParams: InternalWorkflowParams = {
+      workflowUUID: wfId,
+      queueName: inParams?.queueName ?? pctx?.queueAssignedForWorkflows,
+      enqueueOptions: inParams?.enqueueOptions,
+      configuredInstance,
+      parentCtx,
+      timeoutMS: inParams?.timeoutMS ?? pctx?.workflowTimeoutMS,
     };
+
+    for (const op of ops) {
+      if (op.workflowConfig) {
+        proxy[op.name] = (...args: unknown[]) =>
+          DBOS.#executor.workflow(op.registeredFunction as WorkflowFunction<unknown[], unknown>, wfParams, ...args);
+      } else if (op.txnConfig) {
+        const txn = op.registeredFunction as TransactionFunction<unknown[], unknown>;
+        proxy[op.name] = (...args: unknown[]) =>
+          DBOSExecutor.globalInstance!.startTransactionTempWF(txn, wfParams, undefined, undefined, ...args);
+      } else if (op.stepConfig) {
+        const step = op.registeredFunction as StepFunction<unknown[], unknown>;
+        proxy[op.name] = (...args: unknown[]) =>
+          DBOSExecutor.globalInstance!.startStepTempWF(step, wfParams, undefined, undefined, ...args);
+      } else {
+        proxy[op.name] = (..._args: unknown[]) => {
+          throw new DBOSNotRegisteredError(
+            op.name,
+            `${op.name} is not a registered DBOS workflow, step, or transaction function`,
+          );
+        };
+      }
+    }
+
+    augmentProxy(configuredInstance ?? object, proxy);
+
+    return proxy as InvokeFunctionsAsync<T>;
   }
 
   /** @deprecated Adjust target function to exclude its `DBOSContext` argument, and then call the function directly */
@@ -1694,7 +1781,7 @@ export class DBOS {
   // TODO: better method name
   static async #runDatWorkflow<This, Args extends unknown[], Return>(
     $this: This,
-    func: DatWorkflowFunction<Args, Return>,
+    func: WorkflowFunction<Args, Return>,
     args: Args,
     params: StartWorkflowParams = {},
   ): Promise<WorkflowHandle<Return>> {
@@ -1734,7 +1821,7 @@ export class DBOS {
         deadlineEpochMS: pctx?.workflowTimeoutMS === null ? undefined : wfctx.deadlineEpochMS,
       };
 
-      return await func(params, wfctx.workflowUUID, funcId, args);
+      return await DBOSExecutor.globalInstance!.internalWorkflow(func, params, wfctx.workflowUUID, funcId, ...args);
     } else {
       // Else, we setup a parent context that includes all the potential metadata the application could have set in DBOSLocalCtx
       let parentCtx: DBOSContextImpl | undefined = undefined;
@@ -1766,7 +1853,7 @@ export class DBOS {
         timeoutMS: pctx?.workflowTimeoutMS,
       };
 
-      return await func(params, undefined, undefined, args);
+      return await DBOS.#executor.workflow(func, params, ...args);
     }
   }
 
@@ -1775,9 +1862,9 @@ export class DBOS {
     config: WorkflowConfig | undefined,
   ): (this: This, ...args: Args) => Promise<Return> {
     registration.setWorkflowConfig(config ?? {});
-    const datFunc = DBOS.#getDatWorkflowFunction<Args, Return>(registration);
     const invokeWrapper = async function (this: This, ...rawArgs: Args): Promise<Return> {
-      const handle = await DBOS.#runDatWorkflow(this, datFunc, rawArgs);
+      const func = registration.registeredFunction as unknown as WorkflowFunction<Args, Return>;
+      const handle = await DBOS.#runDatWorkflow(this, func, rawArgs);
       return await handle.getResult();
     };
     registerFunctionWrapper(invokeWrapper, registration as MethodRegistration<unknown, unknown[], unknown>);

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -2100,7 +2100,8 @@ export class DBOS {
   /**
    * Run the enclosed `callback` as a checkpointed step within a DBOS workflow
    * @param callback - function containing code to run
-   * @param name - Name of step to record, this will be used in traces and introspection
+   * @param config - Configuration information for the step, particularly the retry policy
+   * @param config.name - The name of the step; if not provided, the function name will be used
    * @returns - result (either obtained from invoking function, or retrieved if run before)
    */
   static runStep<Return>(func: () => Promise<Return>, config: StepConfig & { name?: string } = {}): Promise<Return> {

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1286,6 +1286,11 @@ export class DBOS {
   static startWorkflow<T extends object>(targetClass: T, params?: StartWorkflowParams): InvokeFunctionsAsync<T>;
   static startWorkflow<T extends object>(target: T, params?: StartWorkflowParams): InvokeFunctionsAsync<T> {
     const instance = typeof target === 'function' ? null : (target as ConfiguredInstance);
+    if (instance && !(instance instanceof ConfiguredInstance)) {
+      throw new DBOSInvalidWorkflowTransitionError(
+        'Attempt to call `startWorkflow` on an object that is not a `ConfiguredInstance`',
+      );
+    }
 
     const regOps = getRegisteredOperations(target);
     const proxy: Record<string, unknown> = {};
@@ -1669,14 +1674,10 @@ export class DBOS {
     const timeoutMS = params.timeoutMS ?? pctx?.workflowTimeoutMS;
 
     const instance = $this === undefined || typeof $this === 'function' ? undefined : ($this as ConfiguredInstance);
-    if (instance) {
-      if ('name' in instance) {
-        DBOS.logger.warn(`Configured instance is set to ${instance.name}`);
-      } else {
-        throw new DBOSInvalidWorkflowTransitionError(
-          'Attempt to call a `workflow` function on an object that is not a `ConfiguredInstance`',
-        );
-      }
+    if (instance && !(instance instanceof ConfiguredInstance)) {
+      throw new DBOSInvalidWorkflowTransitionError(
+        'Attempt to call a `workflow` function on an object that is not a `ConfiguredInstance`',
+      );
     }
 
     // If this is called from within a workflow, this is a child workflow,
@@ -1796,7 +1797,7 @@ export class DBOS {
           // This is static
         } else {
           inst = this as ConfiguredInstance;
-          if (!('name' in inst)) {
+          if (!(inst instanceof ConfiguredInstance)) {
             throw new DBOSInvalidWorkflowTransitionError(
               'Attempt to call a `transaction` function on an object that is not a `ConfiguredInstance`',
             );
@@ -1975,7 +1976,7 @@ export class DBOS {
           // This is static
         } else {
           inst = this as ConfiguredInstance;
-          if (!('name' in inst)) {
+          if (!(inst instanceof ConfiguredInstance)) {
             throw new DBOSInvalidWorkflowTransitionError(
               'Attempt to call a `step` function on an object that is not a `ConfiguredInstance`',
             );

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1290,7 +1290,7 @@ export class DBOS {
     return DBOS.#createStartWorkflowProxy(target, instance, params) as unknown as InvokeFunctionsAsync<T>;
   }
 
-  static #createStartWorkflowProxyMethod<T extends Object>(
+  static #createStartWorkflowProxyMethod(
     op: MethodRegistrationBase,
     configuredInstance: ConfiguredInstance | null,
     inParams?: StartWorkflowParams,

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1839,7 +1839,8 @@ export class DBOS {
    * @param func - The function to register as a workflow
    * @param name - The name of the registered workflow
    * @param options - Configuration information for the registered workflow
-   */ static registerWorkflow<This, Args extends unknown[], Return>(
+   */
+  static registerWorkflow<This, Args extends unknown[], Return>(
     func: (this: This, ...args: Args) => Promise<Return>,
     name: string,
     options: {
@@ -2240,7 +2241,6 @@ export class DBOS {
    * @param config - Configuration information for the step, particularly the retry policy
    * @param config.name - The name of the step; if not provided, the function name will be used
    */
-
   static registerStep<This, Args extends unknown[], Return>(
     func: (this: This, ...args: Args) => Promise<Return>,
     config: StepConfig & { name?: string } = {},

--- a/tests/contextfreeapi.test.ts
+++ b/tests/contextfreeapi.test.ts
@@ -555,10 +555,10 @@ async function main9() {
     'Invalid call to a `workflow` function from within a `step` or `transaction`',
   );
   await expect(() => TransitionTests.oopsCallStartWFFromTransaction()).rejects.toThrow(
-    'Invalid call to `DBOS.startWorkflow` from within a `step` or `transaction`',
+    'Invalid call to a `workflow` function from within a `step` or `transaction`',
   );
   await expect(() => TransitionTests.oopsCallStartWFFromStep()).rejects.toThrow(
-    'Invalid call to `DBOS.startWorkflow` from within a `step` or `transaction`',
+    'Invalid call to a `workflow` function from within a `step` or `transaction`',
   );
 
   await DBOS.shutdown();

--- a/tests/decorator-free.test.ts
+++ b/tests/decorator-free.test.ts
@@ -107,15 +107,15 @@ TestClass.wfRegRetryStatic = DBOS.registerWorkflow(TestClass.wfRegRetryStatic, '
 TestClass.prototype.stepTest = DBOS.registerStep(TestClass.prototype.stepTest);
 TestClass.prototype.retryTest = DBOS.registerStep(TestClass.prototype.retryTest, { retriesAllowed: true });
 TestClass.prototype.wfRegStep = DBOS.registerWorkflow(TestClass.prototype.wfRegStep, 'TestClass.prototype.wfRegStep', {
-  classOrInst: inst,
+  classOrInst: TestClass,
 });
 TestClass.prototype.wfRunStep = DBOS.registerWorkflow(TestClass.prototype.wfRunStep, 'TestClass.prototype.wfRunStep', {
-  classOrInst: inst,
+  classOrInst: TestClass,
 });
 TestClass.prototype.wfRegRetry = DBOS.registerWorkflow(
   TestClass.prototype.wfRegRetry,
   'TestClass.prototype.wfRegRetry',
-  { classOrInst: inst },
+  { classOrInst: TestClass },
 );
 
 describe('decorator-free-tests', () => {

--- a/tests/decorator-free.test.ts
+++ b/tests/decorator-free.test.ts
@@ -155,7 +155,24 @@ describe('decorator-free-tests', () => {
     expect(steps[0].childWorkflowID).toBeNull();
   });
 
-  test('wf-free-step-reg-queue', async () => {
+  test('wf-free-step-reg-swf', async () => {
+    const handle = await DBOS.startWorkflowFunction({ queueName: queue.name }, regWFRegStep, 10);
+    await expect(handle.getResult()).resolves.toBe(1000);
+
+    const status = await DBOS.getWorkflowStatus(handle.workflowID);
+    expect(status).not.toBeNull();
+    expect(status!.workflowName).toBe('wfRegStep');
+
+    const steps = (await DBOS.listWorkflowSteps(handle.workflowID))!;
+    expect(steps.length).toBe(1);
+    expect(steps[0].functionID).toBe(0);
+    expect(steps[0].name).toBe('stepTest');
+    expect(steps[0].output).toEqual(1000);
+    expect(steps[0].error).toBeNull();
+    expect(steps[0].childWorkflowID).toBeNull();
+  });
+
+  test('wf-free-step-reg-client', async () => {
     const client = await DBOSClient.create(config.databaseUrl!);
     try {
       const handle = await client.enqueue<typeof regWFRegStep>(
@@ -248,7 +265,24 @@ describe('decorator-free-tests', () => {
     expect(steps[0].childWorkflowID).toBeNull();
   });
 
-  test('wf-static-step-reg-queue', async () => {
+  test('wf-static-step-reg-swf', async () => {
+    const handle = await DBOS.startWorkflowFunction({ queueName: queue.name }, TestClass.wfRegStepStatic, 10);
+    await expect(handle.getResult()).resolves.toBe(1000);
+
+    const status = await DBOS.getWorkflowStatus(handle.workflowID);
+    expect(status).not.toBeNull();
+    expect(status!.workflowName).toBe('TestClass.wfRegStepStatic');
+
+    const steps = (await DBOS.listWorkflowSteps(handle.workflowID))!;
+    expect(steps.length).toBe(1);
+    expect(steps[0].functionID).toBe(0);
+    expect(steps[0].name).toBe('stepTestStatic');
+    expect(steps[0].output).toEqual(1000);
+    expect(steps[0].error).toBeNull();
+    expect(steps[0].childWorkflowID).toBeNull();
+  });
+
+  test('wf-static-step-reg-client', async () => {
     const client = await DBOSClient.create(config.databaseUrl!);
     try {
       const handle = await client.enqueue<typeof TestClass.wfRunStepStatic>(
@@ -340,7 +374,31 @@ describe('decorator-free-tests', () => {
     expect(steps[0].childWorkflowID).toBeNull();
   });
 
-  test('wf-inst-step-reg-queue', async () => {
+  test('wf-inst-step-reg-swf', async () => {
+    const handle = await DBOS.startWorkflowFunction(
+      {
+        queueName: queue.name,
+        instance: inst,
+      },
+      inst.wfRegStep,
+      10,
+    );
+    await expect(handle.getResult()).resolves.toBe(1000);
+
+    const status = await DBOS.getWorkflowStatus(handle.workflowID);
+    expect(status).not.toBeNull();
+    expect(status!.workflowName).toBe('TestClass.prototype.wfRegStep');
+
+    const steps = (await DBOS.listWorkflowSteps(handle.workflowID))!;
+    expect(steps.length).toBe(1);
+    expect(steps[0].functionID).toBe(0);
+    expect(steps[0].name).toBe('stepTest');
+    expect(steps[0].output).toEqual(1000);
+    expect(steps[0].error).toBeNull();
+    expect(steps[0].childWorkflowID).toBeNull();
+  });
+
+  test('wf-inst-step-reg-client', async () => {
     const client = await DBOSClient.create(config.databaseUrl!);
     try {
       const handle = await client.enqueue<typeof TestClass.prototype.wfRegStep>(
@@ -353,6 +411,17 @@ describe('decorator-free-tests', () => {
         10,
       );
       await expect(handle.getResult()).resolves.toBe(1000);
+      const status = await DBOS.getWorkflowStatus(handle.workflowID);
+      expect(status).not.toBeNull();
+      expect(status!.workflowName).toBe('TestClass.prototype.wfRegStep');
+
+      const steps = (await DBOS.listWorkflowSteps(handle.workflowID))!;
+      expect(steps.length).toBe(1);
+      expect(steps[0].functionID).toBe(0);
+      expect(steps[0].name).toBe('stepTest');
+      expect(steps[0].output).toEqual(1000);
+      expect(steps[0].error).toBeNull();
+      expect(steps[0].childWorkflowID).toBeNull();
     } finally {
       await client.destroy();
     }

--- a/tests/scheduler/scheduler.test.ts
+++ b/tests/scheduler/scheduler.test.ts
@@ -174,7 +174,7 @@ describe('scheduled-wf-tests-oaoo', () => {
     } finally {
       await DBOS.shutdown();
     }
-  }, 15000);
+  }, 30000);
 });
 
 describe('scheduled-wf-tests-when-active', () => {

--- a/tests/scheduler/scheduler.test.ts
+++ b/tests/scheduler/scheduler.test.ts
@@ -174,7 +174,7 @@ describe('scheduled-wf-tests-oaoo', () => {
     } finally {
       await DBOS.shutdown();
     }
-  }, 30000);
+  }, 20000);
 });
 
 describe('scheduled-wf-tests-when-active', () => {


### PR DESCRIPTION
Adds `DBOS.startWorkflowFunction` - like `DBOS.startWorkflow` for for registered workflows. 

Also adds a few missing JSDoc comments from previous PR and tests.

Note, there looks to be duplicate code between `@DBOS.step` and `registerStep` as well as between `startWorkflow`, `startWorkflowFunction` and `#proxyInvoke`. This will be DRYed out in a future PR.

Update: In the end, this PR DRYed out the multiple workflow invocation paths into a single function `DBOS.#invokeWorkflow`. Additional changes to DRY steps + improve `startWorkflowFunction` and improve `startWorkflow` support for registered workflows will come in later PRs. 