### PR TITLE
update knex db schema init/uninit functions

### DIFF
--- a/packages/knex-datasource/index.ts
+++ b/packages/knex-datasource/index.ts
@@ -214,7 +214,6 @@ export class KnexDataSource implements DBOSDataSource<TransactionConfig> {
     }
 
     async function $initSchema(knexDB: Knex) {
-      knexDB;
       await knexDB.raw(createTransactionCompletionSchemaPG);
       await knexDB.raw(createTransactionCompletionTablePG);
     }
@@ -233,7 +232,6 @@ export class KnexDataSource implements DBOSDataSource<TransactionConfig> {
     }
 
     async function $uninitSchema(knexDB: Knex) {
-      knexDB;
       await knexDB.raw('DROP TABLE IF EXISTS dbos.transaction_completion; DROP SCHEMA IF EXISTS dbos;');
     }
   }

--- a/packages/knex-datasource/index.ts
+++ b/packages/knex-datasource/index.ts
@@ -185,6 +185,10 @@ class KnexTransactionHandler implements DataSourceTransactionHandler {
   }
 }
 
+function isKnex(value: Knex | Knex.Config): value is Knex {
+  return 'raw' in value;
+}
+
 export class KnexDataSource implements DBOSDataSource<TransactionConfig> {
   static get client(): Knex.Transaction {
     if (!DBOS.isInTransaction()) {
@@ -197,13 +201,40 @@ export class KnexDataSource implements DBOSDataSource<TransactionConfig> {
     return ctx.client;
   }
 
-  static async initializeInternalSchema(config: Knex.Config) {
-    const knexDB = knex(config);
-    try {
+  static async initializeSchema(knexOrConfig: Knex.Config) {
+    if (isKnex(knexOrConfig)) {
+      await $initSchema(knexOrConfig);
+    } else {
+      const knexDB = knex(knexOrConfig);
+      try {
+        await $initSchema(knexDB);
+      } finally {
+        await knexDB.destroy();
+      }
+    }
+
+    async function $initSchema(knexDB: Knex) {
+      knexDB;
       await knexDB.raw(createTransactionCompletionSchemaPG);
       await knexDB.raw(createTransactionCompletionTablePG);
-    } finally {
-      await knexDB.destroy();
+    }
+  }
+
+  static async uninitializeSchema(knexOrConfig: Knex.Config) {
+    if (isKnex(knexOrConfig)) {
+      await $uninitSchema(knexOrConfig);
+    } else {
+      const knexDB = knex(knexOrConfig);
+      try {
+        await $uninitSchema(knexDB);
+      } finally {
+        await knexDB.destroy();
+      }
+    }
+
+    async function $uninitSchema(knexDB: Knex) {
+      knexDB;
+      await knexDB.raw('DROP TABLE IF EXISTS dbos.transaction_completion; DROP SCHEMA IF EXISTS dbos;');
     }
   }
 

--- a/packages/knex-datasource/tests/config.test.ts
+++ b/packages/knex-datasource/tests/config.test.ts
@@ -1,7 +1,7 @@
 import { Client } from 'pg';
 import { KnexDataSource } from '../index';
 import { dropDB, ensureDB } from './test-helpers';
-import knex, { type Knex } from 'knex';
+import knex from 'knex';
 
 describe('KnexDataSource.initializeSchema', () => {
   const config = { user: 'postgres', database: 'knex_ds_config_test' };
@@ -18,8 +18,10 @@ describe('KnexDataSource.initializeSchema', () => {
   });
 
   async function queryTxCompletionTable(client: Client) {
-    const result = await client.query('SELECT workflow_id, function_num, output FROM dbos.transaction_completion');
-    return result.rows;
+    const result = await client.query(
+      'SELECT workflow_id, function_num, output, error FROM dbos.transaction_completion',
+    );
+    return result.rowCount;
   }
 
   async function txCompletionTableExists(client: Client) {
@@ -38,7 +40,7 @@ describe('KnexDataSource.initializeSchema', () => {
     try {
       await client.connect();
       await expect(txCompletionTableExists(client)).resolves.toBe(true);
-      await expect(queryTxCompletionTable(client)).resolves.toEqual([]);
+      await expect(queryTxCompletionTable(client)).resolves.toEqual(0);
 
       await KnexDataSource.uninitializeSchema(knexConfig);
 
@@ -56,7 +58,7 @@ describe('KnexDataSource.initializeSchema', () => {
       await client.connect();
 
       await expect(txCompletionTableExists(client)).resolves.toBe(true);
-      await expect(queryTxCompletionTable(client)).resolves.toEqual([]);
+      await expect(queryTxCompletionTable(client)).resolves.toEqual(0);
 
       await KnexDataSource.uninitializeSchema(knexDB);
 

--- a/packages/knex-datasource/tests/config.test.ts
+++ b/packages/knex-datasource/tests/config.test.ts
@@ -1,11 +1,12 @@
 import { Client } from 'pg';
 import { KnexDataSource } from '../index';
 import { dropDB, ensureDB } from './test-helpers';
+import knex, { type Knex } from 'knex';
 
-describe('KnexDataSource.configure', () => {
+describe('KnexDataSource.initializeSchema', () => {
   const config = { user: 'postgres', database: 'knex_ds_config_test' };
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     const client = new Client({ ...config, database: 'postgres' });
     try {
       await client.connect();
@@ -16,16 +17,53 @@ describe('KnexDataSource.configure', () => {
     }
   });
 
-  test('configure creates tx outputs table', async () => {
-    await KnexDataSource.initializeInternalSchema({ client: 'pg', connection: config });
+  async function queryTxCompletionTable(client: Client) {
+    const result = await client.query('SELECT workflow_id, function_num, output FROM dbos.transaction_completion');
+    return result.rows;
+  }
+
+  async function txCompletionTableExists(client: Client) {
+    const result = await client.query<{ exists: boolean }>(
+      "SELECT EXISTS (SELECT 1 FROM information_schema.tables  WHERE table_schema = 'dbos' AND table_name = 'transaction_completion');",
+    );
+    if (result.rowCount !== 1) throw new Error(`unexpected rowcount ${result.rowCount}`);
+    return result.rows[0].exists;
+  }
+
+  test('initializeSchema-with-config', async () => {
+    const knexConfig = { client: 'pg', connection: config };
+    await KnexDataSource.initializeSchema(knexConfig);
 
     const client = new Client(config);
     try {
       await client.connect();
-      const result = await client.query('SELECT workflow_id, function_num, output FROM dbos.transaction_completion');
-      expect(result.rows.length).toBe(0);
+      await expect(txCompletionTableExists(client)).resolves.toBe(true);
+      await expect(queryTxCompletionTable(client)).resolves.toEqual([]);
+
+      await KnexDataSource.uninitializeSchema(knexConfig);
+
+      await expect(txCompletionTableExists(client)).resolves.toBe(false);
     } finally {
       await client.end();
+    }
+  });
+
+  test('initializeSchema-with-knex', async () => {
+    const knexDB = knex({ client: 'pg', connection: config });
+    const client = new Client(config);
+    try {
+      await KnexDataSource.initializeSchema(knexDB);
+      await client.connect();
+
+      await expect(txCompletionTableExists(client)).resolves.toBe(true);
+      await expect(queryTxCompletionTable(client)).resolves.toEqual([]);
+
+      await KnexDataSource.uninitializeSchema(knexDB);
+
+      await expect(txCompletionTableExists(client)).resolves.toBe(false);
+    } finally {
+      await client.end();
+      await knexDB.destroy();
     }
   });
 });

--- a/packages/knex-datasource/tests/datasource.test.ts
+++ b/packages/knex-datasource/tests/datasource.test.ts
@@ -43,7 +43,7 @@ describe('KnexDataSource', () => {
       }
     }
 
-    await KnexDataSource.initializeInternalSchema(config);
+    await KnexDataSource.initializeSchema(config);
   });
 
   afterAll(async () => {


### PR DESCRIPTION
* initializeInternalSchema -> initializeSchema
* add uninitializeSchema
* both init and uninit Schema functions can take either a Knex config or a Knex object (meaning it can be used from Knex migration files)