### PR TITLE
fix OTLPExporterConfig interface

### DIFF
--- a/src/telemetry/exporters.ts
+++ b/src/telemetry/exporters.ts
@@ -5,10 +5,11 @@ import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-proto';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import type { ReadableLogRecord } from '@opentelemetry/sdk-logs';
 import { ExportResult, ExportResultCode } from '@opentelemetry/core';
+import { toStringSet } from '../utils';
 
 export interface OTLPExporterConfig {
-  logsEndpoint?: string[];
-  tracesEndpoint?: string[];
+  logsEndpoint?: string | string[];
+  tracesEndpoint?: string | string[];
 }
 
 export interface ITelemetryExporter {
@@ -19,9 +20,10 @@ export interface ITelemetryExporter {
 export class TelemetryExporter implements ITelemetryExporter {
   private readonly tracesExporters: OTLPTraceExporter[] = [];
   private readonly logsExporters: OTLPLogExporter[] = [];
+
   constructor(config: OTLPExporterConfig) {
     if (config.tracesEndpoint) {
-      for (const endpoint of config.tracesEndpoint) {
+      for (const endpoint of toStringSet(config.tracesEndpoint)) {
         this.tracesExporters.push(
           new OTLPTraceExporter({
             url: endpoint,
@@ -30,8 +32,9 @@ export class TelemetryExporter implements ITelemetryExporter {
         console.log(`Traces will be exported to ${endpoint}`);
       }
     }
+
     if (config.logsEndpoint) {
-      for (const endpoint of config.logsEndpoint) {
+      for (const endpoint of toStringSet(config.logsEndpoint)) {
         this.logsExporters.push(
           new OTLPLogExporter({
             url: endpoint,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -211,3 +211,7 @@ export function interceptStreams(onMessage: (msg: string, stream: 'stdout' | 'st
   process.stdout.write = intercept('stdout', originalStdoutWrite);
   process.stderr.write = intercept('stderr', originalStderrWrite);
 }
+
+export function toStringSet(endpoint: string | string[] | undefined): Set<string> {
+  return endpoint ? new Set(Array.isArray(endpoint) ? endpoint : [endpoint]) : new Set();
+}

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -13,12 +13,14 @@ import {
   constructPoolConfig,
   dbosConfigFilePath,
   parseSSLConfig,
+  processConfigFile,
+  readConfigFile,
 } from '../../src/dbos-runtime/config';
 import { DBOSRuntimeConfig, defaultEntryPoint } from '../../src/dbos-runtime/runtime';
-import { DBOSConfigKeyTypeError, DBOSInitializationError } from '../../src/error';
-import { DBOSExecutor, DBOSConfig, DBOSConfigInternal } from '../../src/dbos-executor';
-import { get } from 'lodash';
-import { DBOS, DBOSClient } from '../../src';
+import { DBOSInitializationError } from '../../src/error';
+import { DBOSConfig, DBOSConfigInternal } from '../../src/dbos-executor';
+import { DBOSClient } from '../../src';
+import { setUpDBOSTestDb } from '../helpers';
 
 describe('dbos-config', () => {
   const mockCLIOptions = { port: NaN, loglevel: 'info' };
@@ -50,7 +52,7 @@ describe('dbos-config', () => {
   });
 
   describe('Configuration loading', () => {
-    test('translates otlp endpoints from string to list', () => {
+    test('loadConfigFile translates otlp endpoints from string to list', () => {
       const mockConfigFile = `
         database:
             hostname: \${DOESNOTEXISTS}
@@ -71,6 +73,21 @@ describe('dbos-config', () => {
       const cfg: ConfigFile = loadConfigFile(dbosConfigFilePath);
       expect(cfg.telemetry?.OTLPExporter?.tracesEndpoint).toEqual(['http://otel-collector:4317/from-file']);
       expect(cfg.telemetry?.OTLPExporter?.logsEndpoint).toEqual(['http://otel-collector:4317/logs']);
+    });
+
+    test('processConfigFile translates otlp endpoints from string to list', () => {
+      const mockConfigFile = `
+        name: 'test-app'
+        telemetry:
+            OTLPExporter:
+                tracesEndpoint: http://otel-collector:4317/from-file
+                logsEndpoint: http://otel-collector:4317/logs
+        `;
+      jest.spyOn(utils, 'readFileSync').mockReturnValue(mockConfigFile);
+
+      const configFile = readConfigFile();
+      const [config] = processConfigFile(configFile, {});
+      expect(config.telemetry.OTLPExporter?.tracesEndpoint).toEqual(['http://otel-collector:4317/from-file']);
     });
   });
 
@@ -1058,6 +1075,10 @@ describe('dbos-config', () => {
   });
 
   describe('databaseUrl-no-password', () => {
+    beforeAll(async () => {
+      await setUpDBOSTestDb({});
+    });
+
     test('No error when database_url is provided without password', async () => {
       const expected_url = 'postgresql://postgres@localhost:5432/dbostest?sslmode=disable';
       const config: DBOSConfig = {

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -619,6 +619,7 @@ describe('dbos-config', () => {
       const [translatedDBOSConfig, translatedRuntimeConfig] = translatePublicDBOSconfig(dbosConfig, true);
       expect(translatedDBOSConfig).toEqual({
         name: dbosConfig.name, // provided name -- no config file was found
+        databaseUrl: 'postgres://jon:doe@mother:2345/dbostest?sslmode=require&sslrootcert=my_cert&connect_timeout=7',
         poolConfig: {
           host: 'mother',
           port: 2345,
@@ -634,6 +635,7 @@ describe('dbos-config', () => {
         userDbclient: UserDatabaseName.PRISMA,
         telemetry: {
           logs: {
+            addContextMetadata: undefined,
             logLevel: dbosConfig.logLevel,
             forceConsole: true,
           },


### PR DESCRIPTION
The properties of `OTLPExporterConfig` were defined as `string[] | undefined` but the schema for `dbos-config.yaml` were defined as `string | undefined`. 

This PR updates `OTLPExporterConfig` properties to be `string | string[] | undefined` and modifies config parsing code to handle single strings and arrays of strings.

Also fixes an issue where we don't return the database url in `translatePublicDBOSconfig`