### PR TITLE
Remove dbos start with entrypoints

### DIFF
--- a/dbos-config.schema.json
+++ b/dbos-config.schema.json
@@ -166,11 +166,12 @@
         },
         "port": {
           "type": "number",
-          "description": "The port number of the application server (Default: 3000)"
+          "description": "The port number of the application server (Default: 3000)",
+          "deprecated": true
         },
         "admin_port": {
           "type": "number",
-          "description": "The port number of the admin server (Default: 3001 or the app server port + 1)"
+          "description": "The port number of the admin server (Default: 3001)"
         },
         "start": {
           "type": "array",

--- a/dbos-config.schema.json
+++ b/dbos-config.schema.json
@@ -161,7 +161,8 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "deprecated": true
         },
         "port": {
           "type": "number",

--- a/src/context.ts
+++ b/src/context.ts
@@ -42,18 +42,18 @@ export interface DBOSLocalCtx extends DBOSContextOptions {
   koaContext?: Koa.Context;
 }
 
-export function isWithinWorkflowCtx(ctx: DBOSLocalCtx) {
+function isWithinWorkflowCtx(ctx: DBOSLocalCtx) {
   if (ctx.workflowId === undefined) return false;
   return true;
 }
 
-export function isInStepCtx(ctx: DBOSLocalCtx) {
+function isInStepCtx(ctx: DBOSLocalCtx) {
   if (ctx.workflowId === undefined) return false;
   if (ctx.curStepFunctionId) return true;
   return false;
 }
 
-export function isInTxnCtx(ctx: DBOSLocalCtx) {
+function isInTxnCtx(ctx: DBOSLocalCtx) {
   if (ctx.workflowId === undefined) return false;
   if (ctx.curTxFunctionId) return true;
   return false;
@@ -66,7 +66,7 @@ export function isInWorkflowCtx(ctx: DBOSLocalCtx) {
   return true;
 }
 
-export const asyncLocalCtx = new AsyncLocalStorage<DBOSLocalCtx>();
+const asyncLocalCtx = new AsyncLocalStorage<DBOSLocalCtx>();
 
 export function getCurrentContextStore(): DBOSLocalCtx | undefined {
   return asyncLocalCtx.getStore();

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -306,7 +306,7 @@ export const createTransactionCompletionTablePG = `
   );
 `;
 
-export function getPGErrorCode(error: unknown): string | undefined {
+function getPGErrorCode(error: unknown): string | undefined {
   return error && typeof error === 'object' && 'code' in error ? (error.code as string) : undefined;
 }
 
@@ -320,10 +320,4 @@ export function isPGKeyConflictError(error: unknown): boolean {
 
 export function isPGFailedSqlTransactionError(error: unknown): boolean {
   return getPGErrorCode(error) === '25P02';
-}
-
-export type PGDBNotification = Notification;
-export type PGDBNotificationCallback = (n: PGDBNotification) => void;
-export interface PGDBNotificationListener {
-  close(): Promise<void>;
 }

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -109,8 +109,8 @@ import {
 import { getClientConfig } from './utils';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface DBOSNull {}
-export const dbosNull: DBOSNull = {};
+interface DBOSNull {}
+const dbosNull: DBOSNull = {};
 
 export const DBOS_QUEUE_MIN_PRIORITY = 1;
 export const DBOS_QUEUE_MAX_PRIORITY = 2 ** 31 - 1; // 2,147,483,647

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import { DBOSRuntime } from './runtime';
 import {
   ConfigFile,
   getDatabaseUrl,
@@ -44,20 +43,17 @@ function getDbosVersion(): string {
 program
   .command('start')
   .description('Start the server')
-  .option('-p, --port <number>', 'Specify the port number')
   .option('-l, --loglevel <string>', 'Specify log level')
   .option('-d, --appDir <string>', 'Specify the application root directory')
-  .option('--app-version <string>', 'override DBOS__APPVERSION environment variable')
-  .option('--no-app-version', 'ignore DBOS__APPVERSION environment variable')
-  .action(async (options: { port?: number; loglevel?: string; appDir?: string; appVersion?: string | boolean }) => {
+  .action(async (options: { loglevel?: string; appDir?: string }) => {
     const config = readConfigFile(options.appDir);
     const dbosConfig = getDbosConfig(config, { logLevel: options.loglevel });
-    const runtimeConfig = getRuntimeConfig(config, options);
+    const runtimeConfig = getRuntimeConfig(config);
 
     // If no start commands are provided, start the DBOS runtime
     if (runtimeConfig.start.length === 0) {
-      const runtime = new DBOSRuntime(dbosConfig, runtimeConfig);
-      await runtime.initAndStart();
+      console.error('No start commands provided in the configuration file.');
+      exit(1);
     } else {
       const logger = getGlobalLogger(dbosConfig);
       for (const command of runtimeConfig.start) {
@@ -90,14 +86,11 @@ program
   .requiredOption('-u, --uuid <string>', 'Specify the workflow UUID to replay')
   .option('-l, --loglevel <string>', 'Specify log level')
   .option('-d, --appDir <string>', 'Specify the application root directory')
-  .option('--app-version <string>', 'override DBOS__APPVERSION environment variable')
-  .option('--no-app-version', 'ignore DBOS__APPVERSION environment variable')
   .action(
     async (options: {
       uuid: string; // Workflow UUID
       loglevel?: string;
       appDir?: string;
-      appVersion?: string | boolean;
     }) => {
       const config = readConfigFile(options.appDir);
       const dbosConfig = getDbosConfig(config, { logLevel: options.loglevel, forceConsole: true });

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -253,17 +253,18 @@ export function translateDbosConfig(options: DBOSConfig, forceConsole: boolean =
   };
 }
 
-export function getRuntimeConfig(config: ConfigFile, options: { port?: number } = {}): DBOSRuntimeConfig {
-  return translateRuntimeConfig(config.runtimeConfig, options.port);
+export function getRuntimeConfig(config: ConfigFile): DBOSRuntimeConfig {
+  return translateRuntimeConfig(config.runtimeConfig);
 }
 
-export function translateRuntimeConfig(config: Partial<DBOSRuntimeConfig> = {}, port?: number): DBOSRuntimeConfig {
+export function translateRuntimeConfig(config: Partial<DBOSRuntimeConfig> = {}): DBOSRuntimeConfig {
+  // TODO: remove the parsing of entrypoints once debugWorkflow is updated to not use it
   const entrypoints = new Set<string>();
   config.entrypoints?.forEach((entry) => entrypoints.add(entry));
   if (entrypoints.size === 0) {
     entrypoints.add(defaultEntryPoint);
   }
-  port ??= config.port ?? 3000;
+  const port = config.port ?? 3000;
   return {
     entrypoints: [...entrypoints],
     port: port,

--- a/src/dbos-runtime/runtime.ts
+++ b/src/dbos-runtime/runtime.ts
@@ -1,14 +1,8 @@
-import { DBOSExecutor, DBOSConfigInternal } from '../dbos-executor';
-import { DBOSHttpServer } from '../httpServer/server';
 import * as fs from 'fs';
 import { isObject } from 'lodash';
 import { DBOSFailLoadOperationsError } from '../error';
 import path from 'node:path';
-import { Server } from 'http';
 import { pathToFileURL } from 'url';
-import { ScheduledReceiver } from '../scheduler/scheduler';
-import { wfQueueRunner } from '../wfqueue';
-import { DBOS } from '../dbos';
 
 interface ModuleExports {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -26,61 +20,8 @@ export interface DBOSRuntimeConfig {
 export const defaultEntryPoint = 'dist/operations.js';
 
 export class DBOSRuntime {
-  private dbosConfig: DBOSConfigInternal;
-  private dbosExec?: DBOSExecutor = undefined;
-  private servers: { appServer?: Server; adminServer: Server } | undefined;
-  private scheduler: ScheduledReceiver = new ScheduledReceiver();
-  private wfQueueRunner?: Promise<void> = undefined;
-
-  constructor(
-    dbosConfig: DBOSConfigInternal,
-    private readonly runtimeConfig: DBOSRuntimeConfig,
-  ) {
-    // Initialize workflow executor.
-    this.dbosConfig = dbosConfig;
-    DBOS.setConfig(dbosConfig);
-  }
-
   /**
-   * Initialize the runtime and start the server
-   */
-  async initAndStart() {
-    try {
-      if (!this.dbosConfig.databaseUrl) {
-        throw new Error('DBOS pool configuration is not initialized');
-      }
-      this.dbosExec = new DBOSExecutor(this.dbosConfig);
-      this.dbosExec.logger.debug(`Loading classes from entrypoints ${JSON.stringify(this.runtimeConfig.entrypoints)}`);
-      await DBOSRuntime.loadClasses(this.runtimeConfig.entrypoints);
-      await this.dbosExec.init();
-      const server = new DBOSHttpServer(this.dbosExec);
-      this.servers = await server.listen(this.runtimeConfig.port, this.runtimeConfig.admin_port);
-      this.dbosExec.logRegisteredHTTPUrls();
-
-      await this.scheduler.initialize();
-      this.scheduler.logRegisteredEndpoints();
-
-      wfQueueRunner.logRegisteredEndpoints(this.dbosExec);
-      this.wfQueueRunner = wfQueueRunner.dispatchLoop(this.dbosExec);
-    } catch (error) {
-      if (!this.dbosExec) {
-        throw error;
-      }
-      this.dbosExec.logger.error(error);
-      if (error instanceof DBOSFailLoadOperationsError) {
-        console.error('\x1b[31m%s\x1b[0m', 'Did you compile this application? Hint: run `npm run build` and try again');
-        process.exit(1);
-      }
-      await this.destroy(); //wrap up, i.e. flush log contents to OpenTelemetry exporters
-      process.exit(1);
-    }
-    const onSigterm = this.onSigterm.bind(this);
-    process.on('SIGTERM', onSigterm);
-    process.on('SIGQUIT', onSigterm);
-  }
-
-  /**
-   * Load an application's workflow functions, assumed to be in src/operations.ts (which is compiled to dist/operations.js).
+   * Load an application's workflow functions from the compiled JS files.
    */
   static async loadClasses(entrypoints: string[]): Promise<object[]> {
     const allClasses: object[] = [];
@@ -105,31 +46,5 @@ export class DBOSRuntime {
       throw new DBOSFailLoadOperationsError('operations not found');
     }
     return allClasses;
-  }
-
-  onSigterm(): void {
-    this.dbosExec?.logger.info('Stopping application: received a termination signal');
-    void this.destroy().finally(() => {
-      process.exit(1);
-    });
-  }
-
-  /**
-   * Shut down the HTTP and other services and destroy workflow executor.
-   */
-  async destroy() {
-    await this.scheduler.destroy();
-    try {
-      wfQueueRunner.stop();
-      await this.wfQueueRunner;
-    } catch (err) {
-      const e = err as Error;
-      this.dbosExec?.logger.warn(`Error destroying workflow queue runner: ${e.message}`);
-    }
-    if (this.servers) {
-      this.servers.appServer?.close();
-      this.servers.adminServer.close();
-    }
-    await this.dbosExec?.destroy();
   }
 }

--- a/tests/dbos-runtime/runtime.test.ts
+++ b/tests/dbos-runtime/runtime.test.ts
@@ -1,4 +1,3 @@
-import axios, { AxiosError } from 'axios';
 import { spawn, execSync, ChildProcess } from 'child_process';
 import { Writable } from 'stream';
 import { Client } from 'pg';
@@ -30,22 +29,20 @@ async function waitForMessageTest(
   }
 
   try {
-    // Axios will throw an exception if the return status is 500
-    // Trying and catching is the only way to debug issues in this test
     const maxAttempts = 10;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       try {
         if (checkResponse) {
-          const response = await axios.get(`http://127.0.0.1:${port}/greeting/dbos`);
+          const response = await fetch(`http://127.0.0.1:${port}/greeting/dbos`);
           expect(response.status).toBe(200);
         }
-        const healthRes = await axios.get(`http://127.0.0.1:${adminPort}${HealthUrl}`);
+        const healthRes = await fetch(`http://127.0.0.1:${adminPort}${HealthUrl}`);
         expect(healthRes.status).toBe(200);
       } catch (error) {
         if (attempt < maxAttempts - 1) {
           await sleepms(1000);
         } else {
-          const errMsg = `Error sending test request: status: ${(error as AxiosError).response?.status}, statusText: ${(error as AxiosError).response?.statusText}`;
+          const errMsg = `Error sending test request: ${(error as Error).message}`;
           console.error(errMsg);
           throw error;
         }


### PR DESCRIPTION
This PR removes support of using `dbos start` with entrypoints + port specified in the config file.
To use `dbos start`, you must specify `start` commands in the `runtimeConfig` section.

Also minor clean ups for unused exports and runtime tests.