### PR TITLE
New "dbos schema" CLI

### DIFF
--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -96,7 +96,7 @@ program
 
 program
   .command('schema')
-  .description('Create the system database and its internal tables')
+  .description('Create the DBOS system database and its internal tables')
   .argument('[systemDatabaseUrl]', 'System database URL')
   .option('-d, --appDir <string>', 'Specify the application root directory')
   .action(async (systemDatabaseUrl: string | undefined, options: { appDir?: string }) => {

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -97,16 +97,16 @@ program
 program
   .command('schema')
   .description('Create the system database and its internal tables')
-  .argument('[systemDatabaseUrl]', 'System database URL (optional if provided in config)')
+  .argument('[systemDatabaseUrl]', 'System database URL (if not provided, uses dbos-config.yaml)')
   .option('-d, --appDir <string>', 'Specify the application root directory')
   .action(async (systemDatabaseUrl: string | undefined, options: { appDir?: string }) => {
     const logger = new GlobalLogger();
-    const configFile = readConfigFile(options.appDir);
 
     // Determine system database URL from argument or config
     let finalSystemDatabaseUrl = systemDatabaseUrl;
     if (!finalSystemDatabaseUrl) {
       try {
+        const configFile = readConfigFile(options.appDir);
         finalSystemDatabaseUrl = getSystemDatabaseUrl(configFile);
       } catch {
         // Config doesn't have system database URL

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -97,7 +97,7 @@ program
 program
   .command('schema')
   .description('Create the system database and its internal tables')
-  .argument('[systemDatabaseUrl]', 'System database URL (if not provided, uses dbos-config.yaml)')
+  .argument('[systemDatabaseUrl]', 'System database URL')
   .option('-d, --appDir <string>', 'Specify the application root directory')
   .action(async (systemDatabaseUrl: string | undefined, options: { appDir?: string }) => {
     const logger = new GlobalLogger();

--- a/tests/dbos-runtime/runtime.test.ts
+++ b/tests/dbos-runtime/runtime.test.ts
@@ -4,6 +4,7 @@ import { Client } from 'pg';
 import { generateDBOSTestConfig } from '../helpers';
 import { HealthUrl } from '../../src/httpServer/server';
 import { sleepms } from '../../src/utils';
+import { ExistenceCheck } from '../../src/system_database';
 
 async function waitForMessageTest(
   command: ChildProcess,
@@ -187,5 +188,39 @@ describe('runtime-tests-drizzle', () => {
       env: process.env,
     });
     await waitForMessageTest(command, '3000');
+  });
+});
+
+describe('schema-command-tests', () => {
+  test('test schema command with system database URL argument', async () => {
+    const config = generateDBOSTestConfig();
+    const systemDatabaseUrl = config.systemDatabaseUrl;
+
+    // Drop the system database if it exists
+    const url = new URL(systemDatabaseUrl!);
+    const systemDbName = url.pathname.slice(1);
+    url.pathname = `/postgres`;
+    const pgClient = new Client({
+      connectionString: url.toString(),
+    });
+    await pgClient.connect();
+    await pgClient.query(`DROP DATABASE IF EXISTS ${systemDbName} WITH (FORCE);`);
+    await pgClient.end();
+
+    // Run schema command with system database URL as argument
+    execSync(`npx dbos schema ${systemDatabaseUrl}`, { env: process.env, stdio: 'inherit' });
+
+    // Verify the system database and tables were created
+    const pgSystemClient = new Client({
+      connectionString: systemDatabaseUrl!,
+    });
+    await pgSystemClient.connect();
+
+    const tableExists = await pgSystemClient.query<ExistenceCheck>(
+      `SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = 'dbos' AND table_name = 'operation_outputs')`,
+    );
+    expect(tableExists.rows[0].exists).toBe(true);
+
+    await pgSystemClient.end();
   });
 });


### PR DESCRIPTION
This command adds a new `dbos schema` CLI command to create DBOS system tables. Usage is:

```
Usage: dbos schema [options] [systemDatabaseUrl]

Create the DBOS system database and its internal tables

Arguments:
  systemDatabaseUrl      System database URL

Options:
  -d, --appDir <string>  Specify the application root directory
  -h, --help             display help for command
````

This is most useful in settings where the application does not run with sufficient privilege to create the DBOS system database or system tables. Prior to deployment, the `dbos schema` command can be run with a privileged user to create DBOS system tables. Then, the application can run with a less privileged user that has access to the system database but does not need CREATE privileges.