### PR TITLE
Use systemDatabaseUrl in setConfig for templates

### DIFF
--- a/packages/create/templates/dbos-drizzle/drizzle.config.ts
+++ b/packages/create/templates/dbos-drizzle/drizzle.config.ts
@@ -1,9 +1,8 @@
 import { defineConfig } from 'drizzle-kit';
 
-const { readConfigFile, getDatabaseUrl } = require('@dbos-inc/dbos-sdk');
-
-const dbosConfig = readConfigFile();
-const databaseUrl = getDatabaseUrl(dbosConfig);
+const databaseUrl =
+  process.env.DBOS_DATABASE_URL ||
+  `postgresql://${process.env.PGUSER || 'postgres'}:${process.env.PGPASSWORD || 'dbos'}@${process.env.PGHOST || 'localhost'}:${process.env.PGPORT || '5432'}/${process.env.PGDATABASE || 'dbos_drizzle'}`;
 
 export default defineConfig({
   schema: './src/schema.ts',

--- a/packages/create/templates/dbos-drizzle/src/main.ts
+++ b/packages/create/templates/dbos-drizzle/src/main.ts
@@ -91,7 +91,7 @@ app.get('/greeting/:name', (req: Request, res: Response) => {
 async function main() {
   DBOS.setConfig({
     name: 'dbos-drizzle',
-    databaseUrl: process.env.DBOS_DATABASE_URL,
+    systemDatabaseUrl: process.env.DBOS_SYSTEM_DATABASE_URL,
   });
   await DBOS.launch();
   const PORT = parseInt(process.env.NODE_PORT || '3000');

--- a/packages/create/templates/dbos-knex/knexfile.js
+++ b/packages/create/templates/dbos-knex/knexfile.js
@@ -1,7 +1,6 @@
-const { readConfigFile, getDatabaseUrl } = require('@dbos-inc/dbos-sdk');
-
-const dbosConfig = readConfigFile();
-const databaseUrl = getDatabaseUrl(dbosConfig);
+const databaseUrl =
+  process.env.DBOS_DATABASE_URL ||
+  `postgresql://${process.env.PGUSER || 'postgres'}:${process.env.PGPASSWORD || 'dbos'}@${process.env.PGHOST || 'localhost'}:${process.env.PGPORT || '5432'}/${process.env.PGDATABASE || 'dbos_knex'}`;
 
 const config = {
   client: 'pg',

--- a/packages/create/templates/dbos-knex/src/main.ts
+++ b/packages/create/templates/dbos-knex/src/main.ts
@@ -104,7 +104,7 @@ app.get('/greeting/:name', (req: Request, res: Response) => {
 async function main() {
   DBOS.setConfig({
     name: 'dbos-knex',
-    databaseUrl: process.env.DBOS_DATABASE_URL,
+    systemDatabaseUrl: process.env.DBOS_SYSTEM_DATABASE_URL,
   });
   await DBOS.launch();
   const PORT = parseInt(process.env.NODE_PORT || '3000');

--- a/packages/create/templates/dbos-prisma/generate_env.js
+++ b/packages/create/templates/dbos-prisma/generate_env.js
@@ -1,10 +1,11 @@
-const { readConfigFile, getDatabaseUrl } = require('@dbos-inc/dbos-sdk');
 const fs = require('node:fs');
 const path = require('node:path');
 
 // Load the configuration file
-const dbosConfig = readConfigFile();
-const databaseUrl = getDatabaseUrl(dbosConfig);
+const databaseUrl =
+  process.env['DBOS_DATABASE_URL'] ||
+  process.env['DATABASE_URL'] ||
+  `postgresql://${process.env.PGUSER || 'postgres'}:${process.env.PGPASSWORD || 'dbos'}@${process.env.PGHOST || 'localhost'}:${process.env.PGPORT || '5432'}/${process.env.PGDATABASE || 'dbos_prisma'}`;
 
 try {
   fs.writeFileSync(path.join(process.cwd(), 'prisma', '.env'), `DATABASE_URL="${databaseUrl}"`);

--- a/packages/create/templates/dbos-prisma/src/main.ts
+++ b/packages/create/templates/dbos-prisma/src/main.ts
@@ -92,7 +92,7 @@ app.get('/greeting/:name', (req: Request, res: Response) => {
 async function main() {
   DBOS.setConfig({
     name: 'dbos-prisma',
-    databaseUrl: process.env.DBOS_DATABASE_URL,
+    systemDatabaseUrl: process.env.DBOS_SYSTEM_DATABASE_URL,
   });
   await DBOS.launch();
   const PORT = parseInt(process.env.NODE_PORT || '3000');

--- a/packages/create/templates/dbos-typeorm/datasource.ts
+++ b/packages/create/templates/dbos-typeorm/datasource.ts
@@ -1,8 +1,8 @@
-import { readConfigFile, getDatabaseUrl } from '@dbos-inc/dbos-sdk';
 import { DataSource } from 'typeorm';
 
-const dbosConfig = readConfigFile();
-const databaseUrl = getDatabaseUrl(dbosConfig);
+const databaseUrl =
+  process.env.DBOS_DATABASE_URL ||
+  `postgresql://${process.env.PGUSER || 'postgres'}:${process.env.PGPASSWORD || 'dbos'}@${process.env.PGHOST || 'localhost'}:${process.env.PGPORT || '5432'}/${process.env.PGDATABASE || 'dbos_typeorm'}`;
 
 const AppDataSource = new DataSource({
   type: 'postgres',

--- a/packages/create/templates/dbos-typeorm/src/main.ts
+++ b/packages/create/templates/dbos-typeorm/src/main.ts
@@ -89,7 +89,7 @@ app.get('/greeting/:name', (req: Request, res: Response) => {
 async function main() {
   DBOS.setConfig({
     name: 'dbos-typeorm',
-    databaseUrl: process.env.DBOS_DATABASE_URL,
+    systemDatabaseUrl: process.env.DBOS_SYSTEM_DATABASE_URL,
   });
   await DBOS.launch();
   const PORT = parseInt(process.env.NODE_PORT || '3000');


### PR DESCRIPTION
- No longer rely on readConfigFile and getDatabaseUrl for application database URL.
- Explicitly set systemDatabaseUrl in config.