### PR TITLE
Handle config.name correctly

### DIFF
--- a/src/conductor/conductor.ts
+++ b/src/conductor/conductor.ts
@@ -7,6 +7,7 @@ import { GetQueuedWorkflowsInput } from '../workflow';
 import { hostname } from 'node:os';
 import { json as streamJSON } from 'stream/consumers';
 import { globalTimeout } from '../dbos-runtime/workflow_management';
+import assert from 'node:assert';
 
 export class Conductor {
   url: string;
@@ -25,7 +26,8 @@ export class Conductor {
     readonly conductorKey: string,
     readonly conductorURL: string,
   ) {
-    const appName = globalParams.appName;
+    const appName = dbosExec.appName;
+    assert(appName, 'Application name must be set in configuration in order to use DBOS Conductor');
     const cleanConductorURL = conductorURL.replace(/\/+$/, '');
     this.url = `${cleanConductorURL}/websocket/${appName}/${conductorKey}`;
   }

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -273,6 +273,10 @@ export class DBOSExecutor {
     DBOSExecutor.globalInstance = this;
   }
 
+  get appName(): string | undefined {
+    return this.config.name;
+  }
+
   #configureDbClient() {
     const userDbClient = this.config.userDbClient;
     const userDBConfig: PoolConfig = getClientConfig(this.config.databaseUrl);

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -233,6 +233,7 @@ export function translateDbosConfig(options: DBOSConfig, forceConsole: boolean =
   }
 
   return {
+    name: options.name,
     databaseUrl,
     userDbPoolSize: options.userDatabasePoolSize,
     systemDatabaseUrl,

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -261,10 +261,6 @@ export class DBOS {
     DBOS.#port = runtimeConfig.port;
     DBOS.#userDbClient = internalConfig.userDbClient;
 
-    if (globalParams.appName === '' && internalConfig.name) {
-      globalParams.appName = internalConfig.name;
-    }
-
     DBOSExecutor.createInternalQueue();
     DBOSExecutor.globalInstance = new DBOSExecutor(internalConfig, { debugMode });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,6 @@ export const globalParams = {
   wasComputed: false, // Was app version set or computed? Stored procs don't support computed versions.
   executorID: process.env.DBOS__VMID || 'local', // The one true source of executorID
   appID: process.env.DBOS__APPID || '', // The one true source of appID
-  appName: '', // The one true source of appName
   dbosVersion: loadDbosVersion(), // The version of the DBOS library
 };
 export const sleepms = (ms: number) => new Promise((r) => setTimeout(r, ms));

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -470,6 +470,7 @@ describe('dbos-config', () => {
         name: 'dbostest',
       });
       expect(internalConfig).toEqual({
+        name: 'dbostest',
         databaseUrl: 'postgresql://postgres:dbos@localhost:5432/dbostest?connect_timeout=10&sslmode=disable',
         userDbPoolSize: undefined,
         systemDatabaseUrl:
@@ -498,6 +499,7 @@ describe('dbos-config', () => {
         true,
       );
       expect(internalConfig).toEqual({
+        name: 'dbostest',
         databaseUrl: 'postgresql://postgres:dbos@localhost:5432/dbostest?connect_timeout=10&sslmode=disable',
         userDbPoolSize: undefined,
         systemDatabaseUrl:
@@ -523,6 +525,7 @@ describe('dbos-config', () => {
         databaseUrl: 'postgres://jon:doe@mother:2345/dbostest?sslmode=require&sslrootcert=my_cert&connect_timeout=7',
       });
       expect(internalConfig).toEqual({
+        name: undefined,
         databaseUrl: 'postgres://jon:doe@mother:2345/dbostest?sslmode=require&sslrootcert=my_cert&connect_timeout=7',
         userDbPoolSize: undefined,
         systemDatabaseUrl:
@@ -549,6 +552,7 @@ describe('dbos-config', () => {
         systemDatabaseUrl: 'postgres://foo:bar@father:1234/blahblahblah',
       });
       expect(internalConfig).toEqual({
+        name: undefined,
         databaseUrl: 'postgres://jon:doe@mother:2345/dbostest?sslmode=require&sslrootcert=my_cert&connect_timeout=7',
         userDbPoolSize: undefined,
         systemDatabaseUrl: 'postgres://foo:bar@father:1234/blahblahblah',


### PR DESCRIPTION
`translateDbosConfig` was dropping the app name on the floor. 

As part of this change, I removed `globalParams.appName` which was only used by `Conductor`. Since `Conductor` has a reference to DBOSExecutor, I added an `appName` getter to that.