### PR TITLE
Max Recovery Attempts

### DIFF
--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -174,7 +174,7 @@ workflowCommands
   .option('-e, --end-time <string>', 'Retrieve workflows starting before this timestamp (ISO 8601 format)')
   .option(
     '-S, --status <string>',
-    'Retrieve workflows with this status (PENDING, SUCCESS, ERROR, RETRIES_EXCEEDED, ENQUEUED, or CANCELLED)',
+    'Retrieve workflows with this status (PENDING, SUCCESS, ERROR, ENQUEUED, CANCELLED, or MAX_RECOVERY_ATTEMPTS_EXCEEDED)',
   )
   .option('-v, --application-version <string>', 'Retrieve workflows with this application version')
   .option('--request', 'Retrieve workflow request information (DEPRECATED)')
@@ -336,7 +336,7 @@ queueCommands
   .option('-e, --end-time <string>', 'Retrieve functions starting before this timestamp (ISO 8601 format)')
   .option(
     '-S, --status <string>',
-    'Retrieve functions with this status (PENDING, SUCCESS, ERROR, RETRIES_EXCEEDED, ENQUEUED, or CANCELLED)',
+    'Retrieve functions with this status (PENDING, SUCCESS, ERROR, ENQUEUED, CANCELLED, or MAX_RECOVERY_ATTEMPTS_EXCEEDED)',
   )
   .option('-l, --limit <number>', 'Limit the results returned')
   .option('-q, --queue <string>', 'Retrieve functions run on this queue')

--- a/src/error.ts
+++ b/src/error.ts
@@ -98,12 +98,12 @@ export class DBOSFailLoadOperationsError extends DBOSError {
   }
 }
 
-const DeadLetterQueueError = 18;
-export class DBOSDeadLetterQueueError extends DBOSError {
+const MaxRecoveryAttemptsExceededError = 18;
+export class DBOSMaxRecoveryAttemptsExceededError extends DBOSError {
   constructor(workflowID: string, maxRetries: number) {
     super(
-      `Workflow ${workflowID} has been moved to the dead-letter queue after exceeding the maximum of ${maxRetries} retries`,
-      DeadLetterQueueError,
+      `Workflow ${workflowID} has exceeded its maximum of ${maxRetries} execution or recovery attempts. Further attempts to execute or recover it will fail.`,
+      MaxRecoveryAttemptsExceededError,
     );
   }
 }

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -319,7 +319,7 @@ async function insertWorkflowStatus(
           END,
           updated_at = EXCLUDED.updated_at,
           executor_id = CASE 
-            WHEN workflow_status.status != '${StatusString.ENQUEUED}' 
+            WHEN EXCLUDED.status != '${StatusString.ENQUEUED}' 
             THEN EXCLUDED.executor_id 
             ELSE workflow_status.executor_id 
           END

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -25,7 +25,7 @@ export interface WorkflowConfig {
 
 export interface WorkflowStatus {
   readonly workflowID: string;
-  readonly status: string; // The status of the workflow.  One of PENDING, SUCCESS, ERROR, RETRIES_EXCEEDED, ENQUEUED, or CANCELLED.
+  readonly status: string; // The status of the workflow.  One of PENDING, SUCCESS, ERROR, ENQUEUED, CANCELLED, or MAX_RECOVERY_ATTEMPTS_EXCEEDED.
   readonly workflowName: string; // The name of the workflow function.
   readonly workflowClassName: string; // The class name holding the workflow function.
   readonly workflowConfigName?: string; // The name of the configuration, if the class needs configuration
@@ -58,7 +58,7 @@ export interface GetWorkflowsInput {
   authenticatedUser?: string; // The user who ran the workflow.
   startTime?: string; // Timestamp in ISO 8601 format
   endTime?: string; // Timestamp in ISO 8601 format
-  status?: 'PENDING' | 'SUCCESS' | 'ERROR' | 'RETRIES_EXCEEDED' | 'CANCELLED' | 'ENQUEUED'; // The status of the workflow.
+  status?: 'PENDING' | 'SUCCESS' | 'ERROR' | 'MAX_RECOVERY_ATTEMPTS_EXCEEDED' | 'CANCELLED' | 'ENQUEUED'; // The status of the workflow.
   applicationVersion?: string; // The application version that ran this workflow.
   limit?: number; // Return up to this many workflows IDs. IDs are ordered by workflow creation time.
   offset?: number; // Skip this many workflows IDs. IDs are ordered by workflow creation time.
@@ -72,7 +72,7 @@ export interface GetQueuedWorkflowsInput {
   workflowName?: string; // The name of the workflow function
   startTime?: string; // Timestamp in ISO 8601 format
   endTime?: string; // Timestamp in ISO 8601 format
-  status?: 'PENDING' | 'SUCCESS' | 'ERROR' | 'RETRIES_EXCEEDED' | 'CANCELLED' | 'ENQUEUED'; // The status of the workflow.
+  status?: 'PENDING' | 'SUCCESS' | 'ERROR' | 'MAX_RECOVERY_ATTEMPTS_EXCEEDED' | 'CANCELLED' | 'ENQUEUED'; // The status of the workflow.
   limit?: number; // Return up to this many workflows IDs. IDs are ordered by workflow creation time.
   queueName?: string; // The queue
   offset?: number; // Skip this many workflows IDs. IDs are ordered by workflow creation time.
@@ -109,8 +109,8 @@ export const StatusString = {
   SUCCESS: 'SUCCESS',
   /** Workflow complete with error thrown */
   ERROR: 'ERROR',
-  /** Workflow has been retried the maximum number of times, without completing (SUCCESS/ERROR) */
-  RETRIES_EXCEEDED: 'RETRIES_EXCEEDED',
+  /** Workflow has exceeded its maximum number of execution or recovery attempts */
+  MAX_RECOVERY_ATTEMPTS_EXCEEDED: 'MAX_RECOVERY_ATTEMPTS_EXCEEDED',
   /** Workflow is being, or has been, cancelled */
   CANCELLED: 'CANCELLED',
   /** Workflow is on a `WorkflowQueue` and has not yet started */

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -138,13 +138,9 @@ describe('recovery-tests', () => {
 
     // Send to DLQ and verify it enters the DLQ status.
     await recoverPendingWorkflows();
-    let result = await systemDBClient.query<{ status: string; recovery_attempts: number }>(
-      `SELECT status, recovery_attempts FROM dbos.workflow_status WHERE workflow_uuid=$1`,
-      [handle.workflowID],
-    );
-    // recovery_attempts is set before checking the number of attempts/retry
-    expect(result.rows[0].recovery_attempts).toBe(String(LocalRecovery.maxRecoveryAttempts + 2));
-    expect(result.rows[0].status).toBe(StatusString.MAX_RECOVERY_ATTEMPTS_EXCEEDED);
+    let status = await handle.getStatus();
+    expect(status?.recoveryAttempts).toBe(LocalRecovery.maxRecoveryAttempts + 2);
+    expect(status?.status).toBe(StatusString.MAX_RECOVERY_ATTEMPTS_EXCEEDED);
 
     // Verify a direct invocation errors
     await expect(
@@ -153,28 +149,21 @@ describe('recovery-tests', () => {
 
     // Resume the workflow. Verify it returns to PENDING status without error and attempts are reset.
     const resumedHandle = await DBOS.resumeWorkflow(handle.workflowID);
-    result = await systemDBClient.query<{ status: string; recovery_attempts: number }>(
-      `SELECT status, recovery_attempts FROM dbos.workflow_status WHERE workflow_uuid=$1`,
-      [handle.workflowID],
-    );
-    expect(result.rows[0].recovery_attempts).toBe(String(0));
-    expect(result.rows[0].status).toBe(StatusString.ENQUEUED);
+    status = await resumedHandle.getStatus();
+    expect(status?.recoveryAttempts).toBe(0);
+    expect(status?.status).toBe(StatusString.ENQUEUED);
+
+    // Complete the blocked workflow. Verify it succeeds.
+    LocalRecovery.deadLetterResolve();
+    await handle.getResult();
+    await resumedHandle.getResult();
+    status = await resumedHandle.getStatus();
+    expect(status?.status).toBe(StatusString.SUCCESS);
 
     // Verify a direct invocation no longer errors
     await expect(
       DBOS.startWorkflow(LocalRecovery, { workflowID: handle.workflowID }).deadLetterWorkflow(),
     ).resolves.toBeDefined();
-
-    // Complete the blocked workflow. Verify it succeeds with two attempts (the resumption and the direct invocation).
-    LocalRecovery.deadLetterResolve();
-    await handle.getResult();
-    await resumedHandle.getResult();
-    result = await systemDBClient.query<{ status: string; recovery_attempts: number }>(
-      `SELECT status, recovery_attempts FROM dbos.workflow_status WHERE workflow_uuid=$1`,
-      [handle.workflowID],
-    );
-    expect(result.rows[0].recovery_attempts).toBe(String(1));
-    expect(result.rows[0].status).toBe(StatusString.SUCCESS);
   });
 
   test('enqueued-dead-letter-queue', async () => {


### PR DESCRIPTION
Consistently refer to "Max Recovery Attempts" instead of DLQ, which was confusing terminology.

Also fix issues where enqueueing a workflow should not change its recovery attempts or executor ID.