### PR TITLE
Migration Permissions

### DIFF
--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -9,11 +9,15 @@ import {
 } from './config';
 import { Command } from 'commander';
 import { DBOSConfigInternal } from '../dbos-executor';
-import { migrate, createSystemDatabase } from './migrate';
+import { migrate, grantDbosSchemaPermissions } from './migrate';
 import { GlobalLogger } from '../telemetry/logs';
 import { TelemetryCollector } from '../telemetry/collector';
 import { TelemetryExporter } from '../telemetry/exporters';
 import { DBOSClient, GetWorkflowsInput, StatusString } from '..';
+import { migrateSystemDatabase } from '../system_database';
+import { createDBIfDoesNotExist } from '../user_database';
+import { getClientConfig } from '../utils';
+import { PoolConfig } from 'pg';
 import { exit } from 'node:process';
 import { runCommand } from './commands';
 import { reset } from './reset';
@@ -120,8 +124,26 @@ program
     }
 
     try {
-      await createSystemDatabase(finalSystemDatabaseUrl, logger, options.appRole);
-      logger.info('System database schema created successfully!');
+      const url = new URL(finalSystemDatabaseUrl);
+      const systemDbName = url.pathname.slice(1);
+
+      if (!systemDbName) {
+        logger.error('Provided database URL does not specify the system database name');
+        process.exit(1);
+      }
+
+      await createDBIfDoesNotExist(finalSystemDatabaseUrl, logger);
+
+      const systemPoolConfig: PoolConfig = getClientConfig(finalSystemDatabaseUrl);
+
+      // Load the DBOS system schema.
+      logger.info('Creating DBOS system schema');
+      await migrateSystemDatabase(systemPoolConfig, logger);
+
+      // Grant permissions to application role if specified
+      if (options.appRole) {
+        await grantDbosSchemaPermissions(finalSystemDatabaseUrl, options.appRole, logger);
+      }
     } catch (e) {
       logger.error(e);
       process.exit(1);

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -99,7 +99,8 @@ program
   .description('Create the DBOS system database and its internal tables')
   .argument('[systemDatabaseUrl]', 'System database URL')
   .option('-d, --appDir <string>', 'Specify the application root directory')
-  .action(async (systemDatabaseUrl: string | undefined, options: { appDir?: string }) => {
+  .option('-r, --app-role <string>', 'The role with which you will run your DBOS application')
+  .action(async (systemDatabaseUrl: string | undefined, options: { appDir?: string; appRole?: string }) => {
     const logger = new GlobalLogger();
 
     // Determine system database URL from argument or config
@@ -119,7 +120,7 @@ program
     }
 
     try {
-      await createSystemDatabase(finalSystemDatabaseUrl, logger);
+      await createSystemDatabase(finalSystemDatabaseUrl, logger, options.appRole);
       logger.info('System database schema created successfully!');
     } catch (e) {
       logger.error(e);

--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -68,36 +68,6 @@ export async function grantDbosSchemaPermissions(
   }
 }
 
-export async function createSystemDatabase(systemDatabaseUrl: string, logger: GlobalLogger, appRole?: string) {
-  const url = new URL(systemDatabaseUrl);
-  const systemDbName = url.pathname.slice(1);
-
-  if (!systemDbName) {
-    logger.error('System database name is empty in the URL');
-    throw new Error('System database name is empty in the URL');
-  }
-
-  logger.info(`Creating system database: ${systemDbName}`);
-  await createDBIfDoesNotExist(systemDatabaseUrl, logger);
-
-  const systemPoolConfig: PoolConfig = getClientConfig(systemDatabaseUrl);
-
-  // Load the DBOS system schema.
-  logger.info('Creating DBOS system tables');
-  try {
-    await migrateSystemDatabase(systemPoolConfig, logger);
-
-    // Grant permissions to application role if specified
-    if (appRole) {
-      await grantDbosSchemaPermissions(systemDatabaseUrl, appRole, logger);
-    }
-    return 0;
-  } catch (e) {
-    logger.warn(`Error in system database creation: ${(e as Error).message}`);
-    throw e;
-  }
-}
-
 export async function migrate(
   migrationCommands: string[],
   databaseUrl: string,

--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -22,7 +22,7 @@ export async function grantDbosSchemaPermissions(
   roleName: string,
   logger: GlobalLogger,
 ): Promise<void> {
-  logger.info(`Granting permissions for DBOS schema to ${roleName} in database ${databaseUrl}`);
+  logger.info(`Granting permissions for DBOS schema to ${roleName}`);
 
   const client = new Client(getClientConfig(databaseUrl));
   await client.connect();

--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -17,7 +17,58 @@ import {
 } from '../user_database';
 import { getClientConfig } from '../utils';
 
-export async function createSystemDatabase(systemDatabaseUrl: string, logger: GlobalLogger) {
+export async function grantDbosSchemaPermissions(
+  databaseUrl: string,
+  roleName: string,
+  logger: GlobalLogger,
+): Promise<void> {
+  logger.info(`Granting permissions for DBOS schema to ${roleName} in database ${databaseUrl}`);
+
+  const client = new Client(getClientConfig(databaseUrl));
+  await client.connect();
+
+  try {
+    // Grant usage on the dbos schema
+    const grantUsageSql = `GRANT USAGE ON SCHEMA dbos TO "${roleName}"`;
+    logger.info(grantUsageSql);
+    await client.query(grantUsageSql);
+
+    // Grant all privileges on all existing tables in dbos schema (includes views)
+    const grantTablesSql = `GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA dbos TO "${roleName}"`;
+    logger.info(grantTablesSql);
+    await client.query(grantTablesSql);
+
+    // Grant all privileges on all sequences in dbos schema
+    const grantSequencesSql = `GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA dbos TO "${roleName}"`;
+    logger.info(grantSequencesSql);
+    await client.query(grantSequencesSql);
+
+    // Grant execute on all functions and procedures in dbos schema
+    const grantFunctionsSql = `GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA dbos TO "${roleName}"`;
+    logger.info(grantFunctionsSql);
+    await client.query(grantFunctionsSql);
+
+    // Grant default privileges for future objects in dbos schema
+    const alterTablesSql = `ALTER DEFAULT PRIVILEGES IN SCHEMA dbos GRANT ALL ON TABLES TO "${roleName}"`;
+    logger.info(alterTablesSql);
+    await client.query(alterTablesSql);
+
+    const alterSequencesSql = `ALTER DEFAULT PRIVILEGES IN SCHEMA dbos GRANT ALL ON SEQUENCES TO "${roleName}"`;
+    logger.info(alterSequencesSql);
+    await client.query(alterSequencesSql);
+
+    const alterFunctionsSql = `ALTER DEFAULT PRIVILEGES IN SCHEMA dbos GRANT EXECUTE ON FUNCTIONS TO "${roleName}"`;
+    logger.info(alterFunctionsSql);
+    await client.query(alterFunctionsSql);
+  } catch (e) {
+    logger.error(`Failed to grant permissions to role ${roleName}: ${(e as Error).message}`);
+    throw e;
+  } finally {
+    await client.end();
+  }
+}
+
+export async function createSystemDatabase(systemDatabaseUrl: string, logger: GlobalLogger, appRole?: string) {
   const url = new URL(systemDatabaseUrl);
   const systemDbName = url.pathname.slice(1);
 
@@ -35,7 +86,11 @@ export async function createSystemDatabase(systemDatabaseUrl: string, logger: Gl
   logger.info('Creating DBOS system tables');
   try {
     await migrateSystemDatabase(systemPoolConfig, logger);
-    logger.info('System database created successfully!');
+
+    // Grant permissions to application role if specified
+    if (appRole) {
+      await grantDbosSchemaPermissions(systemDatabaseUrl, appRole, logger);
+    }
     return 0;
   } catch (e) {
     logger.warn(`Error in system database creation: ${(e as Error).message}`);

--- a/tests/dbos-runtime/runtime.test.ts
+++ b/tests/dbos-runtime/runtime.test.ts
@@ -4,7 +4,6 @@ import { Client } from 'pg';
 import { generateDBOSTestConfig } from '../helpers';
 import { HealthUrl } from '../../src/httpServer/server';
 import { sleepms } from '../../src/utils';
-import { ExistenceCheck } from '../../src/system_database';
 
 async function waitForMessageTest(
   command: ChildProcess,
@@ -188,39 +187,5 @@ describe('runtime-tests-drizzle', () => {
       env: process.env,
     });
     await waitForMessageTest(command, '3000');
-  });
-});
-
-describe('schema-command-tests', () => {
-  test('test schema command with system database URL argument', async () => {
-    const config = generateDBOSTestConfig();
-    const systemDatabaseUrl = config.systemDatabaseUrl;
-
-    // Drop the system database if it exists
-    const url = new URL(systemDatabaseUrl!);
-    const systemDbName = url.pathname.slice(1);
-    url.pathname = `/postgres`;
-    const pgClient = new Client({
-      connectionString: url.toString(),
-    });
-    await pgClient.connect();
-    await pgClient.query(`DROP DATABASE IF EXISTS ${systemDbName} WITH (FORCE);`);
-    await pgClient.end();
-
-    // Run schema command with system database URL as argument
-    execSync(`npx dbos schema ${systemDatabaseUrl}`, { env: process.env, stdio: 'inherit' });
-
-    // Verify the system database and tables were created
-    const pgSystemClient = new Client({
-      connectionString: systemDatabaseUrl!,
-    });
-    await pgSystemClient.connect();
-
-    const tableExists = await pgSystemClient.query<ExistenceCheck>(
-      `SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = 'dbos' AND table_name = 'operation_outputs')`,
-    );
-    expect(tableExists.rows[0].exists).toBe(true);
-
-    await pgSystemClient.end();
   });
 });

--- a/tests/migrate.test.ts
+++ b/tests/migrate.test.ts
@@ -61,10 +61,11 @@ describe('schema-command-tests', () => {
     // Using the admin role, create the DBOS database and verify it exists.
     // Set permissions for the test role.
     try {
-      execSync(`npx dbos schema ${dbUrl.toString()} -r ${roleName}`, {
+      const result = execSync(`npx dbos schema ${dbUrl.toString()} -r ${roleName}`, {
         env: process.env,
         stdio: 'pipe',
       });
+      console.log(result.toString());
     } catch (error) {
       console.error('Schema command failed:');
       const execError = error as { stdout?: Buffer; stderr?: Buffer; status?: number };

--- a/tests/migrate.test.ts
+++ b/tests/migrate.test.ts
@@ -1,0 +1,38 @@
+import { execSync } from 'child_process';
+import { Client } from 'pg';
+import { generateDBOSTestConfig } from './helpers';
+import { ExistenceCheck } from '../src/system_database';
+
+describe('schema-command-tests', () => {
+  test('test schema command with system database URL argument', async () => {
+    const config = generateDBOSTestConfig();
+    const systemDatabaseUrl = config.systemDatabaseUrl;
+
+    // Drop the system database if it exists
+    const url = new URL(systemDatabaseUrl!);
+    const systemDbName = url.pathname.slice(1);
+    url.pathname = `/postgres`;
+    const pgClient = new Client({
+      connectionString: url.toString(),
+    });
+    await pgClient.connect();
+    await pgClient.query(`DROP DATABASE IF EXISTS ${systemDbName} WITH (FORCE);`);
+    await pgClient.end();
+
+    // Run schema command with system database URL as argument
+    execSync(`npx dbos schema ${systemDatabaseUrl}`, { env: process.env, stdio: 'inherit' });
+
+    // Verify the system database and tables were created
+    const pgSystemClient = new Client({
+      connectionString: systemDatabaseUrl!,
+    });
+    await pgSystemClient.connect();
+
+    const tableExists = await pgSystemClient.query<ExistenceCheck>(
+      `SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = 'dbos' AND table_name = 'operation_outputs')`,
+    );
+    expect(tableExists.rows[0].exists).toBe(true);
+
+    await pgSystemClient.end();
+  });
+});

--- a/tests/migrate.test.ts
+++ b/tests/migrate.test.ts
@@ -2,6 +2,8 @@ import { execSync } from 'child_process';
 import { Client } from 'pg';
 import { generateDBOSTestConfig } from './helpers';
 import { ExistenceCheck } from '../src/system_database';
+import { DBOS } from '../src';
+import { DBOSConfig } from '../dist/src';
 
 describe('schema-command-tests', () => {
   test('test schema command with system database URL argument', async () => {
@@ -34,5 +36,80 @@ describe('schema-command-tests', () => {
     expect(tableExists.rows[0].exists).toBe(true);
 
     await pgSystemClient.end();
+  });
+
+  test('test schema command with permissions for application role', async () => {
+    const databaseName = 'schema_migrate_test';
+    const roleName = 'schema-migrate-test-role';
+    const rolePassword = 'schema_migrate_test_password';
+
+    const config = generateDBOSTestConfig();
+    const baseUrl = new URL(config.systemDatabaseUrl!);
+    const dbUrl = new URL(baseUrl.toString());
+    dbUrl.pathname = `/${databaseName}`;
+
+    // Drop the DBOS database if it exists. Create a test role with no permissions.
+    const pgClient = new Client({
+      connectionString: baseUrl.toString(),
+    });
+    await pgClient.connect();
+    await pgClient.query(`DROP DATABASE IF EXISTS ${databaseName} WITH (FORCE)`);
+    await pgClient.query(`DROP ROLE IF EXISTS "${roleName}"`);
+    await pgClient.query(`CREATE ROLE "${roleName}" WITH LOGIN PASSWORD '${rolePassword}'`);
+    await pgClient.end();
+
+    // Using the admin role, create the DBOS database and verify it exists.
+    // Set permissions for the test role.
+    execSync(`npx dbos schema ${dbUrl.toString()}`, {
+      env: process.env,
+      stdio: 'inherit',
+    });
+
+    const pgVerifyClient = new Client({
+      connectionString: baseUrl.toString(),
+    });
+    await pgVerifyClient.connect();
+    const result = await pgVerifyClient.query<{ count: string }>(
+      `SELECT COUNT(*) FROM pg_database WHERE datname = $1`,
+      [databaseName],
+    );
+    expect(result.rows[0].count).toBe('1');
+    await pgVerifyClient.end();
+
+    // Initialize DBOS with the test role. Verify various operations work.
+    const testDbUrl = new URL(dbUrl.toString());
+    testDbUrl.username = roleName;
+    testDbUrl.password = rolePassword;
+
+    await DBOS.shutdown();
+    const roleConfig: DBOSConfig = {
+      name: 'schema-migrate-test',
+      databaseUrl: testDbUrl.toString(),
+      systemDatabaseUrl: testDbUrl.toString(),
+    };
+    DBOS.setConfig(roleConfig);
+
+    const testWorkflow = DBOS.registerWorkflow(
+      async () => {
+        const id = DBOS.workflowID;
+        expect(id).toBeTruthy();
+        await DBOS.setEvent(id!, id!);
+        return id!;
+      },
+      { name: 'migrate-test-workflow' },
+    );
+
+    await DBOS.launch();
+
+    const workflowId = await testWorkflow();
+    expect(workflowId).toBeTruthy();
+    expect(await DBOS.getEvent(workflowId, workflowId)).toBe(workflowId);
+
+    const steps = await DBOS.listWorkflowSteps(workflowId);
+    expect(steps).toHaveLength(2);
+    expect(steps![0].name).toBe('testTransaction');
+    expect(steps![1].name).toBe('setEvent');
+
+    await DBOS.shutdown();
   });
 });


### PR DESCRIPTION
When creating the DBOS system tables with `npx dbos schema` you can now specify an "application role."
If you specify this role, it is granted all permissions needed to run a DBOS app.

```
Usage: dbos schema [options] [systemDatabaseUrl]

Create the DBOS system database and its internal tables

Arguments:
  systemDatabaseUrl        System database URL

Options:
  -d, --appDir <string>    Specify the application root directory
  -r, --app-role <string>  The role with which you will run your DBOS application
  -h, --help               display help for command
```

This is most useful in settings where the application runs with an "application role" that does not have sufficient privileges to create the DBOS system database or system tables. Prior to deployment, the dbos migrate command can be run with a privileged user to create DBOS system tables, specifying the application role to which to grant permissions on those tables. Then, the application can safely run with the application role.