### PR TITLE
update startWorkflow to handle free function registered workflows

### DIFF
--- a/tests/decorator-free.test.ts
+++ b/tests/decorator-free.test.ts
@@ -158,6 +158,24 @@ describe('decorator-free-tests', () => {
     expect(steps[0].childWorkflowID).toBeNull();
   });
 
+  test('static-registered-wf-startWorkflow-2', async () => {
+    const handle = await DBOS.startWorkflow(TestClass.wfRegStepStatic, { queueName: queue.name })(10);
+    await expect(handle.getResult()).resolves.toBe(1000);
+
+    const wfid = handle.workflowID;
+    const status = await DBOS.getWorkflowStatus(wfid);
+    expect(status).not.toBeNull();
+    expect(status!.workflowName).toBe('TestClass.wfRegStepStatic');
+
+    const steps = (await DBOS.listWorkflowSteps(wfid))!;
+    expect(steps.length).toBe(1);
+    expect(steps[0].functionID).toBe(0);
+    expect(steps[0].name).toBe('stepTestStatic');
+    expect(steps[0].output).toEqual(1000);
+    expect(steps[0].error).toBeNull();
+    expect(steps[0].childWorkflowID).toBeNull();
+  });
+
   test('instance-registered-wf-startWorkflow', async () => {
     const handle = await DBOS.startWorkflow(inst, { queueName: queue.name }).wfRegStep(10);
     await expect(handle.getResult()).resolves.toBe(1000);

--- a/tests/decorator-free.test.ts
+++ b/tests/decorator-free.test.ts
@@ -176,7 +176,7 @@ describe('decorator-free-tests', () => {
     expect(steps[0].childWorkflowID).toBeNull();
   });
 
-  test('decorated-wf-startWorkflowFunction', async () => {
+  test('decorated-wf-startWorkflow', async () => {
     const handle = await DBOS.startWorkflow(TestClass, { queueName: queue.name }).decoratedWorkflow(10);
     await expect(handle.getResult()).resolves.toBe(1000);
 
@@ -215,7 +215,7 @@ describe('decorator-free-tests', () => {
     expect(steps[0].childWorkflowID).toBeNull();
   });
 
-  test('wf-free-step-reg-swf', async () => {
+  test('wf-free-step-reg-startWorkflow', async () => {
     const handle = await DBOS.startWorkflow(regWFRegStep, { queueName: queue.name })(10);
     await expect(handle.getResult()).resolves.toBe(1000);
 
@@ -325,7 +325,7 @@ describe('decorator-free-tests', () => {
     expect(steps[0].childWorkflowID).toBeNull();
   });
 
-  test('wf-static-step-reg-swf', async () => {
+  test('wf-static-step-reg-startWorkflow', async () => {
     const handle = await DBOS.startWorkflow(TestClass, { queueName: queue.name }).wfRegStepStatic(10);
     await expect(handle.getResult()).resolves.toBe(1000);
 
@@ -434,7 +434,7 @@ describe('decorator-free-tests', () => {
     expect(steps[0].childWorkflowID).toBeNull();
   });
 
-  test('wf-inst-step-reg-swf', async () => {
+  test('wf-inst-step-reg-startWorkflow', async () => {
     const handle = await DBOS.startWorkflow(inst, { queueName: queue.name }).wfRegStep(10);
     await expect(handle.getResult()).resolves.toBe(1000);
 

--- a/tests/decorator-free.test.ts
+++ b/tests/decorator-free.test.ts
@@ -177,7 +177,7 @@ describe('decorator-free-tests', () => {
   });
 
   test('decorated-wf-startWorkflowFunction', async () => {
-    const handle = await DBOS.startWorkflowFunction({ queueName: queue.name }, TestClass.decoratedWorkflow, 10);
+    const handle = await DBOS.startWorkflow(TestClass, { queueName: queue.name }).decoratedWorkflow(10);
     await expect(handle.getResult()).resolves.toBe(1000);
 
     const wfid = handle.workflowID;
@@ -216,7 +216,7 @@ describe('decorator-free-tests', () => {
   });
 
   test('wf-free-step-reg-swf', async () => {
-    const handle = await DBOS.startWorkflowFunction({ queueName: queue.name }, regWFRegStep, 10);
+    const handle = await DBOS.startWorkflow(regWFRegStep, { queueName: queue.name })(10);
     await expect(handle.getResult()).resolves.toBe(1000);
 
     const status = await DBOS.getWorkflowStatus(handle.workflowID);
@@ -326,7 +326,7 @@ describe('decorator-free-tests', () => {
   });
 
   test('wf-static-step-reg-swf', async () => {
-    const handle = await DBOS.startWorkflowFunction({ queueName: queue.name }, TestClass.wfRegStepStatic, 10);
+    const handle = await DBOS.startWorkflow(TestClass, { queueName: queue.name }).wfRegStepStatic(10);
     await expect(handle.getResult()).resolves.toBe(1000);
 
     const status = await DBOS.getWorkflowStatus(handle.workflowID);
@@ -435,15 +435,7 @@ describe('decorator-free-tests', () => {
   });
 
   test('wf-inst-step-reg-swf', async () => {
-    const handle = await DBOS.startWorkflowFunction(
-      {
-        queueName: queue.name,
-        instance: inst,
-      },
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      inst.wfRegStep,
-      10,
-    );
+    const handle = await DBOS.startWorkflow(inst, { queueName: queue.name }).wfRegStep(10);
     await expect(handle.getResult()).resolves.toBe(1000);
 
     const status = await DBOS.getWorkflowStatus(handle.workflowID);

--- a/tests/decorator-free.test.ts
+++ b/tests/decorator-free.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/unbound-method */
 import { ConfiguredInstance, DBOS, DBOSClient, WorkflowQueue } from '../src/';
 import { DBOSConflictingRegistrationError } from '../src/error';
 import { generateDBOSTestConfig, setUpDBOSTestDb } from './helpers';
@@ -109,6 +108,7 @@ TestClass.wfRegStepStatic = DBOS.registerWorkflow(TestClass.wfRegStepStatic, 'Te
 TestClass.wfRunStepStatic = DBOS.registerWorkflow(TestClass.wfRunStepStatic, 'TestClass.wfRunStepStatic');
 TestClass.wfRegRetryStatic = DBOS.registerWorkflow(TestClass.wfRegRetryStatic, 'TestClass.wfRegRetryStatic');
 
+/* eslint-disable @typescript-eslint/unbound-method */
 TestClass.prototype.stepTest = DBOS.registerStep(TestClass.prototype.stepTest);
 TestClass.prototype.retryTest = DBOS.registerStep(TestClass.prototype.retryTest, { retriesAllowed: true });
 TestClass.prototype.wfRegStep = DBOS.registerWorkflow(TestClass.prototype.wfRegStep, 'TestClass.prototype.wfRegStep', {
@@ -122,6 +122,7 @@ TestClass.prototype.wfRegRetry = DBOS.registerWorkflow(
   'TestClass.prototype.wfRegRetry',
   { classOrInst: TestClass },
 );
+/* eslint-enable @typescript-eslint/unbound-method */
 
 describe('decorator-free-tests', () => {
   const config = generateDBOSTestConfig();
@@ -439,6 +440,7 @@ describe('decorator-free-tests', () => {
         queueName: queue.name,
         instance: inst,
       },
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       inst.wfRegStep,
       10,
     );

--- a/tests/decorator-free.test.ts
+++ b/tests/decorator-free.test.ts
@@ -148,6 +148,7 @@ describe('decorator-free-tests', () => {
     const status = await DBOS.getWorkflowStatus(wfid);
     expect(status).not.toBeNull();
     expect(status!.workflowName).toBe('TestClass.wfRegStepStatic');
+    expect(status!.queueName).toBe(queue.name);
 
     const steps = (await DBOS.listWorkflowSteps(wfid))!;
     expect(steps.length).toBe(1);
@@ -166,6 +167,7 @@ describe('decorator-free-tests', () => {
     const status = await DBOS.getWorkflowStatus(wfid);
     expect(status).not.toBeNull();
     expect(status!.workflowName).toBe('TestClass.wfRegStepStatic');
+    expect(status!.queueName).toBe(queue.name);
 
     const steps = (await DBOS.listWorkflowSteps(wfid))!;
     expect(steps.length).toBe(1);
@@ -184,6 +186,7 @@ describe('decorator-free-tests', () => {
     const status = await DBOS.getWorkflowStatus(wfid);
     expect(status).not.toBeNull();
     expect(status!.workflowName).toBe('TestClass.prototype.wfRegStep');
+    expect(status!.queueName).toBe(queue.name);
 
     const steps = (await DBOS.listWorkflowSteps(wfid))!;
     expect(steps.length).toBe(1);
@@ -202,6 +205,7 @@ describe('decorator-free-tests', () => {
     const status = await DBOS.getWorkflowStatus(wfid);
     expect(status).not.toBeNull();
     expect(status!.workflowName).toBe('decoratedWorkflow');
+    expect(status!.queueName).toBe(queue.name);
 
     const steps = (await DBOS.listWorkflowSteps(wfid))!;
     expect(steps.length).toBe(1);
@@ -240,6 +244,7 @@ describe('decorator-free-tests', () => {
     const status = await DBOS.getWorkflowStatus(handle.workflowID);
     expect(status).not.toBeNull();
     expect(status!.workflowName).toBe('wfRegStep');
+    expect(status!.queueName).toBe(queue.name);
 
     const steps = (await DBOS.listWorkflowSteps(handle.workflowID))!;
     expect(steps.length).toBe(1);
@@ -265,6 +270,7 @@ describe('decorator-free-tests', () => {
       const status = await DBOS.getWorkflowStatus(handle.workflowID);
       expect(status).not.toBeNull();
       expect(status!.workflowName).toBe('wfRegStep');
+      expect(status!.queueName).toBe(queue.name);
 
       const steps = (await DBOS.listWorkflowSteps(handle.workflowID))!;
       expect(steps.length).toBe(1);
@@ -350,6 +356,7 @@ describe('decorator-free-tests', () => {
     const status = await DBOS.getWorkflowStatus(handle.workflowID);
     expect(status).not.toBeNull();
     expect(status!.workflowName).toBe('TestClass.wfRegStepStatic');
+    expect(status!.queueName).toBe(queue.name);
 
     const steps = (await DBOS.listWorkflowSteps(handle.workflowID))!;
     expect(steps.length).toBe(1);
@@ -375,6 +382,7 @@ describe('decorator-free-tests', () => {
       const status = await DBOS.getWorkflowStatus(handle.workflowID);
       expect(status).not.toBeNull();
       expect(status!.workflowName).toBe('TestClass.wfRegStepStatic');
+      expect(status!.queueName).toBe(queue.name);
 
       const steps = (await DBOS.listWorkflowSteps(handle.workflowID))!;
       expect(steps.length).toBe(1);
@@ -459,6 +467,7 @@ describe('decorator-free-tests', () => {
     const status = await DBOS.getWorkflowStatus(handle.workflowID);
     expect(status).not.toBeNull();
     expect(status!.workflowName).toBe('TestClass.prototype.wfRegStep');
+    expect(status!.queueName).toBe(queue.name);
 
     const steps = (await DBOS.listWorkflowSteps(handle.workflowID))!;
     expect(steps.length).toBe(1);
@@ -485,6 +494,7 @@ describe('decorator-free-tests', () => {
       const status = await DBOS.getWorkflowStatus(handle.workflowID);
       expect(status).not.toBeNull();
       expect(status!.workflowName).toBe('TestClass.prototype.wfRegStep');
+      expect(status!.queueName).toBe(queue.name);
 
       const steps = (await DBOS.listWorkflowSteps(handle.workflowID))!;
       expect(steps.length).toBe(1);


### PR DESCRIPTION
Update the overloads and proxy returned from startWorkflow to handle free registered function workflows

Example usage:
```ts
function wfFunction(value: number) { /* implementation omitted */ }

const registeredWFFunction= DBOS.registerWorkflow(
    wfFunction, 
    'wfFunction');

// when using startWorkflow with a function, it returns a function;
const handle = await DBOS.startWorkflow(registeredWFFunction)(10);
```