### PR TITLE
Drop Node 23 from test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20', '22', '23', '24']
+        node-version: ['20', '22', '24']
 
     services:
       # Postgres service container


### PR DESCRIPTION
Node 23 exited support June 2025

Note, odd number Node releases are only supported for about 8 months. Generally, production apps are only supposed to use supported LTS releases which are always even numbered. We add supported odd numbered versions to our test matrix primarily as a jump on the next LTS release. (i.e. if there's an issue w/ Node 23, it will also be an issue w/ Node 24).