### PR TITLE
use Proxy/Reflect in startWorkflow

### DIFF
--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1297,7 +1297,7 @@ export class DBOS {
     const handler: ProxyHandler<T> = {
       get(target, p, receiver) {
         const func = Reflect.get(target, p, receiver);
-        const regOp = regOps.find((op) => op.wrappedFunction === func);
+        const regOp = getRegistrationForFunction(func) ?? regOps.find((op) => op.name === p);
         if (regOp) {
           return (...args: unknown[]) => DBOS.#invokeWorkflow(instance, regOp, args, params);
         }

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1293,15 +1293,21 @@ export class DBOS {
     }
 
     const regOps = getRegisteredOperations(target);
-    const proxy: Record<string, unknown> = {};
 
-    for (const regOp of regOps) {
-      proxy[regOp.name] = (...args: unknown[]) => DBOS.#invokeWorkflow(instance, regOp, args, params);
-    }
+    const handler: ProxyHandler<T> = {
+      get(target, p, receiver) {
+        const func = Reflect.get(target, p, receiver);
+        const regOp = regOps.find((op) => op.wrappedFunction === func);
+        if (regOp) {
+          return (...args: unknown[]) => DBOS.#invokeWorkflow(instance, regOp, args, params);
+        }
 
-    augmentProxy(instance ?? target, proxy);
+        const name = typeof p === 'string' ? p : String(p);
+        throw new DBOSNotRegisteredError(name, `${name} is not a registered DBOS workflow function`);
+      },
+    };
 
-    return proxy as InvokeFunctionsAsync<T>;
+    return new Proxy(target, handler) as unknown as InvokeFunctionsAsync<T>;
   }
 
   /** @deprecated Adjust target function to exclude its `DBOSContext` argument, and then call the function directly */

--- a/tests/decorator-free.test.ts
+++ b/tests/decorator-free.test.ts
@@ -139,6 +139,42 @@ describe('decorator-free-tests', () => {
     await DBOS.shutdown();
   });
 
+  test('static-registered-wf-startWorkflow', async () => {
+    const handle = await DBOS.startWorkflow(TestClass, { queueName: queue.name }).wfRegStepStatic(10);
+    await expect(handle.getResult()).resolves.toBe(1000);
+
+    const wfid = handle.workflowID;
+    const status = await DBOS.getWorkflowStatus(wfid);
+    expect(status).not.toBeNull();
+    expect(status!.workflowName).toBe('TestClass.wfRegStepStatic');
+
+    const steps = (await DBOS.listWorkflowSteps(wfid))!;
+    expect(steps.length).toBe(1);
+    expect(steps[0].functionID).toBe(0);
+    expect(steps[0].name).toBe('stepTestStatic');
+    expect(steps[0].output).toEqual(1000);
+    expect(steps[0].error).toBeNull();
+    expect(steps[0].childWorkflowID).toBeNull();
+  });
+
+  test('instance-registered-wf-startWorkflow', async () => {
+    const handle = await DBOS.startWorkflow(inst, { queueName: queue.name }).wfRegStep(10);
+    await expect(handle.getResult()).resolves.toBe(1000);
+
+    const wfid = handle.workflowID;
+    const status = await DBOS.getWorkflowStatus(wfid);
+    expect(status).not.toBeNull();
+    expect(status!.workflowName).toBe('TestClass.prototype.wfRegStep');
+
+    const steps = (await DBOS.listWorkflowSteps(wfid))!;
+    expect(steps.length).toBe(1);
+    expect(steps[0].functionID).toBe(0);
+    expect(steps[0].name).toBe('stepTest');
+    expect(steps[0].output).toEqual(1000);
+    expect(steps[0].error).toBeNull();
+    expect(steps[0].childWorkflowID).toBeNull();
+  });
+
   test('decorated-wf-startWorkflowFunction', async () => {
     const handle = await DBOS.startWorkflowFunction({ queueName: queue.name }, TestClass.decoratedWorkflow, 10);
     await expect(handle.getResult()).resolves.toBe(1000);


### PR DESCRIPTION
`startWorkflow` creates a proxy object from an existing class or class instance where the workflow methods return a WorkflowHandle. The previous proxy creation approach was dependent on the workflow's registered name being the same as the method name. With the new `registerWorkflow` API, the developer can choose whatever name they wish. Unless they pick the method name, `startWorkflow` no longer works. 

This PR modifies `startWorkflow` to use JS's native [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) object. The proxy handler's `get` method first uses `getRegistrationForFunction` to retrieve the `MethodRegistration` for the workflow function. If this fails, `startWorkflow` falls back to matching on the workflow function name, as it did previously. This enables `startWorkflow` to work with both decorated and registered workflows, regardless of what the developer names the registered workflow.