### PR TITLE
Make registrations consistent

### DIFF
--- a/packages/aws-s3-workflows/README.md
+++ b/packages/aws-s3-workflows/README.md
@@ -127,7 +127,7 @@ const s3callback: S3WorkflowCallbacks<UserFile, Opts> = {
 Finally, register and use the S3 workflows:
 
 ```typescript
-export const uploadWF = registerS3UploadWorkflow(s3callback, {}, { className: 'UserFile', name: 'uploadWF' });
+export const uploadWF = registerS3UploadWorkflow(s3callback, { className: 'UserFile', name: 'uploadWF' });
 ...
 await uploadWF(myFileRec, 'This is my file');
 ```
@@ -137,7 +137,7 @@ await uploadWF(myFileRec, 'This is my file');
 The `registerS3UploadWorkflow` function registers a workflow that stores a string to an S3 key, and runs the callback function to update the database. If anything goes wrong during the workflow, S3 will be cleaned up and the database will be unchanged by the workflow.
 
 ```typescript
-export const uploadWF = registerS3UploadWorkflow({ className: 'UserFile', name: 'uploadWF' }, s3callback);
+export const uploadWF = registerS3UploadWorkflow(s3callback, { className: 'UserFile', name: 'uploadWF' });
 ...
 await uploadWF(myFileRec, 'These contents should be saved to S3');
 ```
@@ -153,7 +153,7 @@ This workflow performs the following actions:
 The `registerS3DeleteWorkflow` function creates a workflow that removes a file from both S3 and the database.
 
 ```typescript
-export const deleteWF = registerS3DeleteWorkflow(s3callback, {}, { className: 'UserFile', name: 'deleteWF' });
+export const deleteWF = registerS3DeleteWorkflow(s3callback, { className: 'UserFile', name: 'deleteWF' });
 
 await deleteWF(fileDBRecord);
 ```
@@ -180,11 +180,7 @@ The workflow interaction generally proceeds as follows:
 The workflow can be initiated in the following way:
 
 ```typescript
-export const uploadPWF = registerS3PresignedUploadWorkflow(
-  s3callback,
-  {},
-  { className: 'UserFile', name: 'uploadPWF' },
-);
+export const uploadPWF = registerS3PresignedUploadWorkflow(s3callback, { className: 'UserFile', name: 'uploadPWF' });
 
 // Start the workflow
 const wfHandle = await DBOS.startWorkflow(uploadPWF)(

--- a/packages/aws-s3-workflows/README.md
+++ b/packages/aws-s3-workflows/README.md
@@ -127,7 +127,7 @@ const s3callback: S3WorkflowCallbacks<UserFile, Opts> = {
 Finally, register and use the S3 workflows:
 
 ```typescript
-export const uploadWF = registerS3UploadWorkflow({ className: 'UserFile', name: 'uploadWF' }, s3callback);
+export const uploadWF = registerS3UploadWorkflow(s3callback, {}, { className: 'UserFile', name: 'uploadWF' });
 ...
 await uploadWF(myFileRec, 'This is my file');
 ```
@@ -153,7 +153,7 @@ This workflow performs the following actions:
 The `registerS3DeleteWorkflow` function creates a workflow that removes a file from both S3 and the database.
 
 ```typescript
-export const deleteWF = registerS3DeleteWorkflow({ className: 'UserFile', name: 'deleteWF' }, s3callback);
+export const deleteWF = registerS3DeleteWorkflow(s3callback, {}, { className: 'UserFile', name: 'deleteWF' });
 
 await deleteWF(fileDBRecord);
 ```
@@ -180,7 +180,11 @@ The workflow interaction generally proceeds as follows:
 The workflow can be initiated in the following way:
 
 ```typescript
-export const uploadPWF = registerS3PresignedUploadWorkflow({ className: 'UserFile', name: 'uploadPWF' }, s3callback);
+export const uploadPWF = registerS3PresignedUploadWorkflow(
+  s3callback,
+  {},
+  { className: 'UserFile', name: 'uploadPWF' },
+);
 
 // Start the workflow
 const wfHandle = await DBOS.startWorkflow(uploadPWF)(

--- a/packages/aws-s3-workflows/src/s3_utils.test.ts
+++ b/packages/aws-s3-workflows/src/s3_utils.test.ts
@@ -196,13 +196,9 @@ const s3callback: S3WorkflowCallbacks<UserFile, Opts> = {
   },
 };
 
-export const uploadWF = registerS3UploadWorkflow(s3callback, {}, { className: 'UserFile', name: 'uploadWF' });
-export const uploadPWF = registerS3PresignedUploadWorkflow(
-  s3callback,
-  {},
-  { className: 'UserFile', name: 'uploadPWF' },
-);
-export const deleteWF = registerS3DeleteWorkflow(s3callback, {}, { className: 'UserFile', name: 'deleteWF' });
+export const uploadWF = registerS3UploadWorkflow(s3callback, { className: 'UserFile', name: 'uploadWF' });
+export const uploadPWF = registerS3PresignedUploadWorkflow(s3callback, { className: 'UserFile', name: 'uploadPWF' });
+export const deleteWF = registerS3DeleteWorkflow(s3callback, { className: 'UserFile', name: 'deleteWF' });
 
 describe('ses-tests', () => {
   let s3IsAvailable = true;

--- a/packages/aws-s3-workflows/src/s3_utils.test.ts
+++ b/packages/aws-s3-workflows/src/s3_utils.test.ts
@@ -196,9 +196,13 @@ const s3callback: S3WorkflowCallbacks<UserFile, Opts> = {
   },
 };
 
-export const uploadWF = registerS3UploadWorkflow({ className: 'UserFile', name: 'uploadWF' }, s3callback);
-export const uploadPWF = registerS3PresignedUploadWorkflow({ className: 'UserFile', name: 'uploadPWF' }, s3callback);
-export const deleteWF = registerS3DeleteWorkflow({ className: 'UserFile', name: 'deleteWF' }, s3callback);
+export const uploadWF = registerS3UploadWorkflow(s3callback, {}, { className: 'UserFile', name: 'uploadWF' });
+export const uploadPWF = registerS3PresignedUploadWorkflow(
+  s3callback,
+  {},
+  { className: 'UserFile', name: 'uploadPWF' },
+);
+export const deleteWF = registerS3DeleteWorkflow(s3callback, {}, { className: 'UserFile', name: 'deleteWF' });
 
 describe('ses-tests', () => {
   let s3IsAvailable = true;

--- a/packages/aws-s3-workflows/src/s3_utils.ts
+++ b/packages/aws-s3-workflows/src/s3_utils.ts
@@ -1,6 +1,6 @@
 import { type PresignedPost } from '@aws-sdk/s3-presigned-post';
 
-import { DBOS, WorkflowConfig } from '@dbos-inc/dbos-sdk';
+import { DBOS, FunctionName, WorkflowConfig } from '@dbos-inc/dbos-sdk';
 
 export interface FileRecord {
   key: string;
@@ -30,128 +30,131 @@ export interface S3WorkflowCallbacks<R extends FileRecord, Options = unknown> {
 
 /**
  * Create a workflow function for deleting S3 objects and removing the DB entry
- * @param options - Registration options for the workflow
  * @param callbacks - S3 operation implementation and database recordkeeping transactions
+ * @param config - Workflow configuration
+ * @param target - Target function name for registration
  */
 export function registerS3DeleteWorkflow<R extends FileRecord, Options = unknown>(
-  options: {
-    name?: string;
-    ctorOrProto?: object;
-    className?: string;
-    config?: WorkflowConfig;
-  },
   callbacks: S3WorkflowCallbacks<R, Options>,
+  config?: WorkflowConfig,
+  target?: FunctionName,
 ) {
-  return DBOS.registerWorkflow(async (fileDetails: R) => {
-    await callbacks.fileDeleted(fileDetails);
-    return await DBOS.runStep(
-      async () => {
-        return callbacks.deleteS3Object(fileDetails);
-      },
-      { name: 'deleteS3Object' },
-    );
-  }, options);
+  return DBOS.registerWorkflow(
+    async (fileDetails: R) => {
+      await callbacks.fileDeleted(fileDetails);
+      return await DBOS.runStep(
+        async () => {
+          return callbacks.deleteS3Object(fileDetails);
+        },
+        { name: 'deleteS3Object' },
+      );
+    },
+    { config },
+    target,
+  );
 }
 
 /**
  * Create a workflow function for uploading S3 contents from DBOS
- * @param options - Registration options for the workflow
  * @param callbacks - S3 operation implementation and database recordkeeping transactions
+ * @param config - Workflow configuration
+ * @param target - Target function name for registration
  */
 export function registerS3UploadWorkflow<R extends FileRecord, Options = unknown>(
-  options: {
-    name?: string;
-    ctorOrProto?: object;
-    className?: string;
-    config?: WorkflowConfig;
-  },
   callbacks: S3WorkflowCallbacks<R, Options>,
+  config?: WorkflowConfig,
+  target?: FunctionName,
 ) {
-  return DBOS.registerWorkflow(async (fileDetails: R, content: string, objOptions?: Options) => {
-    try {
-      await DBOS.runStep(
-        async () => {
-          await callbacks.putS3Contents(fileDetails, content, objOptions);
-        },
-        { name: 'putS3Contents' },
-      );
-    } catch (e) {
+  return DBOS.registerWorkflow(
+    async (fileDetails: R, content: string, objOptions?: Options) => {
       try {
         await DBOS.runStep(
           async () => {
-            return callbacks.deleteS3Object(fileDetails);
+            await callbacks.putS3Contents(fileDetails, content, objOptions);
           },
-          { name: 'deleteS3Object' },
+          { name: 'putS3Contents' },
         );
-      } catch (e2) {
-        DBOS.logger.debug(e2);
+      } catch (e) {
+        try {
+          await DBOS.runStep(
+            async () => {
+              return callbacks.deleteS3Object(fileDetails);
+            },
+            { name: 'deleteS3Object' },
+          );
+        } catch (e2) {
+          DBOS.logger.debug(e2);
+        }
+        throw e;
       }
-      throw e;
-    }
 
-    await callbacks.newActiveFile(fileDetails);
-    return fileDetails;
-  }, options);
+      await callbacks.newActiveFile(fileDetails);
+      return fileDetails;
+    },
+    { config },
+    target,
+  );
 }
 
 /**
  * Create a workflow function for uploading S3 contents externally, via a presigned URL
- * @param options - Registration options for the workflow
  * @param callbacks - S3 operation implementation and database recordkeeping transactions
+ * @param config - Workflow configuration
+ * @param target - Target function name for registration
  */
 export function registerS3PresignedUploadWorkflow<R extends FileRecord, Options = unknown>(
-  options: {
-    name?: string;
-    ctorOrProto?: object;
-    className?: string;
-    config?: WorkflowConfig;
-  },
   callbacks: S3WorkflowCallbacks<R, Options>,
+  config?: WorkflowConfig,
+  target?: FunctionName,
 ) {
-  return DBOS.registerWorkflow(async (fileDetails: R, timeoutSeconds: number, objOptions?: Options) => {
-    await callbacks.newPendingFile(fileDetails);
+  return DBOS.registerWorkflow(
+    async (fileDetails: R, timeoutSeconds: number, objOptions?: Options) => {
+      await callbacks.newPendingFile(fileDetails);
 
-    const upkey = await DBOS.runStep(
-      async () => {
-        return await callbacks.createPresignedPost(fileDetails, timeoutSeconds, objOptions);
-      },
-      { name: 'createPresignedPost' },
-    );
-    await DBOS.setEvent<PresignedPost>('uploadkey', upkey);
+      const upkey = await DBOS.runStep(
+        async () => {
+          return await callbacks.createPresignedPost(fileDetails, timeoutSeconds, objOptions);
+        },
+        { name: 'createPresignedPost' },
+      );
+      await DBOS.setEvent<PresignedPost>('uploadkey', upkey);
 
-    try {
-      const res = await DBOS.recv<boolean>('uploadfinish', timeoutSeconds + 60);
-
-      if (!res) {
-        throw new Error('S3 operation timed out or canceled');
-      }
-
-      // Validate the file, if we have code for that
-      if (callbacks.validateS3Upload) {
-        await DBOS.runStep(
-          async () => {
-            await callbacks.validateS3Upload!(fileDetails);
-          },
-          { name: 'validateFileUpload' },
-        );
-      }
-
-      await callbacks?.fileActivated(fileDetails);
-    } catch (e) {
       try {
-        await callbacks.fileDeleted(fileDetails);
-        await DBOS.runStep(
-          async () => {
-            await callbacks.deleteS3Object(fileDetails);
-          },
-          { name: 'deleteS3Object' },
-        );
-      } catch (e2) {
-        DBOS.logger.debug(e2);
-      }
-      throw e;
-    }
+        const res = await DBOS.recv<boolean>('uploadfinish', timeoutSeconds + 60);
 
-    return fileDetails;
-  }, options);
+        if (!res) {
+          throw new Error('S3 operation timed out or canceled');
+        }
+
+        // Validate the file, if we have code for that
+        if (callbacks.validateS3Upload) {
+          await DBOS.runStep(
+            async () => {
+              await callbacks.validateS3Upload!(fileDetails);
+            },
+            { name: 'validateFileUpload' },
+          );
+        }
+
+        await callbacks?.fileActivated(fileDetails);
+      } catch (e) {
+        try {
+          await callbacks.fileDeleted(fileDetails);
+          await DBOS.runStep(
+            async () => {
+              await callbacks.deleteS3Object(fileDetails);
+            },
+            { name: 'deleteS3Object' },
+          );
+        } catch (e2) {
+          DBOS.logger.debug(e2);
+        }
+        throw e;
+      }
+
+      return fileDetails;
+    },
+    { config },
+    target,
+  );
 }

--- a/packages/aws-s3-workflows/src/s3_utils.ts
+++ b/packages/aws-s3-workflows/src/s3_utils.ts
@@ -31,7 +31,7 @@ export interface S3WorkflowCallbacks<R extends FileRecord, Options = unknown> {
 /**
  * Create a workflow function for deleting S3 objects and removing the DB entry
  * @param callbacks - S3 operation implementation and database recordkeeping transactions
- * @param config - Workflow configuration and arget function name for registration
+ * @param config - Workflow configuration and target function name for registration
  */
 export function registerS3DeleteWorkflow<R extends FileRecord, Options = unknown>(
   callbacks: S3WorkflowCallbacks<R, Options>,

--- a/packages/confluent-kafka-receive/index.ts
+++ b/packages/confluent-kafka-receive/index.ts
@@ -1,4 +1,4 @@
-import { DBOS, DBOSLifecycleCallback } from '@dbos-inc/dbos-sdk';
+import { DBOS, DBOSLifecycleCallback, FunctionName } from '@dbos-inc/dbos-sdk';
 
 import { KafkaJS, LibrdKafkaError as KafkaError } from '@confluentinc/kafka-javascript';
 
@@ -130,19 +130,12 @@ export class ConfluentKafkaReceiver implements DBOSLifecycleCallback {
   registerConsumer<This, Return>(
     func: (this: This, ...args: KafkaArgs) => Promise<Return>,
     topics: ConsumerTopics,
-    options: {
-      ctorOrProto?: object;
-      className?: string;
-      name?: string;
+    options: FunctionName & {
       queueName?: string;
       config?: KafkaJS.ConsumerConstructorConfig;
     } = {},
   ) {
-    const { regInfo } = DBOS.associateFunctionWithInfo(this, func, {
-      ctorOrProto: options.ctorOrProto,
-      className: options.className,
-      name: options.name ?? func.name,
-    });
+    const { regInfo } = DBOS.associateFunctionWithInfo(this, func, options);
 
     const kafkaRegInfo = regInfo as KafkaMethodConfig;
     kafkaRegInfo.topics = Array.isArray(topics) ? topics : [topics];

--- a/packages/kafkajs-receive/index.ts
+++ b/packages/kafkajs-receive/index.ts
@@ -1,4 +1,4 @@
-import { DBOS, DBOSLifecycleCallback } from '@dbos-inc/dbos-sdk';
+import { DBOS, DBOSLifecycleCallback, FunctionName } from '@dbos-inc/dbos-sdk';
 import { Kafka as KafkaJS, Consumer, ConsumerConfig, KafkaConfig, KafkaMessage, KafkaJSProtocolError } from 'kafkajs';
 
 export type KafkaArgs = [string, number, KafkaMessage];
@@ -117,19 +117,12 @@ export class KafkaReceiver implements DBOSLifecycleCallback {
   registerConsumer<This, Return>(
     func: (this: This, ...args: KafkaArgs) => Promise<Return>,
     topics: ConsumerTopics,
-    options: {
-      ctorOrProto?: object;
-      className?: string;
-      name?: string;
+    options: FunctionName & {
       queueName?: string;
       config?: ConsumerConfig;
     } = {},
   ) {
-    const { regInfo } = DBOS.associateFunctionWithInfo(this, func, {
-      ctorOrProto: options.ctorOrProto,
-      className: options.className,
-      name: options.name ?? func.name,
-    });
+    const { regInfo } = DBOS.associateFunctionWithInfo(this, func, options);
 
     const kafkaRegInfo = regInfo as KafkaMethodConfig;
     kafkaRegInfo.topics = Array.isArray(topics) ? topics : [topics];

--- a/packages/koa-serve/README.md
+++ b/packages/koa-serve/README.md
@@ -26,7 +26,6 @@ The example above registers an HTTP `GET` endpoint. `postApi`, `deleteApi`, `put
 The Koa server can be started by your main startup function. Note the order of operations below:
 
 ```typescript
-DBOS.registerLifecycleCallback(dhttp); // Registers the HTTP function provider with DBOS
 await DBOS.launch(); // Starts DBOS components and begins any necessary recovery
 DBOS.logRegisteredEndpoints(); // Optional - list out all of the registered DBOS event receivers and URLs
 

--- a/packages/koa-serve/src/dboshttp.ts
+++ b/packages/koa-serve/src/dboshttp.ts
@@ -150,7 +150,7 @@ export class DBOSHTTPBase implements DBOSLifecycleCallback {
 
   /** Parameter decorator indicating which source to use (URL, BODY, etc) for arg data */
   static argSource(source: ArgSources) {
-    return function (target: object, propertyKey: string | symbol, parameterIndex: number) {
+    return function (target: object, propertyKey: PropertyKey, parameterIndex: number) {
       const curParam = DBOS.associateParamWithInfo(
         DBOSHTTP,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
@@ -190,11 +190,11 @@ export class DBOSHTTPBase implements DBOSLifecycleCallback {
     }
   }
 
-  static argRequired(target: object, propertyKey: string | symbol, parameterIndex: number) {
+  static argRequired(target: object, propertyKey: PropertyKey, parameterIndex: number) {
     ArgRequired(target, propertyKey, parameterIndex);
   }
 
-  static argOptional(target: object, propertyKey: string | symbol, parameterIndex: number) {
+  static argOptional(target: object, propertyKey: PropertyKey, parameterIndex: number) {
     ArgOptional(target, propertyKey, parameterIndex);
   }
 

--- a/packages/koa-serve/src/dboskoa.ts
+++ b/packages/koa-serve/src/dboskoa.ts
@@ -72,6 +72,11 @@ function assertCurrentKoaContextStore(): DBOSKoaLocalCtx {
 }
 
 export class DBOSKoa extends DBOSHTTPBase {
+  constructor() {
+    super();
+    DBOS.registerLifecycleCallback(this);
+  }
+
   static get koaContext(): Koa.Context {
     return assertCurrentKoaContextStore().koaCtxt;
   }

--- a/packages/koa-serve/tests/argsource.test.ts
+++ b/packages/koa-serve/tests/argsource.test.ts
@@ -23,7 +23,6 @@ describe('httpserver-argsource-tests', () => {
   });
 
   beforeEach(async () => {
-    DBOS.registerLifecycleCallback(dhttp);
     const _classes = [ArgTestEndpoints];
     await DBOS.launch();
     app = new Koa();

--- a/packages/koa-serve/tests/auth.test.ts
+++ b/packages/koa-serve/tests/auth.test.ts
@@ -29,7 +29,6 @@ describe('httpserver-defsec-tests', () => {
   });
 
   beforeEach(async () => {
-    DBOS.registerLifecycleCallback(dhttp);
     const _classes = [TestEndpointDefSec, SecondClass];
     await DBOS.launch();
     await DBOS.queryUserDB(`DROP TABLE IF EXISTS ${testTableName};`);

--- a/packages/koa-serve/tests/basic.test.ts
+++ b/packages/koa-serve/tests/basic.test.ts
@@ -50,7 +50,6 @@ describe('decoratorless-api-tests', () => {
 
   beforeEach(async () => {
     middlewareCounter = middlewareCounter2 = middlewareCounterG = 0;
-    DBOS.registerLifecycleCallback(dhttp);
     await DBOS.launch();
     DBOS.logRegisteredEndpoints();
     app = new Koa();

--- a/packages/koa-serve/tests/cors.test.ts
+++ b/packages/koa-serve/tests/cors.test.ts
@@ -20,7 +20,6 @@ describe('http-cors-tests', () => {
   });
 
   beforeEach(async () => {
-    DBOS.registerLifecycleCallback(dhttp);
     await DBOS.launch();
     app = new Koa();
     appRouter = new Router();

--- a/packages/koa-serve/tests/endpoints.test.ts
+++ b/packages/koa-serve/tests/endpoints.test.ts
@@ -40,7 +40,6 @@ describe('httpserver-tests', () => {
   });
 
   beforeEach(async () => {
-    DBOS.registerLifecycleCallback(dhttp);
     const _classes = [TestEndpoints];
     await DBOS.launch();
     await DBOS.queryUserDB(`DROP TABLE IF EXISTS ${testTableName};`);

--- a/packages/koa-serve/tests/steps.test.ts
+++ b/packages/koa-serve/tests/steps.test.ts
@@ -1,0 +1,79 @@
+import { DBOS } from '@dbos-inc/dbos-sdk';
+import Koa from 'koa';
+import Router from '@koa/router';
+import { DBOSKoa } from '../src';
+
+import request from 'supertest';
+
+const dhttp = new DBOSKoa();
+
+function customstep() {
+  return function decorator<This, Args extends unknown[], Return>(
+    target: object,
+    propertyKey: PropertyKey,
+    descriptor: TypedPropertyDescriptor<(this: This, ...args: Args) => Promise<Return>>,
+  ) {
+    if (!descriptor.value) {
+      throw Error('Use of decorator when original method is undefined');
+    }
+
+    descriptor.value = DBOS.registerStep(descriptor.value, {
+      name: String(propertyKey),
+      ctorOrProto: target,
+    });
+
+    return descriptor;
+  };
+}
+
+describe('registerstep', () => {
+  let app: Koa;
+  let appRouter: Router;
+
+  beforeAll(async () => {});
+
+  afterAll(async () => {});
+
+  beforeEach(async () => {
+    DBOS.setConfig({ name: 'koa-step-test' });
+    await DBOS.launch();
+    app = new Koa();
+    appRouter = new Router();
+    dhttp.registerWithApp(app, appRouter);
+  });
+
+  afterEach(async () => {
+    await DBOS.shutdown();
+  });
+
+  test('use-customstep-and-koa', async () => {
+    const u1 = await KnexKoa.insertOneWay('joe');
+    expect(u1.user).toBe('joe');
+    const u2 = await KnexKoa.insertTheOtherWay('jack');
+    expect(u2.user).toBe('jack');
+
+    const response1 = await request(app.callback()).get('/api/i1?user=john');
+    expect(response1.statusCode).toBe(200);
+    const response2 = await request(app.callback()).get('/api/i2?user=jeremy');
+    expect(response2.statusCode).toBe(200);
+    const response3 = await request(app.callback()).get('/api/i1');
+    expect(response3.statusCode).toBe(400);
+    const response4 = await request(app.callback()).get('/api/i2');
+    expect(response4.statusCode).toBe(400);
+  });
+});
+
+@DBOSKoa.defaultArgValidate
+class KnexKoa {
+  @customstep()
+  @dhttp.getApi('/api/i2')
+  static async insertTheOtherWay(user: string) {
+    return Promise.resolve({ user, now: Date.now() });
+  }
+
+  @dhttp.getApi('/api/i1')
+  @customstep()
+  static async insertOneWay(user: string) {
+    return Promise.resolve({ user, now: Date.now() });
+  }
+}

--- a/packages/koa-serve/tests/transactions.test.ts
+++ b/packages/koa-serve/tests/transactions.test.ts
@@ -57,7 +57,6 @@ describe('KnexDataSource', () => {
 
   beforeEach(async () => {
     DBOS.setConfig({ name: 'koa-knex-ds-test' });
-    DBOS.registerLifecycleCallback(dhttp);
     await DBOS.launch();
     app = new Koa();
     appRouter = new Router();

--- a/packages/sqs-receive/README.md
+++ b/packages/sqs-receive/README.md
@@ -82,7 +82,6 @@ class SQSEventProcessor {
 Finally, launch DBOS. Your SQS receiver is automatically registered with DBOS on construction.
 
 ```typescript
-DBOS.registerLifecycleCallback(sqsReceiver);
 await DBOS.launch();
 ```
 

--- a/packages/typeorm-datasource/index.ts
+++ b/packages/typeorm-datasource/index.ts
@@ -1,5 +1,5 @@
 import { PoolConfig } from 'pg';
-import { DBOS, DBOSWorkflowConflictError } from '@dbos-inc/dbos-sdk';
+import { DBOS, DBOSWorkflowConflictError, FunctionName } from '@dbos-inc/dbos-sdk';
 import {
   type DataSourceTransactionHandler,
   createTransactionCompletionSchemaPG,
@@ -293,19 +293,9 @@ export class TypeOrmDataSource implements DBOSDataSource<TypeORMTransactionConfi
    */
   registerTransaction<This, Args extends unknown[], Return>(
     func: (this: This, ...args: Args) => Promise<Return>,
-    config?: TypeORMTransactionConfig,
-    target?: { ctorOrProto?: object; className?: string },
+    config?: TypeORMTransactionConfig & FunctionName,
   ): (this: This, ...args: Args) => Promise<Return> {
-    return registerTransaction(
-      this.name,
-      func,
-      {
-        name: config?.name ?? func.name,
-        className: target?.className,
-        ctorOrProto: target?.ctorOrProto,
-      },
-      config,
-    );
+    return registerTransaction(this.name, func, config);
   }
 
   /**
@@ -323,14 +313,11 @@ export class TypeOrmDataSource implements DBOSDataSource<TypeORMTransactionConfi
         throw new Error('Use of decorator when original method is undefined');
       }
 
-      descriptor.value = ds.registerTransaction(
-        descriptor.value,
-        {
-          ...config,
-          name: config?.name ?? String(propertyKey),
-        },
-        { ctorOrProto: target },
-      );
+      descriptor.value = ds.registerTransaction(descriptor.value, {
+        ...config,
+        name: config?.name ?? String(propertyKey),
+        ctorOrProto: target,
+      });
 
       return descriptor;
     };

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -181,12 +181,12 @@ export async function runTransaction<T>(
 export function registerTransaction<This, Args extends unknown[], Return, Config extends FunctionName>(
   dsName: string,
   func: (this: This, ...args: Args) => Promise<Return>,
-  options?: Config,
+  config?: Config,
 ): (this: This, ...args: Args) => Promise<Return> {
   const dsn = dsName ?? '<default>';
 
-  const funcName = options?.name ?? func.name;
-  const reg = registerAndWrapDBOSFunctionByName(options?.ctorOrProto, options?.className, funcName, func);
+  const funcName = config?.name ?? func.name;
+  const reg = registerAndWrapDBOSFunctionByName(config?.ctorOrProto, config?.className, funcName, func);
 
   const invokeWrapper = async function (this: This, ...rawArgs: Args): Promise<Return> {
     const ds = getTransactionalDataSource(dsn);
@@ -200,7 +200,7 @@ export function registerTransaction<This, Args extends unknown[], Return, Config
       }
 
       return await runWithDataSourceContext(undefined, 0, async () => {
-        return await ds.invokeTransactionFunction(options, this, callFunc, ...rawArgs);
+        return await ds.invokeTransactionFunction(config, this, callFunc, ...rawArgs);
       });
     }
 
@@ -229,7 +229,7 @@ export function registerTransaction<This, Args extends unknown[], Return, Config
       const res = await DBOSExecutor.globalInstance!.runInternalStep<Return>(
         async () => {
           return await runWithDataSourceContext(span, callnum, async () => {
-            return await ds.invokeTransactionFunction(options, this, callFunc, ...rawArgs);
+            return await ds.invokeTransactionFunction(config, this, callFunc, ...rawArgs);
           });
         },
         funcName,

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -47,7 +47,7 @@ export interface DataSourceTransactionHandler {
  * This is the suggested interface guideline for presenting to the end user, but not
  *   strictly required.
  */
-export interface DBOSDataSource<Config> {
+export interface DBOSDataSource<Config extends { name?: string }> {
   readonly name: string;
 
   /**

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -4,6 +4,7 @@ import { functionIDGetIncrement, getNextWFID, runWithDataSourceContext } from '.
 import { DBOS } from './dbos';
 import { DBOSExecutor, OperationType } from './dbos-executor';
 import {
+  FunctionName,
   getTransactionalDataSource,
   registerAndWrapDBOSFunctionByName,
   registerFunctionWrapper,
@@ -181,11 +182,7 @@ export async function runTransaction<T>(
 export function registerTransaction<This, Args extends unknown[], Return>(
   dsName: string,
   func: (this: This, ...args: Args) => Promise<Return>,
-  options: {
-    ctorOrProto?: object;
-    className?: string;
-    name: string;
-  },
+  options: FunctionName,
   config?: unknown,
 ): (this: This, ...args: Args) => Promise<Return> {
   const dsn = dsName ?? '<default>';

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1375,10 +1375,9 @@ export class DBOS {
    */
   static registerScheduled<This, Return>(
     func: (this: This, ...args: ScheduledArgs) => Promise<Return>,
-    config: SchedulerConfig,
-    target: FunctionName = {},
+    config: SchedulerConfig & FunctionName,
   ) {
-    ScheduledReceiver.registerScheduled(func, config, target);
+    ScheduledReceiver.registerScheduled(func, config);
   }
 
   //////
@@ -1395,7 +1394,8 @@ export class DBOS {
       descriptor: TypedPropertyDescriptor<(this: This, ...args: ScheduledArgs) => Promise<Return>>,
     ) {
       if (descriptor.value) {
-        DBOS.registerScheduled(descriptor.value, config, {
+        DBOS.registerScheduled(descriptor.value, {
+          ...config,
           ctorOrProto: target,
           name: String(propertyKey),
         });
@@ -1439,18 +1439,15 @@ export class DBOS {
    */
   static registerWorkflow<This, Args extends unknown[], Return>(
     func: (this: This, ...args: Args) => Promise<Return>,
-    options: FunctionName & {
-      config?: WorkflowConfig;
-    } = {},
-    target?: FunctionName,
+    config?: FunctionName & WorkflowConfig,
   ): (this: This, ...args: Args) => Promise<Return> {
     const { registration } = registerAndWrapDBOSFunctionByName(
-      target?.ctorOrProto ?? options.ctorOrProto,
-      target?.className ?? options.className,
-      target?.name ?? options.name ?? func.name,
+      config?.ctorOrProto,
+      config?.className,
+      config?.name ?? func.name,
       func,
     );
-    return DBOS.#getWorkflowInvoker(registration, options.config);
+    return DBOS.#getWorkflowInvoker(registration, config);
   }
 
   static async #invokeWorkflow<This, Args extends unknown[], Return>(

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1845,6 +1845,8 @@ export class DBOS {
       return callFunc.call(this, ...rawArgs);
     };
 
+    registerFunctionWrapper(invokeWrapper, reg.registration);
+
     Object.defineProperty(invokeWrapper, 'name', { value: name });
     return invokeWrapper;
   }

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1805,12 +1805,11 @@ export class DBOS {
    *   This ensures "at least once" execution of the step, and that the step will not
    *    be executed again once the checkpoint is recorded
    * @param func - The function to register as a step
-   * @param config - Configuration information for the step, particularly the retry policy
-   * @param config.name - The name of the step; if not provided, the function name will be used
+   * @param config - Configuration information for the step, particularly the retry policy and name
    */
   static registerStep<This, Args extends unknown[], Return>(
     func: (this: This, ...args: Args) => Promise<Return>,
-    config: StepConfig & { name?: string } = {},
+    config: StepConfig & FunctionName = {},
   ): (this: This, ...args: Args) => Promise<Return> {
     const name = config.name ?? func.name;
     const invokeWrapper = async function (this: This, ...rawArgs: Args): Promise<Return> {

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1428,6 +1428,7 @@ export class DBOS {
 
       descriptor.value = invoker;
       registration.wrappedFunction = invoker;
+      registerFunctionWrapper(invoker, registration);
 
       return descriptor;
     }
@@ -1646,6 +1647,7 @@ export class DBOS {
 
       descriptor.value = invokeWrapper;
       registration.wrappedFunction = invokeWrapper;
+      registerFunctionWrapper(invokeWrapper, registration);
 
       Object.defineProperty(invokeWrapper, 'name', {
         value: registration.name,
@@ -1714,6 +1716,7 @@ export class DBOS {
 
       descriptor.value = invokeWrapper;
       registration.wrappedFunction = invokeWrapper;
+      registerFunctionWrapper(invokeWrapper, registration);
 
       Object.defineProperty(invokeWrapper, 'name', {
         value: registration.name,
@@ -1806,6 +1809,7 @@ export class DBOS {
 
       descriptor.value = invokeWrapper;
       registration.wrappedFunction = invokeWrapper;
+      registerFunctionWrapper(invokeWrapper, registration);
 
       Object.defineProperty(invokeWrapper, 'name', {
         value: registration.name,

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -638,10 +638,12 @@ export function getOrCreateMethodArgsRegistration(
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
     let designParamTypes: Function[] | undefined = undefined;
     if (target) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-      designParamTypes = Reflect.getMetadata('design:paramtypes', target, funcName as string | symbol) as
-        | Function[]
-        | undefined;
+      designParamTypes = Reflect.getMetadata(
+        'design:paramtypes',
+        target,
+        funcName as string | symbol,
+      ) as // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+      Function[] | undefined;
     }
     if (designParamTypes) {
       mParameters = designParamTypes.map((value, index) => new MethodParameter(index, value));

--- a/src/httpServer/handler.ts
+++ b/src/httpServer/handler.ts
@@ -21,7 +21,7 @@ export class HandlerParameter extends MethodParameter {
 ///////////////////////////////////
 
 export function ArgSource(source: ArgSources) {
-  return function (target: object, propertyKey: string | symbol, parameterIndex: number) {
+  return function (target: object, propertyKey: PropertyKey, parameterIndex: number) {
     const existingParameters = getOrCreateMethodArgsRegistration(target, propertyKey);
 
     const curParam = existingParameters[parameterIndex] as HandlerParameter;

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,8 @@ export {
 export { StepConfig } from './step';
 
 export {
+  FunctionName,
+
   // Method Decorators
   DBOSInitializer,
   DBOSMethodMiddlewareInstaller,

--- a/src/paramdecorators.ts
+++ b/src/paramdecorators.ts
@@ -87,7 +87,7 @@ class ValidationMiddleware implements DBOSMethodMiddlewareInstaller {
 
 const validationMiddleware = new ValidationMiddleware();
 
-export function ArgRequired(target: object, propertyKey: string | symbol, parameterIndex: number) {
+export function ArgRequired(target: object, propertyKey: PropertyKey, parameterIndex: number) {
   const curParam = associateParameterWithExternal(
     VALIDATOR,
     target,
@@ -102,7 +102,7 @@ export function ArgRequired(target: object, propertyKey: string | symbol, parame
   registerMiddlewareInstaller(validationMiddleware);
 }
 
-export function ArgOptional(target: object, propertyKey: string | symbol, parameterIndex: number) {
+export function ArgOptional(target: object, propertyKey: PropertyKey, parameterIndex: number) {
   const curParam = associateParameterWithExternal(
     VALIDATOR,
     target,
@@ -119,7 +119,7 @@ export function ArgOptional(target: object, propertyKey: string | symbol, parame
 
 export function ArgDate() {
   // TODO a little more info about it - is it a date or timestamp precision?
-  return function (target: object, propertyKey: string | symbol, parameterIndex: number) {
+  return function (target: object, propertyKey: PropertyKey, parameterIndex: number) {
     const curParam = associateParameterWithExternal(
       'type',
       target,
@@ -137,7 +137,7 @@ export function ArgDate() {
 }
 
 export function ArgVarchar(length: number) {
-  return function (target: object, propertyKey: string | symbol, parameterIndex: number) {
+  return function (target: object, propertyKey: PropertyKey, parameterIndex: number) {
     const curParam = associateParameterWithExternal(
       'type',
       target,
@@ -186,7 +186,7 @@ interface LoggerArgInfo {
 
 export const LOGGER = 'log';
 
-export function SkipLogging(target: object, propertyKey: string | symbol, parameterIndex: number) {
+export function SkipLogging(target: object, propertyKey: PropertyKey, parameterIndex: number) {
   const curParam = associateParameterWithExternal(
     LOGGER,
     target,
@@ -200,7 +200,7 @@ export function SkipLogging(target: object, propertyKey: string | symbol, parame
 }
 
 export function LogMask(mask: LogMasks) {
-  return function (target: object, propertyKey: string | symbol, parameterIndex: number) {
+  return function (target: object, propertyKey: PropertyKey, parameterIndex: number) {
     const curParam = associateParameterWithExternal(
       LOGGER,
       target,

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -1,5 +1,5 @@
 import { DBOS, DBOSExternalState } from '..';
-import { DBOSLifecycleCallback, MethodRegistrationBase } from '../decorators';
+import { DBOSLifecycleCallback, FunctionName, MethodRegistrationBase } from '../decorators';
 import { TimeMatcher } from './crontab';
 
 ////
@@ -202,11 +202,7 @@ export class ScheduledReceiver implements DBOSLifecycleCallback {
   static registerScheduled<This, Return>(
     func: (this: This, ...args: ScheduledArgs) => Promise<Return>,
     config: SchedulerConfig,
-    target: {
-      ctorOrProto?: object;
-      className?: string;
-      name?: string;
-    } = {},
+    target: FunctionName = {},
   ) {
     const { regInfo } = DBOS.associateFunctionWithInfo(SCHEDULER_EVENT_SERVICE_NAME, func, {
       ctorOrProto: target.ctorOrProto,

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -201,13 +201,12 @@ export class ScheduledReceiver implements DBOSLifecycleCallback {
 
   static registerScheduled<This, Return>(
     func: (this: This, ...args: ScheduledArgs) => Promise<Return>,
-    config: SchedulerConfig,
-    target: FunctionName = {},
+    config: SchedulerConfig & FunctionName,
   ) {
     const { regInfo } = DBOS.associateFunctionWithInfo(SCHEDULER_EVENT_SERVICE_NAME, func, {
-      ctorOrProto: target.ctorOrProto,
-      className: target.className,
-      name: target.name ?? func.name,
+      ctorOrProto: config.ctorOrProto,
+      className: config.className,
+      name: config.name ?? func.name,
     });
 
     const schedRegInfo = regInfo as SchedulerConfig;

--- a/tests/datasourceextensions.test.ts
+++ b/tests/datasourceextensions.test.ts
@@ -28,9 +28,7 @@ import { DBOSJSON, sleepms } from '../src/utils';
 /*
  * Knex user data access interface
  */
-interface KnexTransactionConfig extends PGTransactionConfig {
-  name?: string;
-}
+type KnexTransactionConfig = PGTransactionConfig & { name?: string };
 
 // This stuff is all specific to PG DBs...
 //  We are also agnostic about whether there are admin credentials to do this, or not...
@@ -304,27 +302,17 @@ export class DBOSKnexDS implements DBOSDataSource<KnexTransactionConfig> {
 
   registerTransaction<This, Args extends unknown[], Return>(
     func: (this: This, ...args: Args) => Promise<Return>,
-    config?: KnexTransactionConfig,
-    target?: FunctionName,
+    config?: KnexTransactionConfig & FunctionName,
   ): (this: This, ...args: Args) => Promise<Return> {
-    return registerTransaction(
-      this.name,
-      func,
-      {
-        name: target?.name ?? config?.name ?? func.name,
-        className: target?.className,
-        ctorOrProto: target?.ctorOrProto,
-      },
-      config,
-    );
+    return registerTransaction(this.name, func, config);
   }
 
   static registerTransaction<This, Args extends unknown[], Return>(
     dsname: string,
     func: (this: This, ...args: Args) => Promise<Return>,
-    config?: KnexTransactionConfig,
+    config?: KnexTransactionConfig & FunctionName,
   ): (this: This, ...args: Args) => Promise<Return> {
-    return registerTransaction(dsname, func, { name: config?.name ?? func.name }, config);
+    return registerTransaction(dsname, func, config);
   }
 
   // Custom TX decorator
@@ -340,14 +328,7 @@ export class DBOSKnexDS implements DBOSDataSource<KnexTransactionConfig> {
         throw Error('Use of decorator when original method is undefined');
       }
 
-      descriptor.value = ds.registerTransaction(
-        descriptor.value,
-        {
-          ...config,
-          name: config?.name ?? String(propertyKey),
-        },
-        { ctorOrProto: target },
-      );
+      descriptor.value = ds.registerTransaction(descriptor.value, config);
 
       return descriptor;
     };

--- a/tests/datasourceextensions.test.ts
+++ b/tests/datasourceextensions.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { PoolConfig } from 'pg';
 import knex, { Knex } from 'knex';
-import { DBOS } from '../src';
+import { DBOS, FunctionName } from '../src';
 import {
   type DataSourceTransactionHandler,
   createTransactionCompletionSchemaPG,
@@ -305,13 +305,13 @@ export class DBOSKnexDS implements DBOSDataSource<KnexTransactionConfig> {
   registerTransaction<This, Args extends unknown[], Return>(
     func: (this: This, ...args: Args) => Promise<Return>,
     config?: KnexTransactionConfig,
-    target?: { ctorOrProto?: object; className?: string },
+    target?: FunctionName,
   ): (this: This, ...args: Args) => Promise<Return> {
     return registerTransaction(
       this.name,
       func,
       {
-        name: config?.name ?? func.name,
+        name: target?.name ?? config?.name ?? func.name,
         className: target?.className,
         ctorOrProto: target?.ctorOrProto,
       },

--- a/tests/decorator-free.test.ts
+++ b/tests/decorator-free.test.ts
@@ -109,8 +109,11 @@ TestClass.wfRunStepStatic = DBOS.registerWorkflow(TestClass.wfRunStepStatic, { n
 TestClass.wfRegRetryStatic = DBOS.registerWorkflow(TestClass.wfRegRetryStatic, { name: 'TestClass.wfRegRetryStatic' });
 
 /* eslint-disable @typescript-eslint/unbound-method */
-TestClass.prototype.stepTest = DBOS.registerStep(TestClass.prototype.stepTest);
-TestClass.prototype.retryTest = DBOS.registerStep(TestClass.prototype.retryTest, { retriesAllowed: true });
+TestClass.prototype.stepTest = DBOS.registerStep(TestClass.prototype.stepTest, { ctorOrProto: TestClass.prototype });
+TestClass.prototype.retryTest = DBOS.registerStep(TestClass.prototype.retryTest, {
+  retriesAllowed: true,
+  ctorOrProto: TestClass.prototype,
+});
 TestClass.prototype.wfRegStep = DBOS.registerWorkflow(TestClass.prototype.wfRegStep, {
   name: 'TestClass.prototype.wfRegStep',
   ctorOrProto: TestClass,

--- a/tests/decorator-free.test.ts
+++ b/tests/decorator-free.test.ts
@@ -109,10 +109,9 @@ TestClass.wfRunStepStatic = DBOS.registerWorkflow(TestClass.wfRunStepStatic, { n
 TestClass.wfRegRetryStatic = DBOS.registerWorkflow(TestClass.wfRegRetryStatic, { name: 'TestClass.wfRegRetryStatic' });
 
 /* eslint-disable @typescript-eslint/unbound-method */
-TestClass.prototype.stepTest = DBOS.registerStep(TestClass.prototype.stepTest, { ctorOrProto: TestClass.prototype });
+TestClass.prototype.stepTest = DBOS.registerStep(TestClass.prototype.stepTest);
 TestClass.prototype.retryTest = DBOS.registerStep(TestClass.prototype.retryTest, {
   retriesAllowed: true,
-  ctorOrProto: TestClass.prototype,
 });
 TestClass.prototype.wfRegStep = DBOS.registerWorkflow(TestClass.prototype.wfRegStep, {
   name: 'TestClass.prototype.wfRegStep',


### PR DESCRIPTION
Make naming options consistent.
Do not rely on names for steps, transactions in the new scheme; those names are not necessarily unique (no temp workflow constraint).
Fix a bug in step registration w/ other decorators.
registerLifecycleCallback called consistently by the library, not the user.
A few other registration cleanups.