### PR TITLE
Devhawk/config-changes-v3

### DIFF
--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -108,10 +108,6 @@ export function getSystemDatabaseUrl(
     return configFileOrString.system_database_url;
   }
 
-  if (process.env.DBOS_SYSTEM_DATABASE_URL) {
-    return process.env.DBOS_SYSTEM_DATABASE_URL;
-  }
-
   const databaseUrl = getDatabaseUrl(configFileOrString);
   return convertUserDbUrl(databaseUrl);
 
@@ -135,7 +131,7 @@ function isValidDBname(dbName: string): boolean {
 }
 
 export function getDatabaseUrl(configFile: Pick<ConfigFile, 'name' | 'database_url'>): string {
-  const databaseUrl = configFile.database_url || process.env.DBOS_DATABASE_URL || defaultDatabaseUrl(configFile.name);
+  const databaseUrl = configFile.database_url || defaultDatabaseUrl(configFile.name);
 
   const url = new URL(databaseUrl);
   const dbName = url.pathname.slice(1);

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -12,7 +12,6 @@ import { AssertionError } from 'assert';
 import { DBOSConfigInternal } from '../../src/dbos-executor';
 import { DBOSRuntimeConfig } from '../../src';
 import { UserDatabaseName } from '../../src/user_database';
-import { TelemetryCollector } from '../../src/telemetry/collector';
 
 describe('dbos-config', () => {
   beforeEach(() => {


### PR DESCRIPTION
* Don't read db url / sys db url from env var by default
* require db url env var in overwriteConfigForDBOSCloud
