### PR TITLE
Add span to logger again, +test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14029,66 +14029,6 @@
         "@dbos-inc/dbos-sdk": "*"
       }
     },
-    "packages/communicator-bcrypt": {
-      "name": "@dbos-inc/dbos-bcrypt",
-      "version": "0.0.0-placeholder",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "bcryptjs": "^2.4.3"
-      },
-      "devDependencies": {
-        "@types/bcryptjs": "^2.4.6",
-        "typescript": "^5.4.5"
-      },
-      "peerDependencies": {
-        "@dbos-inc/dbos-sdk": "*"
-      }
-    },
-    "packages/communicator-datetime": {
-      "name": "@dbos-inc/dbos-datetime",
-      "version": "0.0.0-placeholder",
-      "extraneous": true,
-      "license": "MIT",
-      "devDependencies": {
-        "typescript": "^5.4.5"
-      },
-      "peerDependencies": {
-        "@dbos-inc/dbos-sdk": "*"
-      }
-    },
-    "packages/communicator-email-ses": {
-      "name": "@dbos-inc/dbos-email-ses",
-      "version": "0.0.0-placeholder",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@aws-sdk/client-sesv2": "^3.574.0"
-      },
-      "devDependencies": {
-        "@types/jest": "^29.5.12",
-        "@types/supertest": "^6.0.2",
-        "jest": "^29.7.0",
-        "supertest": "^7.0.0",
-        "typescript": "^5.3.3"
-      },
-      "peerDependencies": {
-        "@dbos-inc/aws-config": "*",
-        "@dbos-inc/dbos-sdk": "*"
-      }
-    },
-    "packages/communicator-random": {
-      "name": "@dbos-inc/dbos-random",
-      "version": "0.0.0-placeholder",
-      "extraneous": true,
-      "license": "MIT",
-      "devDependencies": {
-        "typescript": "^5.4.5"
-      },
-      "peerDependencies": {
-        "@dbos-inc/dbos-sdk": "*"
-      }
-    },
     "packages/component-aws-s3": {
       "name": "@dbos-inc/component-aws-s3",
       "version": "0.0.0-placeholder",
@@ -14293,75 +14233,6 @@
         "node": ">=0.10.0"
       }
     },
-    "packages/dbos-confluent-kafka": {
-      "name": "@dbos-inc/dbos-confluent-kafka",
-      "version": "0.0.0-placeholder",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@confluentinc/kafka-javascript": "^1.2.0"
-      },
-      "devDependencies": {
-        "@types/jest": "^29.5.12",
-        "@types/supertest": "^6.0.2",
-        "jest": "^29.7.0",
-        "supertest": "^7.0.0",
-        "ts-jest": "^29.1.4",
-        "typescript": "^5.3.3"
-      },
-      "peerDependencies": {
-        "@dbos-inc/dbos-sdk": "*"
-      }
-    },
-    "packages/dbos-kafkajs": {
-      "name": "@dbos-inc/dbos-kafkajs",
-      "version": "0.0.0-placeholder",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "kafkajs": "^2.2.4"
-      },
-      "devDependencies": {
-        "@types/jest": "^29.5.12",
-        "@types/supertest": "^6.0.2",
-        "jest": "^29.7.0",
-        "supertest": "^7.0.0",
-        "ts-jest": "^29.1.4",
-        "typescript": "^5.3.3"
-      },
-      "peerDependencies": {
-        "@dbos-inc/dbos-sdk": "*"
-      }
-    },
-    "packages/dbos-koa": {
-      "name": "@dbos-inc/dbos-koa",
-      "version": "0.0.0-placeholder",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@koa/bodyparser": "5.0.0",
-        "@koa/cors": "5.0.0",
-        "@koa/router": "13.1.0",
-        "jsonwebtoken": "^9.0.2",
-        "koa": "^2.15.4",
-        "serialize-error": "8.1.0"
-      },
-      "devDependencies": {
-        "@types/jest": "^29.5.12",
-        "@types/koa": "^2.15.0",
-        "@types/koa__cors": "^5.0.0",
-        "@types/koa__router": "^12.0.4",
-        "@types/node": "^20.11.25",
-        "@types/supertest": "^6.0.2",
-        "jest": "^29.7.0",
-        "supertest": "^7.0.0",
-        "ts-jest": "^29.1.4",
-        "typescript": "^5.3.3"
-      },
-      "peerDependencies": {
-        "@dbos-inc/dbos-sdk": "*"
-      }
-    },
     "packages/dbos-openapi": {
       "name": "@dbos-inc/dbos-openapi",
       "version": "0.0.0-placeholder",
@@ -14384,27 +14255,6 @@
         "jest": "^29.6.1",
         "supertest": "^7.0.0",
         "ts-jest": "^29.1.1"
-      }
-    },
-    "packages/dbos-sqs": {
-      "name": "@dbos-inc/dbos-sqs",
-      "version": "0.0.0-placeholder",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@aws-sdk/client-sqs": "^3.596.0"
-      },
-      "devDependencies": {
-        "@types/jest": "^29.5.12",
-        "@types/supertest": "^6.0.2",
-        "jest": "^29.7.0",
-        "supertest": "^7.0.0",
-        "ts-jest": "^29.1.4",
-        "typescript": "^5.3.3"
-      },
-      "peerDependencies": {
-        "@dbos-inc/aws-config": "*",
-        "@dbos-inc/dbos-sdk": "*"
       }
     },
     "packages/drizzle-datasource": {
@@ -14581,26 +14431,6 @@
         "jest": "^29.7.0",
         "supertest": "^7.0.0",
         "ts-jest": "^29.1.4",
-        "typescript": "^5.4.5"
-      },
-      "peerDependencies": {
-        "@dbos-inc/dbos-sdk": "*"
-      }
-    },
-    "packages/util-steps": {
-      "name": "@dbos-inc/util-steps",
-      "version": "0.0.0-placeholder",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "bcryptjs": "^2.4.3"
-      },
-      "devDependencies": {
-        "@types/bcryptjs": "^2.4.6",
-        "@types/jest": "^29.5.14",
-        "@types/pg": "^8.15.2",
-        "jest": "^29.7.0",
-        "pg": "^8.11.3",
         "typescript": "^5.4.5"
       },
       "peerDependencies": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,7 @@
 import type { PoolConfig } from 'pg';
 import { PostgresSystemDatabase, type SystemDatabase, type WorkflowStatusInternal } from './system_database';
 
-import { GlobalLogger as Logger } from './telemetry/logs';
+import { GlobalLogger } from './telemetry/logs';
 import { randomUUID } from 'node:crypto';
 import {
   type GetQueuedWorkflowsInput,
@@ -79,7 +79,7 @@ interface ClientEnqueueOptions {
  * DBOSClient is the main entry point for interacting with the DBOS system.
  */
 export class DBOSClient {
-  private readonly logger: Logger;
+  private readonly logger: GlobalLogger;
   private readonly systemDatabase: SystemDatabase;
   private readonly userDatabase: UserDatabase;
 
@@ -93,7 +93,7 @@ export class DBOSClient {
 
     systemDatabase ??= `${poolConfig.database}_dbos_sys`;
 
-    this.logger = new Logger();
+    this.logger = new GlobalLogger();
     this.systemDatabase = new PostgresSystemDatabase(poolConfig, systemDatabase, this.logger);
     this.userDatabase = new PGNodeUserDatabase(poolConfig);
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -6,6 +6,7 @@ import { UserDatabaseClient } from './user_database';
 import { AsyncLocalStorage } from 'async_hooks';
 import { DBOSInvalidWorkflowTransitionError } from './error';
 import Koa from 'koa';
+import { DBOSExecutor } from './dbos-executor';
 
 export interface StepStatus {
   stepID: number;
@@ -147,12 +148,15 @@ export async function runInStepContext<R>(
     maxAttempts: currentAttempt ? maxAttempts : undefined,
   };
 
+  const span = pctx.span;
+
   return await runWithParentContext(
     pctx,
     {
       stepStatus: stepStatus,
       curStepFunctionId: stepID,
       parentCtx: pctx,
+      logger: span ? new DBOSContextualLogger(DBOSExecutor.globalInstance!.logger, { span }) : pctx.logger,
     },
     callback,
   );

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,5 @@
 import { Span } from '@opentelemetry/sdk-trace-base';
-import { Logger as DBOSLogger } from './telemetry/logs';
+import { DBOSContextualLogger } from './telemetry/logs';
 import { IncomingHttpHeaders } from 'http';
 import { ParsedUrlQuery } from 'querystring';
 import { UserDatabaseClient } from './user_database';
@@ -17,7 +17,7 @@ export interface DBOSContextOptions {
   idAssignedForNextWorkflow?: string;
   queueAssignedForWorkflows?: string;
   span?: Span;
-  logger?: DBOSLogger;
+  logger?: DBOSContextualLogger;
   authenticatedUser?: string;
   authenticatedRoles?: string[];
   assumedRole?: string;

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -31,7 +31,7 @@ import { IsolationLevel, type TransactionConfig } from './transaction';
 import { type StepConfig } from './step';
 import { TelemetryCollector } from './telemetry/collector';
 import { Tracer } from './telemetry/traces';
-import { GlobalLogger as Logger } from './telemetry/logs';
+import { GlobalLogger } from './telemetry/logs';
 import { TelemetryExporter } from './telemetry/exporters';
 import type { TelemetryConfig } from './telemetry';
 import { Pool, type PoolClient, type PoolConfig, type QueryResultRow } from 'pg';
@@ -251,7 +251,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
 
   static systemDBSchemaName = 'dbos';
 
-  readonly logger: Logger;
+  readonly logger: GlobalLogger;
   readonly tracer: Tracer;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
   typeormEntities: Function[] = [];
@@ -291,7 +291,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
       // We always setup a collector to drain the signals queue, even if we don't have an exporter.
       this.telemetryCollector = new TelemetryCollector();
     }
-    this.logger = new Logger(this.telemetryCollector, this.config.telemetry.logs);
+    this.logger = new GlobalLogger(this.telemetryCollector, this.config.telemetry.logs);
     this.tracer = new Tracer(this.telemetryCollector);
 
     if (this.debugMode) {

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1151,6 +1151,7 @@ export class DBOS {
         }
       }
     } else {
+      const span = options.span;
       if (!options.span) {
         options.span = DBOS.#executor.tracer.startSpan('topContext', {
           operationUUID: options.idAssignedForNextWorkflow,
@@ -1161,7 +1162,11 @@ export class DBOS {
         });
       }
 
-      return runWithTopContext(options, callback);
+      try {
+        return await runWithTopContext(options, callback);
+      } finally {
+        options.span = span;
+      }
     }
   }
 

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1151,9 +1151,8 @@ export class DBOS {
         }
       }
     } else {
-      let span = options.span;
-      if (!span) {
-        span = DBOS.#executor.tracer.startSpan('topContext', {
+      if (!options.span) {
+        options.span = DBOS.#executor.tracer.startSpan('topContext', {
           operationUUID: options.idAssignedForNextWorkflow,
           operationType: options.operationType,
           authenticatedUser: options.authenticatedUser,

--- a/src/eventreceiver.ts
+++ b/src/eventreceiver.ts
@@ -1,5 +1,5 @@
 import { Tracer } from './telemetry/traces';
-import { GlobalLogger as Logger } from './telemetry/logs';
+import { GlobalLogger } from './telemetry/logs';
 import type {
   GetQueuedWorkflowsInput,
   GetWorkflowsInput,
@@ -39,7 +39,7 @@ export interface DBOSEventReceiverRegistration {
  */
 export interface DBOSExecutorContext {
   /** Logging service; @deprecated: Use `DBOS.logger` instead. */
-  readonly logger: Logger;
+  readonly logger: GlobalLogger;
   /** Tracing service; @deprecated: Use `DBOS.tracer` instead.  */
   readonly tracer: Tracer;
 

--- a/src/httpServer/middleware.ts
+++ b/src/httpServer/middleware.ts
@@ -3,7 +3,7 @@ import { Request, Response, NextFunction } from 'express';
 import { IncomingHttpHeaders } from 'http';
 
 import { ClassRegistration, RegistrationDefaults, getOrCreateClassRegistration } from '../decorators';
-import { Logger as DBOSLogger } from '../telemetry/logs';
+import { DBOSContextualLogger } from '../telemetry/logs';
 import { UserDatabaseClient } from '../user_database';
 import { OperationType } from '../dbos-executor';
 import { DBOS, getExecutor } from '../dbos';
@@ -22,7 +22,7 @@ export interface MiddlewareContext {
   readonly name: string; // Method (handler, transaction, workflow) name
   readonly requiredRole: string[]; // Roles required for the invoked operation, if empty perhaps auth is not required
 
-  readonly logger: DBOSLogger; // Logger, for logging from middleware
+  readonly logger: DBOSContextualLogger; // Logger, for logging from middleware
   readonly span: Span; // Existing span
 
   getConfig<T>(key: string, deflt: T | undefined): T | undefined; // Access to configuration information

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -7,7 +7,7 @@ import { ArgSources, APITypes } from './handlerTypes';
 import { GetWorkflowsInput, GetQueuedWorkflowsInput, StatusString } from '../workflow';
 import { DBOSDataValidationError, DBOSError, DBOSResponseError, isDataValidationError } from '../error';
 import { DBOSExecutor, OperationType } from '../dbos-executor';
-import { DBOSContextualLogger, GlobalLogger } from '../telemetry/logs';
+import { GlobalLogger } from '../telemetry/logs';
 import { getOrGenerateRequestID, MiddlewareDefaults, RequestIDHeader } from './middleware';
 import { SpanStatusCode, trace, ROOT_CONTEXT, defaultTextMapGetter } from '@opentelemetry/api';
 import * as net from 'net';
@@ -649,7 +649,7 @@ export class DBOSHttpServer {
               name: ro.name,
               requiredRole: ro.getRequiredRoles(),
               koaContext: koaCtxt,
-              logger: new DBOSContextualLogger(dbosExec.logger, { span }),
+              logger: dbosExec.ctxLogger,
               span,
               getConfig: (key: string, def) => {
                 return DBOS.getConfig(key, def);

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -7,7 +7,7 @@ import { ArgSources, APITypes } from './handlerTypes';
 import { GetWorkflowsInput, GetQueuedWorkflowsInput, StatusString } from '../workflow';
 import { DBOSDataValidationError, DBOSError, DBOSResponseError, isDataValidationError } from '../error';
 import { DBOSExecutor, OperationType } from '../dbos-executor';
-import { Logger as DBOSLogger, GlobalLogger as Logger } from '../telemetry/logs';
+import { DBOSContextualLogger, GlobalLogger } from '../telemetry/logs';
 import { getOrGenerateRequestID, MiddlewareDefaults, RequestIDHeader } from './middleware';
 import { SpanStatusCode, trace, ROOT_CONTEXT, defaultTextMapGetter } from '@opentelemetry/api';
 import * as net from 'net';
@@ -37,7 +37,7 @@ export class DBOSHttpServer {
   readonly app: Koa;
   readonly adminApp: Koa;
   readonly applicationRouter: Router;
-  readonly logger: Logger;
+  readonly logger: GlobalLogger;
   static nRegisteredEndpoints: number = 0;
   static instance?: DBOSHttpServer = undefined;
 
@@ -110,7 +110,7 @@ export class DBOSHttpServer {
     return appServer;
   }
 
-  static async checkPortAvailabilityIPv4Ipv6(port: number, logger: Logger) {
+  static async checkPortAvailabilityIPv4Ipv6(port: number, logger: GlobalLogger) {
     try {
       await this.checkPortAvailability(port, '127.0.0.1');
     } catch (error) {
@@ -649,7 +649,7 @@ export class DBOSHttpServer {
               name: ro.name,
               requiredRole: ro.getRequiredRoles(),
               koaContext: koaCtxt,
-              logger: new DBOSLogger(dbosExec.logger, { span }),
+              logger: new DBOSContextualLogger(dbosExec.logger, { span }),
               span,
               getConfig: (key: string, def) => {
                 return DBOS.getConfig(key, def);

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -18,7 +18,7 @@ import {
   event_dispatch_kv,
 } from '../schemas/system_db_schema';
 import { findPackageRoot, globalParams, cancellableSleep, INTERNAL_QUEUE_NAME, sleepms } from './utils';
-import { GlobalLogger as Logger } from './telemetry/logs';
+import { GlobalLogger } from './telemetry/logs';
 import knex, { Knex } from 'knex';
 import path from 'path';
 import { WorkflowQueue } from './wfqueue';
@@ -205,7 +205,7 @@ export interface ExistenceCheck {
   exists: boolean;
 }
 
-export async function migrateSystemDatabase(systemPoolConfig: PoolConfig, logger: Logger) {
+export async function migrateSystemDatabase(systemPoolConfig: PoolConfig, logger: GlobalLogger) {
   const migrationsDirectory = path.join(findPackageRoot(__dirname), 'migrations');
   const knexConfig = {
     client: 'pg',
@@ -620,7 +620,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
   constructor(
     readonly pgPoolConfig: PoolConfig,
     readonly systemDatabaseName: string,
-    readonly logger: Logger,
+    readonly logger: GlobalLogger,
     readonly sysDbPoolSize?: number,
   ) {
     // Craft a db string from the app db string, replacing the database name:

--- a/src/telemetry/logs.ts
+++ b/src/telemetry/logs.ts
@@ -136,7 +136,7 @@ export interface DLogger {
 }
 
 // Wrapper around our global logger. Expected to be instantiated by a new contexts so they can inject contextual metadata
-export class Logger implements DLogger {
+export class DBOSContextualLogger implements DLogger {
   readonly metadata: ContextualMetadata;
   constructor(
     private readonly globalLogger: GlobalLogger,

--- a/src/telemetry/logs.ts
+++ b/src/telemetry/logs.ts
@@ -135,33 +135,45 @@ export interface DLogger {
   error(inputError: unknown, metadata?: ContextualMetadata & StackTrace): void;
 }
 
-// Wrapper around our global logger. Expected to be instantiated by a new contexts so they can inject contextual metadata
 export class DBOSContextualLogger implements DLogger {
-  readonly metadata: ContextualMetadata;
+  readonly includeContextMetadata: boolean;
   constructor(
     private readonly globalLogger: GlobalLogger,
-    readonly ctx: { span: Span | (() => Span) },
+    readonly ctx: () => Span,
   ) {
-    this.metadata = {
-      span: typeof ctx.span === 'function' ? ctx.span() : ctx.span,
-      includeContextMetadata: this.globalLogger.addContextMetadata,
-    };
+    this.includeContextMetadata = this.globalLogger.addContextMetadata;
   }
 
   info(logEntry: unknown, metadata?: ContextualMetadata): void {
-    this.globalLogger.info(logEntry, metadata ?? this.metadata);
+    this.globalLogger.info(logEntry, {
+      includeContextMetadata: this.includeContextMetadata,
+      span: this.ctx(),
+      ...metadata,
+    });
   }
 
   debug(logEntry: unknown, metadata?: ContextualMetadata): void {
-    this.globalLogger.debug(logEntry, metadata ?? this.metadata);
+    this.globalLogger.debug(logEntry, {
+      includeContextMetadata: this.includeContextMetadata,
+      span: this.ctx(),
+      ...metadata,
+    });
   }
 
   warn(logEntry: unknown, metadata?: ContextualMetadata): void {
-    this.globalLogger.warn(logEntry, metadata ?? this.metadata);
+    this.globalLogger.warn(logEntry, {
+      includeContextMetadata: this.includeContextMetadata,
+      span: this.ctx(),
+      ...metadata,
+    });
   }
 
   error(inputError: unknown, metadata?: ContextualMetadata & StackTrace): void {
-    this.globalLogger.error(inputError, metadata ?? this.metadata);
+    this.globalLogger.error(inputError, {
+      includeContextMetadata: this.includeContextMetadata,
+      span: this.ctx(),
+      ...metadata,
+    });
   }
 }
 

--- a/src/user_database.ts
+++ b/src/user_database.ts
@@ -10,9 +10,9 @@ import {
 import { IsolationLevel, TransactionConfig } from './transaction';
 import { ValuesOf } from './utils';
 import { Knex } from 'knex';
-import { GlobalLogger as Logger } from './telemetry/logs';
+import { GlobalLogger } from './telemetry/logs';
 
-export async function createDBIfDoesNotExist(poolConfig: PoolConfig, logger: Logger) {
+export async function createDBIfDoesNotExist(poolConfig: PoolConfig, logger: GlobalLogger) {
   const pgUserClient = new Client(poolConfig);
   try {
     await pgUserClient.connect(); // Try to establish a connection

--- a/tests/dboslogger.test.ts
+++ b/tests/dboslogger.test.ts
@@ -20,10 +20,55 @@ describe('dbos-logger', () => {
     let foundWf = false;
     const lines = result.stdout.split('\n');
     for (const l of lines) {
-      if (/Info: WFID should be logged .*"operationUUID":"loggerWorkflowId"/.test(l)) foundWf = true;
-      if (/Info: Step should be logged .*"operationUUID":"loggerWorkflowId"/.test(l)) foundStep = true;
-      if (/Info: Transaction should be logged .*"operationUUID":"loggerWorkflowId"/.test(l)) foundTx = true;
+      if (
+        /Info: WFID should be logged/.test(l) &&
+        /"operationType":"workflow"/.test(l) &&
+        /"operationName":"loggingWorkflow"/ &&
+        /"operationUUID":"loggerWorkflowId"/.test(l) &&
+        /"authenticatedUser":""/.test(l) &&
+        /"authenticatedRoles":\[\]/.test(l) &&
+        /"assumedRole":""/.test(l)
+      ) {
+        foundWf = true;
+      }
+
+      if (
+        /Info: Step should be logged/.test(l) &&
+        /"operationType":"step"/.test(l) &&
+        /"operationName":"loggingStep"/ &&
+        /"operationUUID":"loggerWorkflowId"/.test(l) &&
+        /"authenticatedUser":""/.test(l) &&
+        /"authenticatedRoles":\[\]/.test(l) &&
+        /"assumedRole":""/.test(l)
+      ) {
+        foundStep = true;
+      }
+
+      if (
+        /Info: Transaction should be logged/.test(l) &&
+        /"operationType":"transaction"/.test(l) &&
+        /"operationName":"loggingTransaction"/ &&
+        /"operationUUID":"loggerWorkflowId"/.test(l) &&
+        /"authenticatedUser":""/.test(l) &&
+        /"authenticatedRoles":\[\]/.test(l) &&
+        /"assumedRole":""/.test(l)
+      ) {
+        foundTx = true;
+      }
     }
+
+    if (!foundWf || !foundStep || !foundTx) {
+      console.warn(
+        `
+*** This test is about to fail, something was not found. ***
+  Found workflow: ${foundWf}.
+  Found step: ${foundStep}.
+  Found transaction: ${foundTx}.
+The log was:\n${result.stdout}
+`,
+      );
+    }
+
     expect(foundWf).toBeTruthy();
     expect(foundStep).toBeTruthy();
     expect(foundTx).toBeTruthy();

--- a/tests/dboslogger.test.ts
+++ b/tests/dboslogger.test.ts
@@ -10,12 +10,24 @@ describe('dbos-logger', () => {
       stdio: ['inherit', 'pipe', 'pipe'], // Capture stdout and stderr
     });
 
-    //s Uncomment to see what happened above...
-    console.log('STDOUT:', result.stdout);
+    // Uncomment to see what happened above...
+    //console.log('STDOUT:', result.stdout);
     //console.error('STDERR:', result.stderr);
 
     // Check if the expected error appears in stderr
-    //expect(result.stderr).toContain('DBOSConflictingRegistrationError');
+    let foundTx = false;
+    let foundStep = false;
+    let foundWf = false;
+    const lines = result.stdout.split('\n');
+    for (const l of lines) {
+      if (/Info: WFID should be logged .*"operationUUID":"loggerWorkflowId"/.test(l)) foundWf = true;
+      if (/Info: Step should be logged .*"operationUUID":"loggerWorkflowId"/.test(l)) foundStep = true;
+      if (/Info: Transaction should be logged .*"operationUUID":"loggerWorkflowId"/.test(l)) foundTx = true;
+    }
+    expect(foundWf).toBeTruthy();
+    expect(foundStep).toBeTruthy();
+    expect(foundTx).toBeTruthy();
+
     return Promise.resolve();
   });
 });

--- a/tests/dboslogger.test.ts
+++ b/tests/dboslogger.test.ts
@@ -1,0 +1,21 @@
+import { spawnSync } from 'child_process';
+
+describe('dbos-logger', () => {
+  test('logFromWf', async () => {
+    // Run the TypeScript test script under ts-node
+    const result = spawnSync('npx', ['ts-node', './tests/logtodboslogger.ts'], {
+      encoding: 'utf-8',
+      cwd: process.cwd(),
+      env: { ...process.env },
+      stdio: ['inherit', 'pipe', 'pipe'], // Capture stdout and stderr
+    });
+
+    //s Uncomment to see what happened above...
+    console.log('STDOUT:', result.stdout);
+    //console.error('STDERR:', result.stderr);
+
+    // Check if the expected error appears in stderr
+    //expect(result.stderr).toContain('DBOSConflictingRegistrationError');
+    return Promise.resolve();
+  });
+});

--- a/tests/logtodboslogger.ts
+++ b/tests/logtodboslogger.ts
@@ -1,0 +1,46 @@
+import { DBOS } from '@dbos-inc/dbos-sdk';
+import { generateDBOSTestConfig } from './helpers';
+
+class WF {
+  @DBOS.step()
+  static async loggingStep() {
+    DBOS.logger.info(`Info: Step should be logged`);
+    return Promise.resolve(1);
+  }
+
+  @DBOS.transaction()
+  static async loggingTransaction() {
+    DBOS.logger.info(`Info: Transaction should be logged`);
+    return Promise.resolve(2);
+  }
+
+  @DBOS.workflow()
+  static async loggingWorkflow() {
+    DBOS.logger.info(`Info: WFID should be logged`);
+    return (await WF.loggingStep()) + (await WF.loggingTransaction());
+  }
+}
+
+async function main() {
+  const config = generateDBOSTestConfig();
+  /*
+  if (!config.telemetry.logs) {
+    config.telemetry.logs = {addContextMetadata: true};
+  }
+  config.telemetry.logs.addContextMetadata = true;
+  config.telemetry.logs.forceConsole = true;
+  */
+  DBOS.setConfig(config);
+  await DBOS.launch();
+  //await DBOS.withNextWorkflowID('loggerWorkflowId', async() =>{
+  DBOS.logger.info(`The computed answer is ${await WF.loggingWorkflow()}`);
+  //});
+  await DBOS.shutdown();
+}
+
+main()
+  .then()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/tests/logtodboslogger.ts
+++ b/tests/logtodboslogger.ts
@@ -1,5 +1,5 @@
 import { DBOS } from '@dbos-inc/dbos-sdk';
-import { generateDBOSTestConfig } from './helpers';
+import { generateDBOSTestConfig, setUpDBOSTestDb } from './helpers';
 
 class WF {
   @DBOS.step()
@@ -23,18 +23,20 @@ class WF {
 
 async function main() {
   const config = generateDBOSTestConfig();
-  /*
   if (!config.telemetry.logs) {
-    config.telemetry.logs = {addContextMetadata: true};
+    config.telemetry.logs = {};
   }
   config.telemetry.logs.addContextMetadata = true;
   config.telemetry.logs.forceConsole = true;
-  */
+  config.telemetry.logs.logLevel = 'debug';
+  config.telemetry.logs.silent = false;
+  await setUpDBOSTestDb(config);
+
   DBOS.setConfig(config);
   await DBOS.launch();
-  //await DBOS.withNextWorkflowID('loggerWorkflowId', async() =>{
-  DBOS.logger.info(`The computed answer is ${await WF.loggingWorkflow()}`);
-  //});
+  await DBOS.withNextWorkflowID('loggerWorkflowId', async () => {
+    DBOS.logger.info(`The computed answer is ${await WF.loggingWorkflow()}`);
+  });
   await DBOS.shutdown();
 }
 

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -7,7 +7,7 @@ import { GetQueuedWorkflowsInput, WorkflowHandle, WorkflowStatus } from '../src/
 import { randomUUID } from 'node:crypto';
 import { globalParams, sleepms } from '../src/utils';
 import { PostgresSystemDatabase } from '../src/system_database';
-import { GlobalLogger as Logger } from '../src/telemetry/logs';
+import { GlobalLogger } from '../src/telemetry/logs';
 import {
   getWorkflow,
   globalTimeout,
@@ -236,7 +236,7 @@ describe('workflow-management-tests', () => {
     const failResponse = await request(DBOS.getHTTPHandlersCallback()!).post('/fail/alice');
     expect(failResponse.statusCode).toBe(500);
 
-    const logger = new Logger();
+    const logger = new GlobalLogger();
     const sysdb = new PostgresSystemDatabase(config.poolConfig, config.system_database, logger);
     try {
       const input: GetWorkflowsInput = {};
@@ -542,7 +542,7 @@ describe('test-list-queues', () => {
       await e.wait();
     }
 
-    const logger = new Logger();
+    const logger = new GlobalLogger();
     const sysdb = new PostgresSystemDatabase(config.poolConfig, config.system_database, logger);
     try {
       let input: GetQueuedWorkflowsInput = {};
@@ -1221,7 +1221,7 @@ describe('test-list-steps', () => {
     const result2 = await handle.getResult();
     expect(result1).toEqual(result2);
 
-    const sysdb = new PostgresSystemDatabase(config.poolConfig, config.system_database, new Logger());
+    const sysdb = new PostgresSystemDatabase(config.poolConfig, config.system_database, new GlobalLogger());
     try {
       const wfs = await listWorkflows(sysdb, {});
       expect(wfs.length).toBe(2);


### PR DESCRIPTION
Add a test for the contextual information the logger is supposed to report.
Simplify this logger to get context dynamically, rather than creating new loggers.
Sanitize (IMO) the names of the loggers.
Fix the spans a bit, based on issues found by the test.

Also removes some dead stuff from package-lock.json