### PR TITLE
Custom Pool

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -188,6 +188,7 @@ export function translateDbosConfig(options: DBOSConfig, forceConsole: boolean =
     name: options.name,
     systemDatabaseUrl,
     sysDbPoolSize: options.systemDatabasePoolSize,
+    systemDatabasePool: options.systemDatabasePool,
     telemetry: {
       logs: {
         logLevel: options.logLevel || 'info',

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -83,6 +83,7 @@ import {
 } from './workflow_management';
 import { maskDatabaseUrl } from './database_utils';
 import { debouncerWorkflowFunction } from './debouncer';
+import { Pool } from 'pg';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface DBOSNull {}
@@ -97,6 +98,7 @@ export interface DBOSConfig {
 
   systemDatabaseUrl?: string;
   systemDatabasePoolSize?: number;
+  systemDatabasePool?: Pool;
 
   enableOTLP?: boolean;
   logLevel?: string;
@@ -139,6 +141,7 @@ export type DBOSConfigInternal = {
 
   systemDatabaseUrl: string;
   sysDbPoolSize?: number;
+  systemDatabasePool?: Pool;
 
   telemetry: TelemetryConfig;
 
@@ -247,6 +250,7 @@ export class DBOSExecutor {
         this.config.systemDatabaseUrl,
         this.logger,
         this.config.sysDbPoolSize,
+        this.config.systemDatabasePool,
       );
     }
 

--- a/src/sysdb_migrations/migration_runner.ts
+++ b/src/sysdb_migrations/migration_runner.ts
@@ -1,4 +1,4 @@
-import type { Client } from 'pg';
+import type { ClientBase } from 'pg';
 
 export type DBMigration = {
   name?: string;
@@ -7,7 +7,7 @@ export type DBMigration = {
 };
 
 /** Get the current DB version, or 0 if table is missing/empty. */
-export async function getCurrentSysDBVersion(client: Client): Promise<number> {
+export async function getCurrentSysDBVersion(client: ClientBase): Promise<number> {
   // Does table exist?
   const regRes = await client.query<{ table_name: string | null }>(
     "SELECT table_name FROM information_schema.tables WHERE table_schema = 'dbos' AND table_name = 'dbos_migrations'",
@@ -55,7 +55,7 @@ function isDDLAlreadyAppliedPgError(err: unknown, ignoreCodes: ReadonlySet<strin
 
 /** Run a list of statements, ignoring “already applied” errors. */
 async function runStatementsIgnoring(
-  client: Client,
+  client: ClientBase,
   stmts: ReadonlyArray<string>,
   ignoreCodes: ReadonlySet<string>,
   warn: (m: string, e?: unknown) => void,
@@ -81,7 +81,7 @@ async function runStatementsIgnoring(
  * - Warns if current version > max known (likely newer software concurrently)
  */
 export async function runSysMigrationsPg(
-  client: Client,
+  client: ClientBase,
   allMigrations: ReadonlyArray<DBMigration>,
   opts: PgMigratorOptions = {},
 ): Promise<{

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -44,6 +44,7 @@ export const DBOS_FUNCNAME_SLEEP = 'DBOS.sleep';
 export const DBOS_FUNCNAME_GETSTATUS = 'getStatus';
 export const DBOS_FUNCNAME_WRITESTREAM = 'DBOS.writeStream';
 export const DBOS_FUNCNAME_CLOSESTREAM = 'DBOS.closeStream';
+export const DEFAULT_POOL_SIZE = 10;
 
 export const DBOS_STREAM_CLOSED_SENTINEL = '__DBOS_STREAM_CLOSED__';
 
@@ -765,7 +766,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
   constructor(
     readonly systemDatabaseUrl: string,
     readonly logger: GlobalLogger,
-    sysDbPoolSize: number = 10,
+    sysDbPoolSize: number = DEFAULT_POOL_SIZE,
     systemDatabasePool?: Pool,
   ) {
     if (systemDatabasePool) {

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1718,15 +1718,19 @@ export class PostgresSystemDatabase implements SystemDatabase {
         client.on('notification', handler);
         client.on('error', (err: Error) => {
           this.logger.warn(`Error in notifications client: ${err}`);
-          client!.removeAllListeners();
-          client!.release(true);
+          if (client) {
+            client.removeAllListeners();
+            client.release(true);
+          }
           reconnect();
         });
         this.notificationsClient = client;
       } catch (error) {
         this.logger.warn(`Error in notifications listener: ${String(error)}`);
-        client!.removeAllListeners();
-        client!.release(true);
+        if (client) {
+          client.removeAllListeners();
+          client.release(true);
+        }
         reconnect();
       }
     };

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -6,6 +6,7 @@ import { DBOSConfig } from '../src/dbos-executor';
 import { Client, Pool } from 'pg';
 import { DBOSWorkflowCancelledError, DBOSAwaitedWorkflowCancelledError } from '../src/error';
 import assert from 'node:assert';
+import { DBOSClient } from '../dist/src';
 
 describe('dbos-tests', () => {
   let username: string;
@@ -530,5 +531,12 @@ describe('custom-pool-test', () => {
     const handle = await DBOS.startWorkflow(workflow)();
     await DBOS.send(handle.workflowID, message);
     assert.equal(await handle.getResult(), message);
+
+    const client = DBOSClient.create({
+      systemDatabaseUrl: config.systemDatabaseUrl!,
+      systemDatabasePool: config.systemDatabasePool,
+    });
+    const clientHandle = (await client).retrieveWorkflow(handle.workflowID);
+    assert.equal(await clientHandle.getResult(), message);
   });
 });

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -7,6 +7,7 @@ import { Client, Pool } from 'pg';
 import { DBOSWorkflowCancelledError, DBOSAwaitedWorkflowCancelledError } from '../src/error';
 import assert from 'node:assert';
 import { DBOSClient } from '../dist/src';
+import { dropPGDatabase, ensurePGDatabase } from '../src/database_utils';
 
 describe('dbos-tests', () => {
   let username: string;
@@ -510,6 +511,8 @@ describe('custom-pool-test', () => {
 
   test('custom-pool-test', async () => {
     const baseConfig = generateDBOSTestConfig();
+    await dropPGDatabase({ urlToDrop: baseConfig.systemDatabaseUrl, logger: () => {} });
+    await ensurePGDatabase({ urlToEnsure: baseConfig.systemDatabaseUrl, logger: () => {} });
     await setUpDBOSTestSysDb(baseConfig);
     const systemDatabaseURL = baseConfig.systemDatabaseUrl;
     assert(systemDatabaseURL);


### PR DESCRIPTION
You can now pass in a custom `node-postgres` pool through DBOS configuration. If a pool is passed in, DBOS **exclusively** uses it to access the system database; it does not construct any pool of its own.

```typescript
const systemDatabaseURL = ...
const pool = new Pool({ connectionString: systemDatabaseURL });
const config: DBOSConfig = {
  name: "my-dbos-app"
  systemDatabaseUrl: systemDatabaseURL,
  systemDatabasePool: pool,
};
DBOS.setConfig(config);
await DBOS.launch();
```