### PR TITLE
List workflows/queues support skipping input/output

### DIFF
--- a/src/conductor/conductor.ts
+++ b/src/conductor/conductor.ts
@@ -206,6 +206,8 @@ export class Conductor {
               limit: body.limit,
               offset: body.offset,
               sortDesc: body.sort_desc,
+              loadInput: body.load_input ?? false, // Default to false if not provided
+              loadOutput: body.load_output ?? false, // Default to false if not provided
             };
             let workflowsOutput: protocol.WorkflowsOutput[] = [];
             try {
@@ -230,6 +232,7 @@ export class Conductor {
               queueName: bodyQueued.queue_name,
               offset: bodyQueued.offset,
               sortDesc: bodyQueued.sort_desc,
+              loadInput: bodyQueued.load_input ?? false, // Default to false if not provided
             };
             let queuedWFOutput: protocol.WorkflowsOutput[] = [];
             try {

--- a/src/conductor/protocol.ts
+++ b/src/conductor/protocol.ts
@@ -134,6 +134,8 @@ export interface ListWorkflowsBody {
   limit?: number;
   offset?: number;
   sort_desc: boolean;
+  load_input?: boolean; // Load the input of the workflow (default false)
+  load_output?: boolean; // Load the output of the workflow (default false)
 }
 
 export class WorkflowsOutput {
@@ -221,6 +223,7 @@ export interface ListQueuedWorkflowsBody {
   limit?: number;
   offset?: number;
   sort_desc: boolean;
+  load_input?: boolean; // Load the input of the workflow (default false)
 }
 
 export class ListQueuedWorkflowsRequest implements BaseMessage {

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -451,6 +451,8 @@ export class DBOSHttpServer {
         offset?: number;
         sort_desc?: boolean;
         workflow_id_prefix?: string;
+        load_input?: boolean; // Load the input of the workflow (default false)
+        load_output?: boolean; // Load the output of the workflow (default false)
       };
 
       // Map request body keys to GetWorkflowsInput properties
@@ -466,6 +468,8 @@ export class DBOSHttpServer {
         offset: body.offset,
         sortDesc: body.sort_desc,
         workflow_id_prefix: body.workflow_id_prefix,
+        loadInput: body.load_input ?? false, // Default to false
+        loadOutput: body.load_output ?? false, // Default to false
       };
 
       const workflows = await dbosExec.listWorkflows(input);
@@ -495,6 +499,7 @@ export class DBOSHttpServer {
         limit?: number;
         offset?: number;
         sort_desc?: boolean;
+        load_input?: boolean; // Load the input of the workflow (default false)
       };
 
       // Map request body keys to GetQueuedWorkflowsInput properties
@@ -507,6 +512,7 @@ export class DBOSHttpServer {
         limit: body.limit,
         offset: body.offset,
         sortDesc: body.sort_desc,
+        loadInput: body.load_input ?? false, // Default to false
       };
 
       const workflows = await dbosExec.listQueuedWorkflows(input);

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1721,8 +1721,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     input.loadInput = input.loadInput ?? true;
     input.loadOutput = input.loadOutput ?? true;
     if (input.loadInput) {
-      selectColumns.push('inputs');
-      selectColumns.push('request');
+      selectColumns.push('inputs', 'request');
     }
 
     if (input.loadOutput) {
@@ -1791,8 +1790,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
 
     input.loadInput = input.loadInput ?? true;
     if (input.loadInput) {
-      selectColumns.push('inputs');
-      selectColumns.push('request');
+      selectColumns.push('inputs', 'request');
     }
 
     const sortDesc = input.sortDesc ?? false; // By default, sort in ascending order

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -105,6 +105,8 @@ export interface GetWorkflowsInput {
   offset?: number; // Skip this many workflows IDs. IDs are ordered by workflow creation time.
   sortDesc?: boolean; // Sort the workflows in descending order by creation time (default ascending order).
   workflow_id_prefix?: string;
+  loadInput?: boolean; // Load the input of the workflow (default true)
+  loadOutput?: boolean; // Load the output of the workflow (default true)
 }
 
 export interface GetQueuedWorkflowsInput {
@@ -116,6 +118,7 @@ export interface GetQueuedWorkflowsInput {
   queueName?: string; // The queue
   offset?: number; // Skip this many workflows IDs. IDs are ordered by workflow creation time.
   sortDesc?: boolean; // Sort the workflows in descending order by creation time (default ascending order).
+  loadInput?: boolean; // Load the input of the workflow (default true)
 }
 
 export interface GetWorkflowsOutput {

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -275,6 +275,18 @@ describe('workflow-management-tests', () => {
 
       const getInfo = await getWorkflow(sysdb, info.workflowID);
       expect(info).toEqual(getInfo);
+
+      // Test ignoring input and output
+      input.loadInput = false;
+      input.loadOutput = false;
+      const noIOInfos = await listWorkflows(sysdb, input);
+      expect(noIOInfos.length).toBe(2);
+      expect(noIOInfos[0].input).toBeUndefined();
+      expect(noIOInfos[0].output).toBeUndefined();
+      expect(noIOInfos[0].error).toBeUndefined();
+      expect(noIOInfos[1].input).toBeUndefined();
+      expect(noIOInfos[1].output).toBeUndefined();
+      expect(noIOInfos[1].error).toBeUndefined();
     } finally {
       await sysdb.destroy();
     }
@@ -547,6 +559,14 @@ describe('test-list-queues', () => {
       expect(output.length).toBe(TestListQueues.queuedSteps);
       for (let i = 0; i < TestListQueues.queuedSteps; i++) {
         expect(output[i].input).toEqual([i]);
+      }
+
+      // Test ignoring input
+      input.loadInput = false;
+      output = await listQueuedWorkflows(sysdb, input);
+      expect(output.length).toBe(TestListQueues.queuedSteps);
+      for (let i = 0; i < TestListQueues.queuedSteps; i++) {
+        expect(output[i].input).toBeUndefined();
       }
 
       input = {


### PR DESCRIPTION
- Support not loading input/output of workflows in list workflows/queues. This improves performance when we want to list workflows with large input/output.
- By default admin endpoints and conductor skips input/output.
- Add tests.