### PR TITLE
Streaming API

### DIFF
--- a/migrations/20252806000000_streaming.js
+++ b/migrations/20252806000000_streaming.js
@@ -1,0 +1,30 @@
+// Due to a naming issue, this migration is named "20252806000000_streaming.js"
+// Please see the 20252101000000_workflow_queues_executor_id migration for more details.
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.withSchema('dbos').createTable('streams', function (table) {
+    table.text('workflow_uuid').notNullable();
+    table.text('key').notNullable();
+    table.text('value').notNullable();
+    table.integer('offset').notNullable();
+    table.primary(['workflow_uuid', 'key', 'offset']);
+    table
+      .foreign('workflow_uuid')
+      .references('workflow_uuid')
+      .inTable('dbos.workflow_status')
+      .onUpdate('CASCADE')
+      .onDelete('CASCADE');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.withSchema('dbos').dropTable('streams');
+};

--- a/schemas/system_db_schema.ts
+++ b/schemas/system_db_schema.ts
@@ -58,6 +58,13 @@ export interface event_dispatch_kv {
   update_seq?: bigint; // Sequence number of record (for upsert)
 }
 
+export interface streams {
+  workflow_uuid: string;
+  key: string;
+  value: string;
+  offset: number;
+}
+
 // This is the deserialized version of operation_outputs
 export interface step_info {
   function_id: number;

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -14,6 +14,7 @@ import {
   GetQueuedWorkflowsInput,
   GetWorkflowsInput,
   GetWorkflowsOutput,
+  isWorkflowActive,
   RetrievedHandle,
   StepInfo,
   WorkflowConfig,
@@ -91,7 +92,7 @@ import { StoredProcedureConfig } from './procedure';
 import { APITypes } from './httpServer/handlerTypes';
 import { HandlerRegistrationBase } from './httpServer/handler';
 import { Conductor } from './conductor/conductor';
-import { EnqueueOptions } from './system_database';
+import { EnqueueOptions, DBOS_STREAM_CLOSED_SENTINEL } from './system_database';
 import { wfQueueRunner } from './wfqueue';
 import { registerAuthChecker } from './authdecorators';
 import assert from 'node:assert';
@@ -1323,6 +1324,89 @@ export class DBOS {
       ) as T;
     }
     return DBOS.#executor.getEvent(workflowID, key, timeoutSeconds);
+  }
+
+  /**
+   * Write a value to a stream.
+   * @param key - The stream key/name within the workflow
+   * @param value - A serializable value to write to the stream
+   */
+  static async writeStream<T>(key: string, value: T): Promise<void> {
+    ensureDBOSIsLaunched('writeStream');
+    if (DBOS.isWithinWorkflow()) {
+      if (DBOS.isInWorkflow()) {
+        const functionID: number = functionIDGetIncrement();
+        return await DBOSExecutor.globalInstance!.systemDatabase.writeStreamFromWorkflow(
+          DBOS.workflowID!,
+          functionID,
+          key,
+          value,
+        );
+      } else if (DBOS.isInStep()) {
+        return await DBOSExecutor.globalInstance!.systemDatabase.writeStreamFromStep(DBOS.workflowID!, key, value);
+      } else {
+        throw new DBOSInvalidWorkflowTransitionError(
+          'Invalid call to `DBOS.writeStream` inside a `transaction` or `stored procedure`',
+        );
+      }
+    } else {
+      throw new DBOSInvalidWorkflowTransitionError('Invalid call to `DBOS.writeStream` outside of a workflow or step');
+    }
+  }
+
+  /**
+   * Close a stream by writing a sentinel value.
+   * @param key - The stream key/name within the workflow
+   */
+  static async closeStream(key: string): Promise<void> {
+    ensureDBOSIsLaunched('closeStream');
+    if (DBOS.isWithinWorkflow()) {
+      if (DBOS.isInWorkflow()) {
+        const functionID: number = functionIDGetIncrement();
+        return await DBOSExecutor.globalInstance!.systemDatabase.closeStream(DBOS.workflowID!, functionID, key);
+      } else {
+        throw new DBOSInvalidWorkflowTransitionError(
+          'Invalid call to `DBOS.closeStream` inside a `step` or `transaction`. closeStream must be called from within a workflow.',
+        );
+      }
+    } else {
+      throw new DBOSInvalidWorkflowTransitionError('Invalid call to `DBOS.closeStream` outside of a workflow');
+    }
+  }
+
+  /**
+   * Read values from a stream as an async generator.
+   * This function reads values from a stream identified by the workflowID and key,
+   * yielding each value in order until the stream is closed or the workflow terminates.
+   * @param workflowID - The workflow instance ID that owns the stream
+   * @param key - The stream key/name within the workflow
+   * @returns An async generator that yields each value in the stream until the stream is closed
+   */
+  static async *readStream<T>(workflowID: string, key: string): AsyncGenerator<T, void, unknown> {
+    ensureDBOSIsLaunched('readStream');
+    let offset = 0;
+
+    while (true) {
+      try {
+        const value = await DBOSExecutor.globalInstance!.systemDatabase.readStream(workflowID, key, offset);
+        if (value === DBOS_STREAM_CLOSED_SENTINEL) {
+          break;
+        }
+        yield value as T;
+        offset += 1;
+      } catch (error: unknown) {
+        if (error instanceof Error && error.message.includes('No value found')) {
+          // Poll the offset until a value arrives or the workflow terminates
+          const status = await DBOS.getWorkflowStatus(workflowID);
+          if (!status || !isWorkflowActive(status.status)) {
+            break;
+          }
+          await sleepms(1000); // 1 second polling interval
+          continue;
+        }
+        throw error;
+      }
+    }
   }
 
   /**

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -1346,7 +1346,7 @@ export class DBOS {
         return await DBOSExecutor.globalInstance!.systemDatabase.writeStreamFromStep(DBOS.workflowID!, key, value);
       } else {
         throw new DBOSInvalidWorkflowTransitionError(
-          'Invalid call to `DBOS.writeStream` inside a `transaction` or `stored procedure`',
+          'Invalid call to `DBOS.writeStream` outside of a workflow or step',
         );
       }
     } else {
@@ -1366,7 +1366,7 @@ export class DBOS {
         return await DBOSExecutor.globalInstance!.systemDatabase.closeStream(DBOS.workflowID!, functionID, key);
       } else {
         throw new DBOSInvalidWorkflowTransitionError(
-          'Invalid call to `DBOS.closeStream` inside a `step` or `transaction`. closeStream must be called from within a workflow.',
+          'Invalid call to `DBOS.closeStream` outside of a workflow or step',
         );
       }
     } else {

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -16,7 +16,6 @@ import {
   workflow_status,
   workflow_events,
   event_dispatch_kv,
-  streams,
 } from '../schemas/system_db_schema';
 import { findPackageRoot, globalParams, cancellableSleep, INTERNAL_QUEUE_NAME, sleepms } from './utils';
 import { GlobalLogger } from './telemetry/logs';
@@ -2001,7 +2000,8 @@ export class PostgresSystemDatabase implements SystemDatabase {
       );
 
       // Next offset is max + 1, or 0 if no records exist
-      const nextOffset = maxOffsetResult.rows[0].max !== null ? maxOffsetResult.rows[0].max + 1 : 0;
+      const maxOffset = (maxOffsetResult.rows[0] as { max: number | null }).max;
+      const nextOffset = maxOffset !== null ? maxOffset + 1 : 0;
 
       // Serialize the value before storing
       const serializedValue = JSON.stringify(value);
@@ -2041,7 +2041,8 @@ export class PostgresSystemDatabase implements SystemDatabase {
         );
 
         // Next offset is max + 1, or 0 if no records exist
-        const nextOffset = maxOffsetResult.rows[0].max !== null ? maxOffsetResult.rows[0].max + 1 : 0;
+        const maxOffset = (maxOffsetResult.rows[0] as { max: number | null }).max;
+        const nextOffset = maxOffset !== null ? maxOffset + 1 : 0;
 
         // Serialize the value before storing
         const serializedValue = JSON.stringify(value);
@@ -2085,7 +2086,8 @@ export class PostgresSystemDatabase implements SystemDatabase {
       }
 
       // Deserialize the value before returning
-      return JSON.parse(result.rows[0].value);
+      const row = result.rows[0] as { value: string };
+      return JSON.parse(row.value);
     } finally {
       client.release();
     }

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -119,6 +119,10 @@ export const StatusString = {
   ENQUEUED: 'ENQUEUED',
 } as const;
 
+export function isWorkflowActive(status: string) {
+  return status === StatusString.PENDING || status === StatusString.ENQUEUED;
+}
+
 /**
  * Object representing an active or completed workflow execution, identified by the workflow UUID.
  * Allows retrieval of information about the workflow.

--- a/tests/streaming.test.ts
+++ b/tests/streaming.test.ts
@@ -352,6 +352,7 @@ describe('dbos-streaming-tests', () => {
     const countingStep = DBOS.registerStep(
       async () => {
         callCount += 1;
+        await DBOS.writeStream('recovery_stream', `in step`);
         return Promise.resolve(callCount);
       },
       { name: 'counting-step' },
@@ -393,7 +394,7 @@ describe('dbos-streaming-tests', () => {
     for await (const value of DBOS.readStream(wfid, 'recovery_stream')) {
       values.push(value);
     }
-    expect(values).toEqual(['step_1', 'step_2']);
+    expect(values).toEqual(['in step', 'step_1', 'in step', 'step_2']);
 
     // Check workflow steps were recorded correctly
     const steps = await DBOS.listWorkflowSteps(wfid);

--- a/tests/streaming.test.ts
+++ b/tests/streaming.test.ts
@@ -23,12 +23,15 @@ describe('dbos-streaming-tests', () => {
 
     const wfid = randomUUID();
 
-    const writerWorkflow = DBOS.registerWorkflow(async (streamKey: string, testValues: unknown[]) => {
-      for (const value of testValues) {
-        await DBOS.writeStream(streamKey, value);
-      }
-      await DBOS.closeStream(streamKey);
-    });
+    const writerWorkflow = DBOS.registerWorkflow(
+      async (streamKey: string, testValues: unknown[]) => {
+        for (const value of testValues) {
+          await DBOS.writeStream(streamKey, value);
+        }
+        await DBOS.closeStream(streamKey);
+      },
+      { name: 'basic-stream-write-read' },
+    );
     await DBOS.launch();
 
     // Start the writer workflow
@@ -51,5 +54,249 @@ describe('dbos-streaming-tests', () => {
     }
 
     expect(readValues2).toEqual(testValues);
+  });
+
+  test('unclosed-stream', async () => {
+    // Test that reading from a stream stops when the workflow terminates
+    const testValues = ['hello', 42, { key: 'value' }, [1, 2, 3], null];
+    const streamKey = 'test_stream';
+
+    const writerWorkflow = DBOS.registerWorkflow(
+      async (streamKey: string, testValues: unknown[]) => {
+        for (const value of testValues) {
+          await DBOS.writeStream(streamKey, value);
+        }
+        // Note: Not closing the stream
+      },
+      { name: 'unclosed-stream-writer' },
+    );
+
+    const writerWorkflowError = DBOS.registerWorkflow(
+      async (streamKey: string, testValues: unknown[]) => {
+        for (const value of testValues) {
+          await DBOS.writeStream(streamKey, value);
+        }
+        throw new Error('Test error');
+      },
+      { name: 'unclosed-stream-writer-error' },
+    );
+
+    await DBOS.launch();
+
+    // Test successful workflow without closing
+    const wfid1 = randomUUID();
+    await DBOS.withNextWorkflowID(wfid1, async () => {
+      await writerWorkflow(streamKey, testValues);
+    });
+
+    const readValues1: unknown[] = [];
+    for await (const value of DBOS.readStream(wfid1, streamKey)) {
+      readValues1.push(value);
+    }
+    expect(readValues1).toEqual(testValues);
+
+    // Test error workflow without closing
+    const wfid2 = randomUUID();
+    await expect(
+      DBOS.withNextWorkflowID(wfid2, async () => {
+        await writerWorkflowError(streamKey, testValues);
+      }),
+    ).rejects.toThrow('Test error');
+
+    const readValues2: unknown[] = [];
+    for await (const value of DBOS.readStream(wfid2, streamKey)) {
+      readValues2.push(value);
+    }
+    expect(readValues2).toEqual(testValues);
+  });
+
+  test('multiple-keys', async () => {
+    // Test multiple streams with different keys in the same workflow
+    const multiStreamWorkflow = DBOS.registerWorkflow(
+      async () => {
+        // Write to stream A
+        await DBOS.writeStream('stream_a', 'a1');
+        await DBOS.writeStream('stream_a', 'a2');
+
+        // Write to stream B
+        await DBOS.writeStream('stream_b', 'b1');
+        await DBOS.writeStream('stream_b', 'b2');
+        await DBOS.writeStream('stream_b', 'b3');
+
+        // Close both streams
+        await DBOS.closeStream('stream_a');
+        await DBOS.closeStream('stream_b');
+      },
+      { name: 'multiple-keys-workflow' },
+    );
+
+    await DBOS.launch();
+
+    const wfid = randomUUID();
+    await DBOS.withNextWorkflowID(wfid, async () => {
+      await multiStreamWorkflow();
+    });
+
+    // Read stream A
+    const streamAValues: unknown[] = [];
+    for await (const value of DBOS.readStream(wfid, 'stream_a')) {
+      streamAValues.push(value);
+    }
+    expect(streamAValues).toEqual(['a1', 'a2']);
+
+    // Read stream B
+    const streamBValues: unknown[] = [];
+    for await (const value of DBOS.readStream(wfid, 'stream_b')) {
+      streamBValues.push(value);
+    }
+    expect(streamBValues).toEqual(['b1', 'b2', 'b3']);
+  });
+
+  test('empty-stream', async () => {
+    // Test reading from an empty stream (only close marker)
+    const emptyStreamWorkflow = DBOS.registerWorkflow(
+      async () => {
+        await DBOS.closeStream('empty_stream');
+      },
+      { name: 'empty-stream-workflow' },
+    );
+
+    await DBOS.launch();
+
+    const wfid = randomUUID();
+    await DBOS.withNextWorkflowID(wfid, async () => {
+      await emptyStreamWorkflow();
+    });
+
+    // Read the empty stream
+    const values: unknown[] = [];
+    for await (const value of DBOS.readStream(wfid, 'empty_stream')) {
+      values.push(value);
+    }
+    expect(values).toEqual([]);
+  });
+
+  test('serialization-types', async () => {
+    // Test that various data types are properly serialized/deserialized
+    const testValues = ['string', 42, 3.14, true, false, null, [1, 2, 3], { nested: { dict: 'value' } }];
+
+    const serializationTestWorkflow = DBOS.registerWorkflow(
+      async (testValues: unknown[]) => {
+        for (const value of testValues) {
+          await DBOS.writeStream('serialize_test', value);
+        }
+        await DBOS.closeStream('serialize_test');
+      },
+      { name: 'serialization-test-workflow' },
+    );
+
+    await DBOS.launch();
+
+    const wfid = randomUUID();
+    await DBOS.withNextWorkflowID(wfid, async () => {
+      await serializationTestWorkflow(testValues);
+    });
+
+    // Read and verify
+    const readValues: unknown[] = [];
+    for await (const value of DBOS.readStream(wfid, 'serialize_test')) {
+      readValues.push(value);
+    }
+
+    expect(readValues).toEqual(testValues);
+  });
+
+  test('error-cases', async () => {
+    // Test error cases and edge conditions
+    await DBOS.launch();
+
+    // Test writing to stream outside of workflow
+    await expect(DBOS.writeStream('test', 'value')).rejects.toThrow(
+      'Invalid call to `DBOS.writeStream` outside of a workflow or step',
+    );
+
+    // Test closing stream outside of workflow
+    await expect(DBOS.closeStream('test')).rejects.toThrow('Invalid call to `DBOS.closeStream` outside of a workflow');
+  });
+
+  test('large-data', async () => {
+    // Test streaming with larger amounts of data
+    const largeDataWorkflow = DBOS.registerWorkflow(
+      async () => {
+        // Write 100 items
+        for (let i = 0; i < 100; i++) {
+          const data = { id: i, data: `item_${i}`, large_field: 'x'.repeat(1000) };
+          await DBOS.writeStream('large_stream', data);
+        }
+        await DBOS.closeStream('large_stream');
+      },
+      { name: 'large-data-workflow' },
+    );
+
+    await DBOS.launch();
+
+    const wfid = randomUUID();
+    await DBOS.withNextWorkflowID(wfid, async () => {
+      await largeDataWorkflow();
+    });
+
+    // Read all values
+    const values: unknown[] = [];
+    for await (const value of DBOS.readStream(wfid, 'large_stream')) {
+      values.push(value);
+    }
+
+    expect(values).toHaveLength(100);
+    for (let i = 0; i < values.length; i++) {
+      const value = values[i] as { id: number; data: string; large_field: string };
+      expect(value.id).toBe(i);
+      expect(value.data).toBe(`item_${i}`);
+      expect(value.large_field).toBe('x'.repeat(1000));
+    }
+  });
+
+  test('interleaved-operations', async () => {
+    // Test interleaved write operations across multiple streams
+    const interleavedWorkflow = DBOS.registerWorkflow(
+      async () => {
+        await DBOS.writeStream('stream1', '1a');
+        await DBOS.writeStream('stream2', '2a');
+        await DBOS.writeStream('stream1', '1b');
+        await DBOS.writeStream('stream3', '3a');
+        await DBOS.writeStream('stream2', '2b');
+        await DBOS.writeStream('stream1', '1c');
+
+        await DBOS.closeStream('stream1');
+        await DBOS.closeStream('stream2');
+        await DBOS.closeStream('stream3');
+      },
+      { name: 'interleaved-workflow' },
+    );
+
+    await DBOS.launch();
+
+    const wfid = randomUUID();
+    await DBOS.withNextWorkflowID(wfid, async () => {
+      await interleavedWorkflow();
+    });
+
+    // Verify each stream has the correct values in order
+    const stream1Values: unknown[] = [];
+    for await (const value of DBOS.readStream(wfid, 'stream1')) {
+      stream1Values.push(value);
+    }
+    expect(stream1Values).toEqual(['1a', '1b', '1c']);
+
+    const stream2Values: unknown[] = [];
+    for await (const value of DBOS.readStream(wfid, 'stream2')) {
+      stream2Values.push(value);
+    }
+    expect(stream2Values).toEqual(['2a', '2b']);
+
+    const stream3Values: unknown[] = [];
+    for await (const value of DBOS.readStream(wfid, 'stream3')) {
+      stream3Values.push(value);
+    }
+    expect(stream3Values).toEqual(['3a']);
   });
 });

--- a/tests/streaming.test.ts
+++ b/tests/streaming.test.ts
@@ -23,7 +23,7 @@ describe('dbos-streaming-tests', () => {
 
     const wfid = randomUUID();
 
-    const writerWorkflow = DBOS.registerWorkflow(async (streamKey: string, testValues: any[]) => {
+    const writerWorkflow = DBOS.registerWorkflow(async (streamKey: string, testValues: unknown[]) => {
       for (const value of testValues) {
         await DBOS.writeStream(streamKey, value);
       }
@@ -37,7 +37,7 @@ describe('dbos-streaming-tests', () => {
     });
 
     // Read the stream
-    const readValues: any[] = [];
+    const readValues: unknown[] = [];
     for await (const value of DBOS.readStream(wfid, streamKey)) {
       readValues.push(value);
     }
@@ -45,7 +45,7 @@ describe('dbos-streaming-tests', () => {
     expect(readValues).toEqual(testValues);
 
     // Read the stream again, verify no changes
-    const readValues2: any[] = [];
+    const readValues2: unknown[] = [];
     for await (const value of DBOS.readStream(wfid, streamKey)) {
       readValues2.push(value);
     }

--- a/tests/streaming.test.ts
+++ b/tests/streaming.test.ts
@@ -1,0 +1,61 @@
+import { DBOS } from '../src/';
+import { generateDBOSTestConfig, setUpDBOSTestDb } from './helpers';
+import { DBOSConfig } from '../src/dbos-executor';
+import { randomUUID } from 'node:crypto';
+
+describe('dbos-streaming-tests', () => {
+  let config: DBOSConfig;
+
+  beforeAll(async () => {
+    config = generateDBOSTestConfig();
+    await setUpDBOSTestDb(config);
+    DBOS.setConfig(config);
+  });
+
+  beforeEach(async () => {
+    await DBOS.launch();
+  });
+
+  afterEach(async () => {
+    await DBOS.shutdown();
+  });
+
+  test('basic-stream-write-read', async () => {
+    // Test basic stream write and read functionality
+    const testValues = ['hello', 42, { key: 'value' }, [1, 2, 3], null];
+    const streamKey = 'test_stream';
+
+    const wfid = randomUUID();
+
+    // Start the writer workflow
+    await DBOS.withNextWorkflowID(wfid, async () => {
+      await WriterWorkflow.writerWorkflow(streamKey, testValues);
+    });
+
+    // Read the stream
+    const readValues: any[] = [];
+    for await (const value of DBOS.readStream(wfid, streamKey)) {
+      readValues.push(value);
+    }
+
+    expect(readValues).toEqual(testValues);
+
+    // Read the stream again, verify no changes
+    const readValues2: any[] = [];
+    for await (const value of DBOS.readStream(wfid, streamKey)) {
+      readValues2.push(value);
+    }
+
+    expect(readValues2).toEqual(testValues);
+  });
+});
+
+class WriterWorkflow {
+  @DBOS.workflow()
+  static async writerWorkflow(streamKey: string, testValues: any[]) {
+    for (const value of testValues) {
+      await DBOS.writeStream(streamKey, value);
+    }
+    await DBOS.closeStream(streamKey);
+  }
+}


### PR DESCRIPTION
This PR adds an API for streaming data from workflows.

```ts
/**
 * Write a value to a stream.
 * @param key - The stream key/name within the workflow
 * @param value - A serializable value to write to the stream
 */
async writeStream<T>(key: string, value: T): Promise<void>

/**
 * Close a stream by writing a sentinel value.
 * @param key - The stream key/name within the workflow
 */
async closeStream(key: string): Promise<void>

/**
 * Read values from a stream as an async generator.
 * This function reads values from a stream identified by the workflowID and key,
 * yielding each value in order until the stream is closed or the workflow terminates.
 * @param workflowID - The workflow instance ID that owns the stream
 * @param key - The stream key/name within the workflow
 * @returns An async generator that yields each value in the stream until the stream is closed
 */
async *readStream<T>(workflowID: string, key: string): AsyncGenerator<T, void, unknown>
```

Streams are append-only and immutable and can be read from anywhere.

Streams can be written to from a workflow or its steps. Writing to a stream from a workflow is done with exactly-once semantics. Writing to a stream from a step is at-least-once; if a step fails and is retried, it may write to the stream multiple times.