### PR TITLE
replace deprecated husky install command

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint": "rm -rf packages/create/templates/hello-prisma/node_modules/ && eslint --ignore-pattern **/coverage/ .",
     "setversion": "npm run --workspaces setversion && grunt setversion",
     "test": "npm run build && rm -rf packages/create/templates/hello-prisma/node_modules/ && npm run --workspaces test && npx prisma generate --schema tests/prisma/schema.prisma && jest ./tests --coverage --collectCoverageFrom='src/**/*' --detectOpenHandles",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "bin": {
     "dbos": "./dist/src/dbos-runtime/cli.js",


### PR DESCRIPTION
When running `npm install` locally I noticed the warning `husky - install command is DEPRECATED` in the output. Easy fix, simply replace `husky install` with just `husky` in the `prepare` NPM package script