### PR TITLE
Handle attributes safely when ending spans

### DIFF
--- a/src/telemetry/traces.ts
+++ b/src/telemetry/traces.ts
@@ -39,14 +39,14 @@ export class Tracer {
   }
 
   endSpan(span: Span) {
-    span.end(hrTime(performance.now()));
-    if (span.attributes) {
-      span.attributes.applicationID = this.applicationID;
-      span.attributes.applicationVersion = globalParams.appVersion;
-    }
+    span.setAttributes({
+      applicationID: this.applicationID,
+      applicationVersion: globalParams.appVersion,
+    });
     if (span.attributes && !('executorID' in span.attributes)) {
-      span.attributes.executorID = this.executorID;
+      span.setAttribute('executorID', this.executorID);
     }
+    span.end(hrTime(performance.now()));
     this.telemetryCollector.push(span as ReadableSpan);
   }
 }

--- a/src/telemetry/traces.ts
+++ b/src/telemetry/traces.ts
@@ -16,7 +16,7 @@ export class Tracer {
         [SemanticResourceAttributes.SERVICE_NAME]: 'dbos',
       }),
     });
-    this.tracer.register();
+    this.tracer.register(); // this is a no-op if another tracer provider was already registered
     this.applicationID = globalParams.appID;
     this.executorID = globalParams.executorID; // for consistency with src/context.ts
   }
@@ -40,10 +40,12 @@ export class Tracer {
 
   endSpan(span: Span) {
     span.end(hrTime(performance.now()));
-    span.attributes.applicationID = this.applicationID;
-    span.attributes.applicationVersion = globalParams.appVersion;
-    if (!('executorID' in span.attributes)) {
-      span.attributes.executorID = this.executorID;
+    span.setAttributes({
+      applicationID: this.applicationID,
+      applicationVersion: globalParams.appVersion,
+    });
+    if (span.attributes && !('executorID' in span.attributes)) {
+      span.setAttribute('executorID', this.executorID);
     }
     this.telemetryCollector.push(span as ReadableSpan);
   }

--- a/src/telemetry/traces.ts
+++ b/src/telemetry/traces.ts
@@ -40,12 +40,12 @@ export class Tracer {
 
   endSpan(span: Span) {
     span.end(hrTime(performance.now()));
-    span.setAttributes({
-      applicationID: this.applicationID,
-      applicationVersion: globalParams.appVersion,
-    });
+    if (span.attributes) {
+      span.attributes.applicationID = this.applicationID;
+      span.attributes.applicationVersion = globalParams.appVersion;
+    }
     if (span.attributes && !('executorID' in span.attributes)) {
-      span.setAttribute('executorID', this.executorID);
+      span.attributes.executorID = this.executorID;
     }
     this.telemetryCollector.push(span as ReadableSpan);
   }


### PR DESCRIPTION
Ensure attributes exists on the span before setting them in `endSpan`