### PR TITLE
Improve Shutdown

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -437,10 +437,13 @@ export class DBOSExecutor {
     this.logger.info('DBOS launched!');
   }
 
-  async destroy(options?: { workflowCompletionTimeoutSec?: number }) {
-    const timeoutSec = options?.workflowCompletionTimeoutSec;
+  /** Wait for workflows running in this process to finish, for at most `timeoutSec` if one is given. */
+  async awaitRunningWorkflows(timeoutSec?: number) {
+    await this.systemDatabase.awaitRunningWorkflows(timeoutSec === undefined ? undefined : timeoutSec * 1000);
+  }
+
+  async destroy() {
     try {
-      await this.systemDatabase.awaitRunningWorkflows(timeoutSec === undefined ? undefined : timeoutSec * 1000);
       await this.systemDatabase.destroy();
       await this.logger.destroy();
     } catch (err) {

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -437,9 +437,10 @@ export class DBOSExecutor {
     this.logger.info('DBOS launched!');
   }
 
-  async destroy() {
+  async destroy(options?: { workflowCompletionTimeoutSec?: number }) {
+    const timeoutSec = options?.workflowCompletionTimeoutSec;
     try {
-      await this.systemDatabase.awaitRunningWorkflows();
+      await this.systemDatabase.awaitRunningWorkflows(timeoutSec === undefined ? undefined : timeoutSec * 1000);
       await this.systemDatabase.destroy();
       await this.logger.destroy();
     } catch (err) {

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -437,9 +437,9 @@ export class DBOSExecutor {
     this.logger.info('DBOS launched!');
   }
 
-  /** Wait for workflows running in this process to finish, for at most `timeoutSec` if one is given. */
-  async awaitRunningWorkflows(timeoutSec?: number) {
-    await this.systemDatabase.awaitRunningWorkflows(timeoutSec === undefined ? undefined : timeoutSec * 1000);
+  /** Wait up to `timeoutMS` for workflows running in this process to finish. Without a timeout, do not wait. */
+  async awaitRunningWorkflows(timeoutMS?: number) {
+    await this.systemDatabase.awaitRunningWorkflows(timeoutMS);
   }
 
   async destroy() {

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -793,19 +793,17 @@ export class DBOSExecutor {
       exec: DBOSExecutor,
     ): Promise<{ recorded: boolean; reviveError: () => Promise<Error> }> {
       // Record the error.
-      const e = err as Error & { dbos_already_logged?: boolean };
-      const sererr = await serializeResErrorWithSerializer(e, eserializer, ires.serialization ?? null);
+      const sererr = await serializeResErrorWithSerializer(err, eserializer, ires.serialization ?? null);
       internalStatus.error = sererr.serializedValue;
       internalStatus.status = StatusString.ERROR;
       releaseRunningWorkflow();
       const recorded = await exec.systemDatabase.recordWorkflowError(workflowID, internalStatus);
       if (recorded) {
-        exec.logger.error(e);
-        e.dbos_already_logged = true;
+        exec.logger.error(err);
       } else {
-        exec.logger.debug(e);
+        exec.logger.debug(err);
       }
-      span.setStatus({ code: SpanStatusCode.ERROR, message: e.message });
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
       return {
         recorded,
         // deserializeResError can throw directly if the serialized error represents a portable workflow error.

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -589,8 +589,9 @@ export class DBOS {
   /**
    * Shut down DBOS processing:
    *   Stops receiving external workflow requests
+   *   Stops workflow processing, optionally waiting for workflows running here to finish
    *   Disconnects from administration / Conductor
-   *   Stops workflow processing and disconnects from databases
+   *   Disconnects from the databases
    * @param options Optional shutdown options.
    * @param options.deregister
    *   If true, clear the DBOS workflow, queue, instance, data source, listener, and other registries.

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -616,6 +616,11 @@ export class DBOS {
       );
     }
 
+    // Mark uninitialized before any teardown, so callers guarding on isInitialized() do not re-enter.
+    if (DBOSExecutor.globalInstance) {
+      DBOSExecutor.globalInstance.initialized = false;
+    }
+
     // Stop the admin server
     if (DBOS.adminServer) {
       DBOS.adminServer.close();

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -415,6 +415,8 @@ export class DBOS {
   ///////
   static adminServer: Server | undefined = undefined;
   static conductor: Conductor | undefined = undefined;
+  // Blocks launch/shutdown overlap: `initialized` goes false before the drain, so it cannot do this job.
+  static #shuttingDown: boolean = false;
 
   /**
    * Set configuration of `DBOS` prior to `launch`
@@ -438,6 +440,10 @@ export class DBOS {
    * @param options - Launch options for connecting to DBOS Conductor
    */
   static async launch(options?: DBOSLaunchOptions): Promise<void> {
+    if (DBOS.#shuttingDown) {
+      throw new DBOSError('Cannot call DBOS.launch while DBOS.shutdown is in progress.');
+    }
+
     const configFile = await readConfigFile();
 
     let internalConfig = DBOS.#dbosConfig ? translateDbosConfig(DBOS.#dbosConfig) : getDbosConfig(configFile);
@@ -616,52 +622,62 @@ export class DBOS {
       );
     }
 
-    // Mark uninitialized before any teardown, so callers guarding on isInitialized() do not re-enter.
-    if (DBOSExecutor.globalInstance) {
-      DBOSExecutor.globalInstance.initialized = false;
-    }
+    // Tear down the executor this call started with, not whatever the global points at later.
+    const executor = DBOSExecutor.globalInstance;
 
-    // Stop the admin server
-    if (DBOS.adminServer) {
-      DBOS.adminServer.close();
-      DBOS.adminServer = undefined;
-    }
-
-    // Stop background processing, then drain the workflows still running in this process.
-    // Conductor stays connected for the drain, so it can still observe and cancel those workflows.
-    if (DBOSExecutor.globalInstance) {
-      await DBOSExecutor.globalInstance.deactivateEventReceivers();
-      await DBOSExecutor.globalInstance.awaitRunningWorkflows(drainTimeoutMS);
-    }
-
-    // Stop the conductor
-    if (DBOS.conductor) {
-      DBOS.conductor.stop();
-      while (!DBOS.conductor.isClosed) {
-        await sleepms(500);
+    DBOS.#shuttingDown = true;
+    try {
+      // Report uninitialized for the whole teardown; #shuttingDown is what blocks a relaunch.
+      if (executor) {
+        executor.initialized = false;
       }
-      DBOS.conductor = undefined;
+
+      // Stop the admin server
+      if (DBOS.adminServer) {
+        DBOS.adminServer.close();
+        DBOS.adminServer = undefined;
+      }
+
+      // Stop background processing, then drain the workflows still running in this process.
+      // Conductor stays connected for the drain, so it can still observe and cancel those workflows.
+      if (executor) {
+        await executor.deactivateEventReceivers();
+        await executor.awaitRunningWorkflows(drainTimeoutMS);
+      }
+
+      // Stop the conductor
+      if (DBOS.conductor) {
+        DBOS.conductor.stop();
+        while (!DBOS.conductor.isClosed) {
+          await sleepms(500);
+        }
+        DBOS.conductor = undefined;
+      }
+
+      // Disconnect the executor from the databases
+      if (executor) {
+        await executor.destroy();
+        if (DBOSExecutor.globalInstance === executor) {
+          DBOSExecutor.globalInstance = undefined;
+        }
+      }
+
+      for (const [_n, ds] of transactionalDataSources) {
+        await ds.destroy();
+      }
+
+      // Reset the global app name, version and executor ID
+      globalParams.appVersion = process.env.DBOS__APPVERSION || '';
+      globalParams.wasComputed = false;
+      globalParams.appID = process.env.DBOS__APPID || '';
+      globalParams.executorID = process.env.DBOS__VMID || 'local';
+      // Set at launch from the config, so a relaunch under another name must not inherit this one.
+      globalParams.appName = undefined;
+
+      recordDBOSShutdown();
+    } finally {
+      DBOS.#shuttingDown = false;
     }
-
-    // Disconnect the executor from the databases
-    if (DBOSExecutor.globalInstance) {
-      await DBOSExecutor.globalInstance.destroy();
-      DBOSExecutor.globalInstance = undefined;
-    }
-
-    for (const [_n, ds] of transactionalDataSources) {
-      await ds.destroy();
-    }
-
-    // Reset the global app name, version and executor ID
-    globalParams.appVersion = process.env.DBOS__APPVERSION || '';
-    globalParams.wasComputed = false;
-    globalParams.appID = process.env.DBOS__APPID || '';
-    globalParams.executorID = process.env.DBOS__VMID || 'local';
-    // Set at launch from the config, so a relaunch under another name must not inherit this one.
-    globalParams.appName = undefined;
-
-    recordDBOSShutdown();
 
     if (options?.deregister) {
       DBOS.clearRegistry();

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -598,8 +598,12 @@ export class DBOS {
    *   Functions may then be registered before the next call to DBOS.launch().
    *   Decorated / registered functions created prior to `clearRegistry` may no longer be used.
    *     Fresh wrappers may be created from the original functions.
+   * @param options.workflowCompletionTimeoutSec
+   *   How long to wait, after background processing stops, for workflows running in this process
+   *   to complete. If they do not finish in time, shutdown proceeds without them.
+   *   Defaults to waiting indefinitely.
    */
-  static async shutdown(options?: { deregister?: boolean }) {
+  static async shutdown(options?: { deregister?: boolean; workflowCompletionTimeoutSec?: number }) {
     // Stop the admin server
     if (DBOS.adminServer) {
       DBOS.adminServer.close();
@@ -618,7 +622,9 @@ export class DBOS {
     // Stop the executor
     if (DBOSExecutor.globalInstance) {
       await DBOSExecutor.globalInstance.deactivateEventReceivers();
-      await DBOSExecutor.globalInstance.destroy();
+      await DBOSExecutor.globalInstance.destroy({
+        workflowCompletionTimeoutSec: options?.workflowCompletionTimeoutSec,
+      });
       DBOSExecutor.globalInstance = undefined;
     }
 

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -601,7 +601,7 @@ export class DBOS {
    * @param options.workflowCompletionTimeoutSec
    *   How long to wait, after background processing stops, for workflows running in this process
    *   to complete. If they do not finish in time, shutdown proceeds without them.
-   *   Defaults to waiting indefinitely.
+   *   Defaults is to not wait.
    */
   static async shutdown(options?: { deregister?: boolean; workflowCompletionTimeoutSec?: number }) {
     // Stop the admin server

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -610,6 +610,13 @@ export class DBOS {
       DBOS.adminServer = undefined;
     }
 
+    // Stop background processing, then drain the workflows still running in this process.
+    // Conductor stays connected for the drain, so it can still observe and cancel those workflows.
+    if (DBOSExecutor.globalInstance) {
+      await DBOSExecutor.globalInstance.deactivateEventReceivers();
+      await DBOSExecutor.globalInstance.awaitRunningWorkflows(options?.workflowCompletionTimeoutSec);
+    }
+
     // Stop the conductor
     if (DBOS.conductor) {
       DBOS.conductor.stop();
@@ -619,12 +626,9 @@ export class DBOS {
       DBOS.conductor = undefined;
     }
 
-    // Stop the executor
+    // Disconnect the executor from the databases
     if (DBOSExecutor.globalInstance) {
-      await DBOSExecutor.globalInstance.deactivateEventReceivers();
-      await DBOSExecutor.globalInstance.destroy({
-        workflowCompletionTimeoutSec: options?.workflowCompletionTimeoutSec,
-      });
+      await DBOSExecutor.globalInstance.destroy();
       DBOSExecutor.globalInstance = undefined;
     }
 

--- a/src/dbos.ts
+++ b/src/dbos.ts
@@ -598,12 +598,23 @@ export class DBOS {
    *   Functions may then be registered before the next call to DBOS.launch().
    *   Decorated / registered functions created prior to `clearRegistry` may no longer be used.
    *     Fresh wrappers may be created from the original functions.
-   * @param options.workflowCompletionTimeoutSec
+   * @param options.workflowCompletionTimeoutMS
    *   How long to wait, after background processing stops, for workflows running in this process
    *   to complete. If they do not finish in time, shutdown proceeds without them.
-   *   Defaults is to not wait.
+   *   Default is to not wait.
    */
-  static async shutdown(options?: { deregister?: boolean; workflowCompletionTimeoutSec?: number }) {
+  static async shutdown(options?: { deregister?: boolean; workflowCompletionTimeoutMS?: number }) {
+    // Validate before tearing anything down, so a bad timeout leaves DBOS running.
+    const drainTimeoutMS = options?.workflowCompletionTimeoutMS;
+    if (
+      drainTimeoutMS !== undefined &&
+      (!Number.isFinite(drainTimeoutMS) || drainTimeoutMS < 0 || drainTimeoutMS > sleepConfig.maxTimeoutMS)
+    ) {
+      throw new DBOSError(
+        `Invalid workflowCompletionTimeoutMS '${drainTimeoutMS}': must be between 0 and ${sleepConfig.maxTimeoutMS} ms. Omit it to shut down without waiting.`,
+      );
+    }
+
     // Stop the admin server
     if (DBOS.adminServer) {
       DBOS.adminServer.close();
@@ -614,7 +625,7 @@ export class DBOS {
     // Conductor stays connected for the drain, so it can still observe and cancel those workflows.
     if (DBOSExecutor.globalInstance) {
       await DBOSExecutor.globalInstance.deactivateEventReceivers();
-      await DBOSExecutor.globalInstance.awaitRunningWorkflows(options?.workflowCompletionTimeoutSec);
+      await DBOSExecutor.globalInstance.awaitRunningWorkflows(drainTimeoutMS);
     }
 
     // Stop the conductor

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -2417,25 +2417,38 @@ export class SystemDatabase {
 
   /** Wait for locally-running workflows to finish, for at most `timeoutMS` if one is given. */
   async awaitRunningWorkflows(timeoutMS?: number): Promise<void> {
+    const deadline = timeoutMS === undefined ? undefined : Date.now() + timeoutMS;
     if (this.runningWorkflowMap.size > 0) {
       this.logger.info('Waiting for pending workflows to finish.');
-      const allRunning = Promise.allSettled(Array.from(this.runningWorkflowMap.values(), (entry) => entry.promise));
-      if (timeoutMS === undefined) {
-        await allRunning;
-      } else {
-        let timer: ReturnType<typeof setTimeout> | undefined;
-        const timedOut = await Promise.race([
-          allRunning.then(() => false),
-          new Promise<boolean>((resolve) => {
-            timer = setTimeout(() => resolve(true), timeoutMS);
-          }),
-        ]);
-        clearTimeout(timer);
-        if (timedOut) {
-          this.logger.warn(
-            `Shutting down while ${this.runningWorkflowMap.size} workflows are still running: ${Array.from(this.runningWorkflowMap.keys()).join(', ')}`,
-          );
-        }
+    }
+    // Each pass picks up workflows a draining workflow started, and awaits any given ID only once.
+    const awaited = new Set<string>();
+    for (;;) {
+      const pending = Array.from(this.runningWorkflowMap)
+        .filter(([workflowID]) => !awaited.has(workflowID))
+        .map(([workflowID, entry]) => {
+          awaited.add(workflowID);
+          return entry.promise;
+        });
+      if (pending.length === 0) break;
+      const allPending = Promise.allSettled(pending);
+      if (deadline === undefined) {
+        await allPending;
+        continue;
+      }
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timedOut = await Promise.race([
+        allPending.then(() => false),
+        new Promise<boolean>((resolve) => {
+          timer = setTimeout(() => resolve(true), Math.max(0, deadline - Date.now()));
+        }),
+      ]);
+      clearTimeout(timer);
+      if (timedOut) {
+        this.logger.warn(
+          `Shutting down while ${this.runningWorkflowMap.size} workflows are still running: ${Array.from(this.runningWorkflowMap.keys()).join(', ')}`,
+        );
+        break;
       }
     }
     if (this.workflowEventsMap.map.size > 0) {

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -2415,41 +2415,38 @@ export class SystemDatabase {
     return count;
   }
 
-  /** Wait for locally-running workflows to finish, for at most `timeoutMS` if one is given. */
+  /** Wait up to `timeoutMS` for locally-running workflows to finish. Without a timeout, do not wait at all. */
   async awaitRunningWorkflows(timeoutMS?: number): Promise<void> {
-    const deadline = timeoutMS === undefined ? undefined : Date.now() + timeoutMS;
-    if (this.runningWorkflowMap.size > 0) {
-      this.logger.info('Waiting for pending workflows to finish.');
+    if (timeoutMS !== undefined && timeoutMS > 0) {
+      const deadline = Date.now() + timeoutMS;
+      if (this.runningWorkflowMap.size > 0) {
+        this.logger.info('Waiting for pending workflows to finish.');
+      }
+      // Each pass picks up workflows a draining workflow started, and awaits any given ID only once.
+      const awaited = new Set<string>();
+      for (;;) {
+        const pending = Array.from(this.runningWorkflowMap)
+          .filter(([workflowID]) => !awaited.has(workflowID))
+          .map(([workflowID, entry]) => {
+            awaited.add(workflowID);
+            return entry.promise;
+          });
+        if (pending.length === 0) break;
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const timedOut = await Promise.race([
+          Promise.allSettled(pending).then(() => false),
+          new Promise<boolean>((resolve) => {
+            timer = setTimeout(() => resolve(true), Math.max(0, deadline - Date.now()));
+          }),
+        ]);
+        clearTimeout(timer);
+        if (timedOut) break;
+      }
     }
-    // Each pass picks up workflows a draining workflow started, and awaits any given ID only once.
-    const awaited = new Set<string>();
-    for (;;) {
-      const pending = Array.from(this.runningWorkflowMap)
-        .filter(([workflowID]) => !awaited.has(workflowID))
-        .map(([workflowID, entry]) => {
-          awaited.add(workflowID);
-          return entry.promise;
-        });
-      if (pending.length === 0) break;
-      const allPending = Promise.allSettled(pending);
-      if (deadline === undefined) {
-        await allPending;
-        continue;
-      }
-      let timer: ReturnType<typeof setTimeout> | undefined;
-      const timedOut = await Promise.race([
-        allPending.then(() => false),
-        new Promise<boolean>((resolve) => {
-          timer = setTimeout(() => resolve(true), Math.max(0, deadline - Date.now()));
-        }),
-      ]);
-      clearTimeout(timer);
-      if (timedOut) {
-        this.logger.warn(
-          `Shutting down while ${this.runningWorkflowMap.size} workflows are still running: ${Array.from(this.runningWorkflowMap.keys()).join(', ')}`,
-        );
-        break;
-      }
+    if (this.runningWorkflowMap.size > 0) {
+      this.logger.warn(
+        `Shutting down while ${this.runningWorkflowMap.size} workflows are still running: ${Array.from(this.runningWorkflowMap.keys()).join(', ')}`,
+      );
     }
     if (this.workflowEventsMap.map.size > 0) {
       this.logger.warn('Workflow events map is not empty - shutdown is not clean.');

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -2377,11 +2377,8 @@ export class SystemDatabase {
     // Need to await for the workflow and capture errors.
     const awaitWorkflowPromise = workflowPromise
       .catch((error) => {
-        if (this.#destroyed) {
-          this.logger.warn(`Workflow ${workflowID} was abandoned by shutdown: ${error}`);
-        } else {
-          this.logger.debug('Captured error in awaitWorkflowPromise: ' + error);
-        }
+        const outcome = this.#destroyed ? 'was abandoned by shutdown' : 'failed';
+        this.logger.debug(`Workflow ${workflowID} ${outcome}: ${error}`);
       })
       .finally(() => {
         onSettled();

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -2415,10 +2415,28 @@ export class SystemDatabase {
     return count;
   }
 
-  async awaitRunningWorkflows(): Promise<void> {
+  /** Wait for locally-running workflows to finish, for at most `timeoutMS` if one is given. */
+  async awaitRunningWorkflows(timeoutMS?: number): Promise<void> {
     if (this.runningWorkflowMap.size > 0) {
       this.logger.info('Waiting for pending workflows to finish.');
-      await Promise.allSettled(Array.from(this.runningWorkflowMap.values(), (entry) => entry.promise));
+      const allRunning = Promise.allSettled(Array.from(this.runningWorkflowMap.values(), (entry) => entry.promise));
+      if (timeoutMS === undefined) {
+        await allRunning;
+      } else {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const timedOut = await Promise.race([
+          allRunning.then(() => false),
+          new Promise<boolean>((resolve) => {
+            timer = setTimeout(() => resolve(true), timeoutMS);
+          }),
+        ]);
+        clearTimeout(timer);
+        if (timedOut) {
+          this.logger.warn(
+            `Shutting down while ${this.runningWorkflowMap.size} workflows are still running: ${Array.from(this.runningWorkflowMap.keys()).join(', ')}`,
+          );
+        }
+      }
     }
     if (this.workflowEventsMap.map.size > 0) {
       this.logger.warn('Workflow events map is not empty - shutdown is not clean.');

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -2377,7 +2377,11 @@ export class SystemDatabase {
     // Need to await for the workflow and capture errors.
     const awaitWorkflowPromise = workflowPromise
       .catch((error) => {
-        this.logger.debug('Captured error in awaitWorkflowPromise: ' + error);
+        if (this.#destroyed) {
+          this.logger.warn(`Workflow ${workflowID} was abandoned by shutdown: ${error}`);
+        } else {
+          this.logger.debug('Captured error in awaitWorkflowPromise: ' + error);
+        }
       })
       .finally(() => {
         onSettled();
@@ -2422,16 +2426,14 @@ export class SystemDatabase {
       if (this.runningWorkflowMap.size > 0) {
         this.logger.info('Waiting for pending workflows to finish.');
       }
-      // Each pass picks up workflows a draining workflow started, and awaits any given ID only once.
-      const awaited = new Set<string>();
+      // Each pass picks up workflows a draining workflow started, and awaits any given run only once.
+      const awaited = new Set<Promise<unknown>>();
       for (;;) {
-        const pending = Array.from(this.runningWorkflowMap)
-          .filter(([workflowID]) => !awaited.has(workflowID))
-          .map(([workflowID, entry]) => {
-            awaited.add(workflowID);
-            return entry.promise;
-          });
+        const pending = Array.from(this.runningWorkflowMap.values(), (entry) => entry.promise).filter(
+          (promise) => !awaited.has(promise),
+        );
         if (pending.length === 0) break;
+        for (const promise of pending) awaited.add(promise);
         let timer: ReturnType<typeof setTimeout> | undefined;
         const timedOut = await Promise.race([
           Promise.allSettled(pending).then(() => false),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,11 +58,7 @@ export const globalParams = {
   dbosVersion: loadDbosVersion(), // The version of the DBOS library
   dbosCloud: process.env.DBOS__CLOUD === 'true', // Whether running in DBOS Cloud
 };
-export const sleepms = (ms: number) =>
-  new Promise((r) => {
-    // Unref'd: a pending sleep must not keep the process alive after DBOS shuts down.
-    setTimeout(r, ms).unref();
-  });
+export const sleepms = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 // Node.js setTimeout uses a 32-bit signed integer for the delay, so the max is 2^31 - 1 ms (~24.8 days).
 export const sleepConfig = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,7 +58,11 @@ export const globalParams = {
   dbosVersion: loadDbosVersion(), // The version of the DBOS library
   dbosCloud: process.env.DBOS__CLOUD === 'true', // Whether running in DBOS Cloud
 };
-export const sleepms = (ms: number) => new Promise((r) => setTimeout(r, ms));
+export const sleepms = (ms: number) =>
+  new Promise((r) => {
+    // Unref'd: a pending sleep must not keep the process alive after DBOS shuts down.
+    setTimeout(r, ms).unref();
+  });
 
 // Node.js setTimeout uses a 32-bit signed integer for the delay, so the max is 2^31 - 1 ms (~24.8 days).
 export const sleepConfig = {

--- a/tests/scheduler_decorator.test.ts
+++ b/tests/scheduler_decorator.test.ts
@@ -22,7 +22,8 @@ describe('cf-scheduled-wf-tests-simple', () => {
   });
 
   afterEach(async () => {
-    await DBOS.shutdown();
+    // scheduledDefault sleeps 2s, so let the in-flight runs finish instead of stranding them.
+    await DBOS.shutdown({ workflowCompletionTimeoutMS: 10000 });
   });
 
   test('wf-scheduled', async () => {
@@ -277,7 +278,8 @@ describe('decorator-free-scheduled', () => {
   });
 
   afterEach(async () => {
-    await DBOS.shutdown();
+    // scheduledDefault sleeps 2s, so let the in-flight runs finish instead of stranding them.
+    await DBOS.shutdown({ workflowCompletionTimeoutMS: 10000 });
   });
 
   test('free-func-scheduled', async () => {

--- a/tests/shutdown_timeout.test.ts
+++ b/tests/shutdown_timeout.test.ts
@@ -2,6 +2,7 @@ import { DBOS } from '../src/';
 import { DBOSConfig } from '../src/dbos-executor';
 import { generateDBOSTestConfig, setUpDBOSTestSysDb, Event } from './helpers';
 import { sleepms } from '../src/utils';
+import { Conductor } from '../src/conductor/conductor';
 
 const started = new Event();
 const release = new Event();
@@ -12,6 +13,19 @@ const blockingWorkflow = DBOS.registerWorkflow(
     await release.wait();
   },
   { name: 'shutdownTimeoutBlockingWorkflow' },
+);
+
+const started2 = new Event();
+const release2 = new Event();
+let workflow2Done = false;
+
+const blockingWorkflow2 = DBOS.registerWorkflow(
+  async () => {
+    started2.set();
+    await release2.wait();
+    workflow2Done = true;
+  },
+  { name: 'shutdownConductorOrderWorkflow' },
 );
 
 const childStarted = new Event();
@@ -89,6 +103,31 @@ describe('shutdown-workflow-completion-timeout', () => {
     releaseChild.set();
     await shutdownPromise;
     expect(childFinished).toBe(true);
+  }, 20000);
+
+  test('conductor-disconnects-after-the-drain', async () => {
+    await DBOS.launch();
+    await DBOS.startWorkflow(blockingWorkflow2)();
+    await started2.wait();
+
+    let stopSawWorkflowDone: boolean | undefined = undefined;
+    const fakeConductor = {
+      isClosed: false,
+      stop() {
+        stopSawWorkflowDone = workflow2Done;
+        this.isClosed = true;
+      },
+    };
+    DBOS.conductor = fakeConductor as unknown as Conductor;
+
+    const shutdownPromise = DBOS.shutdown({ workflowCompletionTimeoutSec: 30 });
+    await sleepms(500);
+    expect(stopSawWorkflowDone).toBeUndefined();
+
+    release2.set();
+    await shutdownPromise;
+    expect(stopSawWorkflowDone).toBe(true);
+    expect(DBOS.conductor).toBeUndefined();
   }, 20000);
 
   test('shutdown-returns-when-workflows-complete-before-timeout', async () => {

--- a/tests/shutdown_timeout.test.ts
+++ b/tests/shutdown_timeout.test.ts
@@ -68,6 +68,8 @@ const parentWorkflow = DBOS.registerWorkflow(
 
 describe('shutdown-workflow-completion-timeout', () => {
   let config: DBOSConfig;
+  // A shutdown a test started but may not have finished, so cleanup settles it before the next launch.
+  let pendingShutdown: Promise<void> | undefined;
 
   beforeAll(async () => {
     config = generateDBOSTestConfig();
@@ -76,6 +78,11 @@ describe('shutdown-workflow-completion-timeout', () => {
   });
 
   afterEach(async () => {
+    if (pendingShutdown) {
+      await pendingShutdown;
+      pendingShutdown = undefined;
+    }
+    DBOS.conductor = undefined;
     if (DBOS.isInitialized()) {
       await DBOS.shutdown();
     }
@@ -112,21 +119,21 @@ describe('shutdown-workflow-completion-timeout', () => {
     await DBOS.startWorkflow(parentWorkflow)();
     await parentStarted.wait();
 
-    // The drain logs this synchronously, in the same turn as its first snapshot of the
-    // running workflows, so releasing the parent afterwards guarantees the child registers later.
+    // Set in the same turn as the drain's first snapshot of the running workflows, so
+    // releasing the parent afterwards guarantees the child registers later.
     let drainStarted = false;
-    const logger = DBOSExecutor.globalInstance!.systemDatabase.logger;
-    const infoSpy = jest.spyOn(logger, 'info').mockImplementation((logEntry: unknown) => {
-      if (typeof logEntry === 'string' && logEntry.includes('Waiting for pending workflows')) {
-        drainStarted = true;
-      }
+    const executor = DBOSExecutor.globalInstance!;
+    const drainSpy = jest.spyOn(executor, 'awaitRunningWorkflows').mockImplementation(async (timeoutMS?: number) => {
+      drainStarted = true;
+      await executor.systemDatabase.awaitRunningWorkflows(timeoutMS);
     });
 
     try {
       let shutdownDone = false;
-      const shutdownPromise = DBOS.shutdown({ workflowCompletionTimeoutMS: 30000 }).then(() => {
+      const shutdownPromise = DBOS.shutdown({ workflowCompletionTimeoutMS: 10000 }).then(() => {
         shutdownDone = true;
       });
+      pendingShutdown = shutdownPromise.catch(() => {});
 
       while (!drainStarted) {
         await sleepms(10);
@@ -141,7 +148,7 @@ describe('shutdown-workflow-completion-timeout', () => {
       await shutdownPromise;
       expect(childFinished).toBe(true);
     } finally {
-      infoSpy.mockRestore();
+      drainSpy.mockRestore();
       releaseParent.set();
       releaseChild.set();
     }
@@ -162,7 +169,8 @@ describe('shutdown-workflow-completion-timeout', () => {
     };
     DBOS.conductor = fakeConductor as unknown as Conductor;
 
-    const shutdownPromise = DBOS.shutdown({ workflowCompletionTimeoutMS: 30000 });
+    const shutdownPromise = DBOS.shutdown({ workflowCompletionTimeoutMS: 10000 });
+    pendingShutdown = shutdownPromise.catch(() => {});
     try {
       await sleepms(500);
       expect(stopSawWorkflowDone).toBeUndefined();
@@ -182,7 +190,7 @@ describe('shutdown-workflow-completion-timeout', () => {
     try {
       const startTime = Date.now();
       await DBOS.shutdown();
-      expect(Date.now() - startTime).toBeLessThan(1000);
+      expect(Date.now() - startTime).toBeLessThan(10000);
       expect(workflow3Done).toBe(false);
     } finally {
       release3.set();

--- a/tests/shutdown_timeout.test.ts
+++ b/tests/shutdown_timeout.test.ts
@@ -1,5 +1,5 @@
 import { DBOS } from '../src/';
-import { DBOSConfig } from '../src/dbos-executor';
+import { DBOSConfig, DBOSExecutor } from '../src/dbos-executor';
 import { generateDBOSTestConfig, setUpDBOSTestSysDb, Event } from './helpers';
 import { sleepms } from '../src/utils';
 import { Conductor } from '../src/conductor/conductor';
@@ -75,6 +75,12 @@ describe('shutdown-workflow-completion-timeout', () => {
     DBOS.setConfig(config);
   });
 
+  afterEach(async () => {
+    if (DBOS.isInitialized()) {
+      await DBOS.shutdown();
+    }
+  });
+
   afterAll(() => {
     release.set();
     release2.set();
@@ -88,15 +94,17 @@ describe('shutdown-workflow-completion-timeout', () => {
     const handle = await DBOS.startWorkflow(blockingWorkflow)();
     await started.wait();
 
-    const startTime = Date.now();
-    await DBOS.shutdown({ workflowCompletionTimeoutMS: 1000 });
-    const elapsed = Date.now() - startTime;
+    try {
+      const startTime = Date.now();
+      await DBOS.shutdown({ workflowCompletionTimeoutMS: 1000 });
+      const elapsed = Date.now() - startTime;
 
-    expect(elapsed).toBeGreaterThanOrEqual(900);
-    expect(elapsed).toBeLessThan(10000);
-
-    release.set();
-    await handle.getResult().catch(() => {});
+      expect(elapsed).toBeGreaterThanOrEqual(900);
+      expect(elapsed).toBeLessThan(10000);
+    } finally {
+      release.set();
+      await handle.getResult().catch(() => {});
+    }
   }, 20000);
 
   test('shutdown-waits-for-a-child-started-during-the-drain', async () => {
@@ -104,22 +112,39 @@ describe('shutdown-workflow-completion-timeout', () => {
     await DBOS.startWorkflow(parentWorkflow)();
     await parentStarted.wait();
 
-    let shutdownDone = false;
-    const shutdownPromise = DBOS.shutdown({ workflowCompletionTimeoutMS: 30000 }).then(() => {
-      shutdownDone = true;
+    // The drain logs this synchronously, in the same turn as its first snapshot of the
+    // running workflows, so releasing the parent afterwards guarantees the child registers later.
+    let drainStarted = false;
+    const logger = DBOSExecutor.globalInstance!.systemDatabase.logger;
+    const infoSpy = jest.spyOn(logger, 'info').mockImplementation((logEntry: unknown) => {
+      if (typeof logEntry === 'string' && logEntry.includes('Waiting for pending workflows')) {
+        drainStarted = true;
+      }
     });
 
-    // The parent starts its child only after the drain is already under way.
-    await sleepms(500);
-    releaseParent.set();
-    await childStarted.wait();
-    await sleepms(500);
-    expect(shutdownDone).toBe(false);
-    expect(childFinished).toBe(false);
+    try {
+      let shutdownDone = false;
+      const shutdownPromise = DBOS.shutdown({ workflowCompletionTimeoutMS: 30000 }).then(() => {
+        shutdownDone = true;
+      });
 
-    releaseChild.set();
-    await shutdownPromise;
-    expect(childFinished).toBe(true);
+      while (!drainStarted) {
+        await sleepms(10);
+      }
+      releaseParent.set();
+      await childStarted.wait();
+      await sleepms(500);
+      expect(shutdownDone).toBe(false);
+      expect(childFinished).toBe(false);
+
+      releaseChild.set();
+      await shutdownPromise;
+      expect(childFinished).toBe(true);
+    } finally {
+      infoSpy.mockRestore();
+      releaseParent.set();
+      releaseChild.set();
+    }
   }, 20000);
 
   test('conductor-disconnects-after-the-drain', async () => {
@@ -138,11 +163,13 @@ describe('shutdown-workflow-completion-timeout', () => {
     DBOS.conductor = fakeConductor as unknown as Conductor;
 
     const shutdownPromise = DBOS.shutdown({ workflowCompletionTimeoutMS: 30000 });
-    await sleepms(500);
-    expect(stopSawWorkflowDone).toBeUndefined();
-
-    release2.set();
-    await shutdownPromise;
+    try {
+      await sleepms(500);
+      expect(stopSawWorkflowDone).toBeUndefined();
+    } finally {
+      release2.set();
+      await shutdownPromise;
+    }
     expect(stopSawWorkflowDone).toBe(true);
     expect(DBOS.conductor).toBeUndefined();
   }, 20000);
@@ -152,12 +179,14 @@ describe('shutdown-workflow-completion-timeout', () => {
     const handle = await DBOS.startWorkflow(blockingWorkflow3)();
     await started3.wait();
 
-    const startTime = Date.now();
-    await DBOS.shutdown();
-    expect(Date.now() - startTime).toBeLessThan(1000);
-    expect(workflow3Done).toBe(false);
-
-    release3.set();
-    await handle.getResult().catch(() => {});
+    try {
+      const startTime = Date.now();
+      await DBOS.shutdown();
+      expect(Date.now() - startTime).toBeLessThan(1000);
+      expect(workflow3Done).toBe(false);
+    } finally {
+      release3.set();
+      await handle.getResult().catch(() => {});
+    }
   }, 20000);
 });

--- a/tests/shutdown_timeout.test.ts
+++ b/tests/shutdown_timeout.test.ts
@@ -89,7 +89,7 @@ describe('shutdown-workflow-completion-timeout', () => {
     await started.wait();
 
     const startTime = Date.now();
-    await DBOS.shutdown({ workflowCompletionTimeoutSec: 1 });
+    await DBOS.shutdown({ workflowCompletionTimeoutMS: 1000 });
     const elapsed = Date.now() - startTime;
 
     expect(elapsed).toBeGreaterThanOrEqual(900);
@@ -105,7 +105,7 @@ describe('shutdown-workflow-completion-timeout', () => {
     await parentStarted.wait();
 
     let shutdownDone = false;
-    const shutdownPromise = DBOS.shutdown({ workflowCompletionTimeoutSec: 30 }).then(() => {
+    const shutdownPromise = DBOS.shutdown({ workflowCompletionTimeoutMS: 30000 }).then(() => {
       shutdownDone = true;
     });
 
@@ -137,7 +137,7 @@ describe('shutdown-workflow-completion-timeout', () => {
     };
     DBOS.conductor = fakeConductor as unknown as Conductor;
 
-    const shutdownPromise = DBOS.shutdown({ workflowCompletionTimeoutSec: 30 });
+    const shutdownPromise = DBOS.shutdown({ workflowCompletionTimeoutMS: 30000 });
     await sleepms(500);
     expect(stopSawWorkflowDone).toBeUndefined();
 

--- a/tests/shutdown_timeout.test.ts
+++ b/tests/shutdown_timeout.test.ts
@@ -1,0 +1,51 @@
+import { DBOS } from '../src/';
+import { DBOSConfig } from '../src/dbos-executor';
+import { generateDBOSTestConfig, setUpDBOSTestSysDb, Event } from './helpers';
+
+const started = new Event();
+const release = new Event();
+
+const blockingWorkflow = DBOS.registerWorkflow(
+  async () => {
+    started.set();
+    await release.wait();
+  },
+  { name: 'shutdownTimeoutBlockingWorkflow' },
+);
+
+describe('shutdown-workflow-completion-timeout', () => {
+  let config: DBOSConfig;
+
+  beforeAll(async () => {
+    config = generateDBOSTestConfig();
+    await setUpDBOSTestSysDb(config);
+    DBOS.setConfig(config);
+  });
+
+  afterAll(() => {
+    release.set();
+  });
+
+  test('shutdown-waits-for-workflow-then-times-out', async () => {
+    await DBOS.launch();
+    const handle = await DBOS.startWorkflow(blockingWorkflow)();
+    await started.wait();
+
+    const startTime = Date.now();
+    await DBOS.shutdown({ workflowCompletionTimeoutSec: 1 });
+    const elapsed = Date.now() - startTime;
+
+    expect(elapsed).toBeGreaterThanOrEqual(900);
+    expect(elapsed).toBeLessThan(10000);
+
+    release.set();
+    await handle.getResult().catch(() => {});
+  }, 20000);
+
+  test('shutdown-returns-when-workflows-complete-before-timeout', async () => {
+    await DBOS.launch();
+    const startTime = Date.now();
+    await DBOS.shutdown({ workflowCompletionTimeoutSec: 30 });
+    expect(Date.now() - startTime).toBeLessThan(10000);
+  }, 20000);
+});

--- a/tests/shutdown_timeout.test.ts
+++ b/tests/shutdown_timeout.test.ts
@@ -1,45 +1,51 @@
 import { DBOS } from '../src/';
 import { DBOSConfig, DBOSExecutor } from '../src/dbos-executor';
-import { generateDBOSTestConfig, setUpDBOSTestSysDb, Event } from './helpers';
-import { sleepms } from '../src/utils';
-import { Conductor } from '../src/conductor/conductor';
+import { generateDBOSTestConfig, setUpDBOSTestSysDb, retryUntilSuccess, Event } from './helpers';
+import { sleepConfig, sleepms } from '../src/utils';
+import { DBOSError } from '../src/error';
+import type { Conductor } from '../src/conductor/conductor';
 
-const started = new Event();
-const release = new Event();
+// Every wait in this file is bounded: an unbounded one outlives the jest timeout that fails the test.
+const WAIT_TIMEOUT_MS = 10000;
 
-const blockingWorkflow = DBOS.registerWorkflow(
-  async () => {
-    started.set();
-    await release.wait();
-  },
-  { name: 'shutdownTimeoutBlockingWorkflow' },
-);
+async function waitFor(event: Event, what: string) {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      event.wait(),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`Timed out waiting for ${what}`)), WAIT_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
-const started2 = new Event();
-const release2 = new Event();
-let workflow2Done = false;
+const allReleases: Event[] = [];
 
-const blockingWorkflow2 = DBOS.registerWorkflow(
-  async () => {
-    started2.set();
-    await release2.wait();
-    workflow2Done = true;
-  },
-  { name: 'shutdownConductorOrderWorkflow' },
-);
+/** A workflow that parks until released, so a shutdown can be observed while it runs. */
+function blockingWorkflow(name: string) {
+  const started = new Event();
+  const release = new Event();
+  const state = { done: false };
+  allReleases.push(release);
+  const workflow = DBOS.registerWorkflow(
+    async () => {
+      started.set();
+      await release.wait();
+      state.done = true;
+    },
+    { name },
+  );
+  return { workflow, started, release, state };
+}
 
-const started3 = new Event();
-const release3 = new Event();
-let workflow3Done = false;
-
-const blockingWorkflow3 = DBOS.registerWorkflow(
-  async () => {
-    started3.set();
-    await release3.wait();
-    workflow3Done = true;
-  },
-  { name: 'shutdownDefaultNoWaitWorkflow' },
-);
+const drained = blockingWorkflow('shutdownTimeoutBlockingWorkflow');
+const conductorOrder = blockingWorkflow('shutdownConductorOrderWorkflow');
+const defaultNoWait = blockingWorkflow('shutdownDefaultNoWaitWorkflow');
+const zeroNoWait = blockingWorkflow('shutdownZeroTimeoutWorkflow');
+const relaunchGuard = blockingWorkflow('shutdownRelaunchGuardWorkflow');
 
 const childStarted = new Event();
 const releaseChild = new Event();
@@ -70,11 +76,25 @@ describe('shutdown-workflow-completion-timeout', () => {
   let config: DBOSConfig;
   // A shutdown a test started but may not have finished, so cleanup settles it before the next launch.
   let pendingShutdown: Promise<void> | undefined;
+  let pendingShutdownError: Error | undefined;
 
-  beforeAll(async () => {
+  // Returns the raw promise so a caller awaiting it still sees a rejection; afterEach surfaces it otherwise.
+  function trackShutdown(promise: Promise<void>): Promise<void> {
+    pendingShutdown = promise.catch((e: unknown) => {
+      pendingShutdownError = e instanceof Error ? e : new Error(String(e));
+    });
+    return promise;
+  }
+
+  beforeAll(() => {
     config = generateDBOSTestConfig();
-    await setUpDBOSTestSysDb(config);
     DBOS.setConfig(config);
+  });
+
+  // These tests deliberately abandon workflows, and a PENDING row left behind would be recovered
+  // (and re-run) by the next test's launch, so each one gets a fresh system database.
+  beforeEach(async () => {
+    await setUpDBOSTestSysDb(config);
   });
 
   afterEach(async () => {
@@ -83,33 +103,35 @@ describe('shutdown-workflow-completion-timeout', () => {
       pendingShutdown = undefined;
     }
     DBOS.conductor = undefined;
-    if (DBOS.isInitialized()) {
+    // Not isInitialized(): shutdown clears that before the drain, so a shutdown that failed
+    // partway leaves an executor here that still needs closing.
+    if (DBOSExecutor.globalInstance) {
       await DBOS.shutdown();
     }
+    const failure = pendingShutdownError;
+    pendingShutdownError = undefined;
+    if (failure) throw failure;
   });
 
   afterAll(() => {
-    release.set();
-    release2.set();
-    release3.set();
+    for (const release of allReleases) release.set();
     releaseParent.set();
     releaseChild.set();
   });
 
   test('shutdown-waits-for-workflow-then-times-out', async () => {
     await DBOS.launch();
-    const handle = await DBOS.startWorkflow(blockingWorkflow)();
-    await started.wait();
+    const handle = await DBOS.startWorkflow(drained.workflow)();
+    await waitFor(drained.started, 'the blocking workflow to start');
 
     try {
       const startTime = Date.now();
       await DBOS.shutdown({ workflowCompletionTimeoutMS: 1000 });
-      const elapsed = Date.now() - startTime;
 
-      expect(elapsed).toBeGreaterThanOrEqual(900);
-      expect(elapsed).toBeLessThan(10000);
+      expect(Date.now() - startTime).toBeGreaterThanOrEqual(900);
+      expect(drained.state.done).toBe(false);
     } finally {
-      release.set();
+      drained.release.set();
       await handle.getResult().catch(() => {});
     }
   }, 20000);
@@ -117,7 +139,7 @@ describe('shutdown-workflow-completion-timeout', () => {
   test('shutdown-waits-for-a-child-started-during-the-drain', async () => {
     await DBOS.launch();
     await DBOS.startWorkflow(parentWorkflow)();
-    await parentStarted.wait();
+    await waitFor(parentStarted, 'the parent workflow to start');
 
     // Set in the same turn as the drain's first snapshot of the running workflows, so
     // releasing the parent afterwards guarantees the child registers later.
@@ -130,16 +152,17 @@ describe('shutdown-workflow-completion-timeout', () => {
 
     try {
       let shutdownDone = false;
-      const shutdownPromise = DBOS.shutdown({ workflowCompletionTimeoutMS: 10000 }).then(() => {
-        shutdownDone = true;
-      });
-      pendingShutdown = shutdownPromise.catch(() => {});
+      const shutdownPromise = trackShutdown(
+        DBOS.shutdown({ workflowCompletionTimeoutMS: 10000 }).then(() => {
+          shutdownDone = true;
+        }),
+      );
 
-      while (!drainStarted) {
-        await sleepms(10);
-      }
+      await retryUntilSuccess(() => {
+        expect(drainStarted).toBe(true);
+      });
       releaseParent.set();
-      await childStarted.wait();
+      await waitFor(childStarted, 'the child workflow to start');
       await sleepms(500);
       expect(shutdownDone).toBe(false);
       expect(childFinished).toBe(false);
@@ -156,26 +179,25 @@ describe('shutdown-workflow-completion-timeout', () => {
 
   test('conductor-disconnects-after-the-drain', async () => {
     await DBOS.launch();
-    await DBOS.startWorkflow(blockingWorkflow2)();
-    await started2.wait();
+    await DBOS.startWorkflow(conductorOrder.workflow)();
+    await waitFor(conductorOrder.started, 'the blocking workflow to start');
 
     let stopSawWorkflowDone: boolean | undefined = undefined;
     const fakeConductor = {
       isClosed: false,
       stop() {
-        stopSawWorkflowDone = workflow2Done;
+        stopSawWorkflowDone = conductorOrder.state.done;
         this.isClosed = true;
       },
     };
     DBOS.conductor = fakeConductor as unknown as Conductor;
 
-    const shutdownPromise = DBOS.shutdown({ workflowCompletionTimeoutMS: 10000 });
-    pendingShutdown = shutdownPromise.catch(() => {});
+    const shutdownPromise = trackShutdown(DBOS.shutdown({ workflowCompletionTimeoutMS: 10000 }));
     try {
       await sleepms(500);
       expect(stopSawWorkflowDone).toBeUndefined();
     } finally {
-      release2.set();
+      conductorOrder.release.set();
       await shutdownPromise;
     }
     expect(stopSawWorkflowDone).toBe(true);
@@ -184,17 +206,57 @@ describe('shutdown-workflow-completion-timeout', () => {
 
   test('shutdown-does-not-wait-when-no-timeout-is-given', async () => {
     await DBOS.launch();
-    const handle = await DBOS.startWorkflow(blockingWorkflow3)();
-    await started3.wait();
+    const handle = await DBOS.startWorkflow(defaultNoWait.workflow)();
+    await waitFor(defaultNoWait.started, 'the blocking workflow to start');
 
     try {
-      const startTime = Date.now();
       await DBOS.shutdown();
-      expect(Date.now() - startTime).toBeLessThan(10000);
-      expect(workflow3Done).toBe(false);
+      expect(defaultNoWait.state.done).toBe(false);
     } finally {
-      release3.set();
+      defaultNoWait.release.set();
       await handle.getResult().catch(() => {});
     }
+  }, 20000);
+
+  test('a-zero-timeout-does-not-wait', async () => {
+    await DBOS.launch();
+    const handle = await DBOS.startWorkflow(zeroNoWait.workflow)();
+    await waitFor(zeroNoWait.started, 'the blocking workflow to start');
+
+    try {
+      await DBOS.shutdown({ workflowCompletionTimeoutMS: 0 });
+      expect(zeroNoWait.state.done).toBe(false);
+    } finally {
+      zeroNoWait.release.set();
+      await handle.getResult().catch(() => {});
+    }
+  }, 20000);
+
+  test('an-invalid-timeout-is-rejected-and-leaves-dbos-running', async () => {
+    await DBOS.launch();
+
+    for (const invalid of [-1, Number.NaN, Number.POSITIVE_INFINITY, sleepConfig.maxTimeoutMS + 1]) {
+      await expect(DBOS.shutdown({ workflowCompletionTimeoutMS: invalid })).rejects.toThrow(DBOSError);
+      expect(DBOS.isInitialized()).toBe(true);
+    }
+  }, 20000);
+
+  test('launch-is-refused-while-a-shutdown-is-in-flight', async () => {
+    await DBOS.launch();
+    const executor = DBOSExecutor.globalInstance;
+    const handle = await DBOS.startWorkflow(relaunchGuard.workflow)();
+    await waitFor(relaunchGuard.started, 'the blocking workflow to start');
+
+    const shutdownPromise = trackShutdown(DBOS.shutdown({ workflowCompletionTimeoutMS: 10000 }));
+    try {
+      await expect(DBOS.launch()).rejects.toThrow(DBOSError);
+      // The refused launch must not have swapped in an executor for the drain to tear down instead.
+      expect(DBOSExecutor.globalInstance).toBe(executor);
+    } finally {
+      relaunchGuard.release.set();
+      await shutdownPromise;
+      await handle.getResult().catch(() => {});
+    }
+    expect(DBOSExecutor.globalInstance).toBeUndefined();
   }, 20000);
 });

--- a/tests/shutdown_timeout.test.ts
+++ b/tests/shutdown_timeout.test.ts
@@ -1,6 +1,7 @@
 import { DBOS } from '../src/';
 import { DBOSConfig } from '../src/dbos-executor';
 import { generateDBOSTestConfig, setUpDBOSTestSysDb, Event } from './helpers';
+import { sleepms } from '../src/utils';
 
 const started = new Event();
 const release = new Event();
@@ -11,6 +12,31 @@ const blockingWorkflow = DBOS.registerWorkflow(
     await release.wait();
   },
   { name: 'shutdownTimeoutBlockingWorkflow' },
+);
+
+const childStarted = new Event();
+const releaseChild = new Event();
+let childFinished = false;
+
+const childWorkflow = DBOS.registerWorkflow(
+  async () => {
+    childStarted.set();
+    await releaseChild.wait();
+    childFinished = true;
+  },
+  { name: 'shutdownTimeoutChildWorkflow' },
+);
+
+const parentStarted = new Event();
+const releaseParent = new Event();
+
+const parentWorkflow = DBOS.registerWorkflow(
+  async () => {
+    parentStarted.set();
+    await releaseParent.wait();
+    await DBOS.startWorkflow(childWorkflow)();
+  },
+  { name: 'shutdownTimeoutParentWorkflow' },
 );
 
 describe('shutdown-workflow-completion-timeout', () => {
@@ -40,6 +66,29 @@ describe('shutdown-workflow-completion-timeout', () => {
 
     release.set();
     await handle.getResult().catch(() => {});
+  }, 20000);
+
+  test('shutdown-waits-for-a-child-started-during-the-drain', async () => {
+    await DBOS.launch();
+    await DBOS.startWorkflow(parentWorkflow)();
+    await parentStarted.wait();
+
+    let shutdownDone = false;
+    const shutdownPromise = DBOS.shutdown({ workflowCompletionTimeoutSec: 30 }).then(() => {
+      shutdownDone = true;
+    });
+
+    // The parent starts its child only after the drain is already under way.
+    await sleepms(500);
+    releaseParent.set();
+    await childStarted.wait();
+    await sleepms(500);
+    expect(shutdownDone).toBe(false);
+    expect(childFinished).toBe(false);
+
+    releaseChild.set();
+    await shutdownPromise;
+    expect(childFinished).toBe(true);
   }, 20000);
 
   test('shutdown-returns-when-workflows-complete-before-timeout', async () => {

--- a/tests/shutdown_timeout.test.ts
+++ b/tests/shutdown_timeout.test.ts
@@ -28,6 +28,19 @@ const blockingWorkflow2 = DBOS.registerWorkflow(
   { name: 'shutdownConductorOrderWorkflow' },
 );
 
+const started3 = new Event();
+const release3 = new Event();
+let workflow3Done = false;
+
+const blockingWorkflow3 = DBOS.registerWorkflow(
+  async () => {
+    started3.set();
+    await release3.wait();
+    workflow3Done = true;
+  },
+  { name: 'shutdownDefaultNoWaitWorkflow' },
+);
+
 const childStarted = new Event();
 const releaseChild = new Event();
 let childFinished = false;
@@ -64,6 +77,10 @@ describe('shutdown-workflow-completion-timeout', () => {
 
   afterAll(() => {
     release.set();
+    release2.set();
+    release3.set();
+    releaseParent.set();
+    releaseChild.set();
   });
 
   test('shutdown-waits-for-workflow-then-times-out', async () => {
@@ -130,10 +147,17 @@ describe('shutdown-workflow-completion-timeout', () => {
     expect(DBOS.conductor).toBeUndefined();
   }, 20000);
 
-  test('shutdown-returns-when-workflows-complete-before-timeout', async () => {
+  test('shutdown-does-not-wait-when-no-timeout-is-given', async () => {
     await DBOS.launch();
+    const handle = await DBOS.startWorkflow(blockingWorkflow3)();
+    await started3.wait();
+
     const startTime = Date.now();
-    await DBOS.shutdown({ workflowCompletionTimeoutSec: 30 });
-    expect(Date.now() - startTime).toBeLessThan(10000);
+    await DBOS.shutdown();
+    expect(Date.now() - startTime).toBeLessThan(1000);
+    expect(workflow3Done).toBe(false);
+
+    release3.set();
+    await handle.getResult().catch(() => {});
   }, 20000);
 });


### PR DESCRIPTION
`DBOS.shutdown` now takes a `workflowCompletionTimeoutMS` option. If this is set, it will "drain" locally running workflows for that period of time before shutting down.

The new shutdown sequence is:

1. Shut down event receivers and the queue thread, so new workflows are not started.
2. "Drain" locally running workflows for `workflowCompletionTimeoutMS`, if set.
3. Disconnect from Conductor.
4. Shut down the system database.