### PR TITLE
Statement Timeouts for Observability Queries

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -243,6 +243,7 @@ export class DBOSClient {
     systemDatabasePollingConcurrency?: number,
     logger?: DLogger,
     applicationName?: string,
+    observabilityQueryTimeoutMs?: number,
   ) {
     this.logger = new GlobalLogger(undefined, logger ? { logger } : undefined);
     this.systemDatabase = new SystemDatabase(
@@ -257,6 +258,7 @@ export class DBOSClient {
       systemDatabasePollingConcurrency,
       undefined,
       applicationName,
+      observabilityQueryTimeoutMs,
     );
   }
 
@@ -270,6 +272,7 @@ export class DBOSClient {
    * @param systemDatabasePollingConcurrency - An optional maximum number of concurrent polling operations. Defaults to half the pool size (minimum 1).
    * @param logger - An optional custom logger to which the client directs all its logging, replacing the built-in console logger.
    * @param applicationName - The application this client acts on behalf of. Always set this when several applications share this system database, so workflows, schedules, and queues created by this client are owned by that application.
+   * @param observabilityQueryTimeoutMs - An optional statement timeout, in milliseconds, for read-only observability queries against the system database. Defaults to 30000. Set to 0 or less to disable the cap.
    * @returns A Promise that resolves with the DBOSClient instance.
    */
   static async create({
@@ -281,6 +284,7 @@ export class DBOSClient {
     systemDatabasePollingConcurrency,
     logger,
     applicationName,
+    observabilityQueryTimeoutMs,
   }: {
     systemDatabaseUrl: string;
     systemDatabasePool?: Pool;
@@ -290,6 +294,7 @@ export class DBOSClient {
     systemDatabasePollingConcurrency?: number;
     logger?: DLogger;
     applicationName?: string;
+    observabilityQueryTimeoutMs?: number;
   }): Promise<DBOSClient> {
     const client = new DBOSClient(
       systemDatabaseUrl,
@@ -300,6 +305,7 @@ export class DBOSClient {
       systemDatabasePollingConcurrency,
       logger,
       applicationName,
+      observabilityQueryTimeoutMs,
     );
     return Promise.resolve(client);
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import assert from 'assert';
 import { maskDatabaseUrl } from './database_utils';
 import { DBOSJSON } from './serialization';
+import { validateObservabilityQueryTimeoutMs } from './system_database';
 
 export const dbosConfigFilePath = 'dbos-config.yaml';
 
@@ -188,6 +189,7 @@ export function translateDbosConfig(options: DBOSConfig, forceConsole: boolean =
   ) {
     throw new Error('notificationCoalesceMs must be a finite number at least 1 millisecond');
   }
+  validateObservabilityQueryTimeoutMs(options.observabilityQueryTimeoutMs);
   const systemDatabaseUrl = getSystemDatabaseUrl({
     system_database_url: options.systemDatabaseUrl,
     name: options.name,
@@ -218,6 +220,7 @@ export function translateDbosConfig(options: DBOSConfig, forceConsole: boolean =
     maxConcurrentQueueDispatches: options.maxConcurrentQueueDispatches,
     useListenNotify: options.useListenNotify ?? true,
     notificationCoalesceMs: options.notificationCoalesceMs,
+    observabilityQueryTimeoutMs: options.observabilityQueryTimeoutMs,
     runMigrations: options.runMigrations ?? true,
   };
 }

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -180,6 +180,11 @@ export interface DBOSConfig {
   /** Interval (ms) for coalescing LISTEN/NOTIFY notifications (streams and events) off the write path; bounds read latency. Default 10, min 1. */
   notificationCoalesceMs?: number;
   /**
+   * Statement timeout, in milliseconds, for read-only observability queries against the system
+   * database. Defaults to 30000. Set to 0 or less to disable the cap.
+   */
+  observabilityQueryTimeoutMs?: number;
+  /**
    * Whether to create and migrate the system database on launch. Defaults to true.
    *
    * Set to false for a process that must not alter the schema, such as one whose database
@@ -246,6 +251,7 @@ export type DBOSConfigInternal = {
   maxConcurrentQueueDispatches?: number;
   useListenNotify: boolean;
   notificationCoalesceMs?: number;
+  observabilityQueryTimeoutMs?: number;
   runMigrations: boolean;
 
   http?: {
@@ -371,6 +377,7 @@ export class DBOSExecutor {
         this.config.systemDatabasePollingConcurrency,
         this.config.notificationCoalesceMs,
         this.appName,
+        this.config.observabilityQueryTimeoutMs,
       );
     }
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -261,6 +261,16 @@ export class DBOSStreamNondeterminismError extends DBOSError {
   }
 }
 
+export const QueryTimeout = 35;
+/** Exception raised when a read-only observability query exceeds its statement timeout. */
+export class DBOSQueryTimeoutError extends DBOSError {
+  constructor(readonly timeoutMS: number) {
+    super(`This query was cancelled after exceeding its ${timeoutMS}ms statement timeout.`, QueryTimeout);
+    // Error serialization records err.name, which is otherwise 'Error'.
+    this.name = 'DBOSQueryTimeoutError';
+  }
+}
+
 /**
  * True if `e` is a stream-read timeout, including the portable-serialization
  * replay form, which carries only the original type name.

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -9,6 +9,7 @@ import {
   DBOSQueueDuplicatedError,
   DBOSInitializationError,
   DBOSError,
+  DBOSQueryTimeoutError,
 } from './error';
 import { GetPendingWorkflowsOutput, GetWorkflowsInput, StatusString } from './workflow';
 import {
@@ -105,6 +106,16 @@ export const DBOS_STREAMS_CHANNEL = 'dbos_streams_channel';
 
 // Interval for coalescing LISTEN/NOTIFY notifications off the write path; caps the rate of notifying commits regardless of write throughput.
 export const DEFAULT_NOTIFICATION_COALESCE_MS = 10;
+
+// An introspection query scanning a huge table for minutes holds back xmin, stalling autovacuum database-wide.
+export const DEFAULT_OBSERVABILITY_QUERY_TIMEOUT_MS = 30_000;
+
+/** Reject NaN/inf: the timeout is rendered into a `SET LOCAL statement_timeout`. */
+export function validateObservabilityQueryTimeoutMs(value: number | undefined): void {
+  if (value !== undefined && !Number.isFinite(value)) {
+    throw new Error(`observabilityQueryTimeoutMs must be a finite number, got ${value}`);
+  }
+}
 
 export interface WorkflowScheduleInternal {
   scheduleId: string;
@@ -767,6 +778,11 @@ function retriablePostgresException(err: unknown): boolean {
   return false;
 }
 
+/** 57014 is query_canceled, which is how statement_timeout cancels a query. */
+function isStatementTimeout(err: unknown): boolean {
+  return !!err && typeof err === 'object' && (err as AnyErr).code === '57014';
+}
+
 function isSerializationError(err: unknown): boolean {
   for (const e of unwrapErrors(err)) {
     const anyErr = e as AnyErr;
@@ -904,6 +920,8 @@ export class SystemDatabase {
 
   // Interval for coalescing LISTEN/NOTIFY notifications pushed off the write path (Postgres + L/N only).
   readonly notificationCoalesceMs: number = DEFAULT_NOTIFICATION_COALESCE_MS;
+  // Statement timeout for observability reads, in ms; undefined disables the cap.
+  readonly observabilityQueryTimeoutMs: number | undefined;
   // Coalesced NOTIFY payloads keyed by channel, flushed by the notifier loop; soft-private so tests can drive a flush.
   private pendingNotifications: Map<string, Set<string>> = new Map();
   #notifierActive: boolean = false;
@@ -942,10 +960,15 @@ export class SystemDatabase {
     notificationCoalesceMs: number = DEFAULT_NOTIFICATION_COALESCE_MS,
     // The application this handle acts for; undefined writes unclaimed rows.
     readonly appName?: string,
+    observabilityQueryTimeoutMs: number = DEFAULT_OBSERVABILITY_QUERY_TIMEOUT_MS,
   ) {
     this.schemaName = schemaName;
     this.shouldUseDBNotifications = useListenNotify;
     this.notificationCoalesceMs = notificationCoalesceMs;
+    validateObservabilityQueryTimeoutMs(observabilityQueryTimeoutMs);
+    // Floor at 1ms: PostgreSQL reads 0 as "no timeout", the loosest cap rather than the tightest.
+    this.observabilityQueryTimeoutMs =
+      observabilityQueryTimeoutMs > 0 ? Math.max(1, Math.round(observabilityQueryTimeoutMs)) : undefined;
 
     if (systemDatabasePool) {
       this.pool = systemDatabasePool;
@@ -982,6 +1005,31 @@ export class SystemDatabase {
   /** Check out a pool connection guarded for as long as we hold it. See {@link borrowClient}. */
   #connect(): Promise<PoolClient> {
     return borrowClient(this.pool, this.#onClientError);
+  }
+
+  /** Cap an introspection read with a statement timeout, so one scanning a huge table cannot hold a snapshot for minutes and stall autovacuum database-wide. */
+  async #observabilityQuery<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
+    const timeoutMs = this.observabilityQueryTimeoutMs;
+    const client = await this.#connect();
+    try {
+      if (timeoutMs === undefined) {
+        return await fn(client);
+      }
+      await client.query('BEGIN');
+      try {
+        // SET LOCAL, so the cap dies with its transaction instead of riding the pooled connection into unrelated queries.
+        await client.query(`SET LOCAL statement_timeout = ${timeoutMs}`);
+        const result = await fn(client);
+        await client.query('COMMIT');
+        return result;
+      } catch (e) {
+        await client.query('ROLLBACK').catch(() => {});
+        // No `cause`: dbRetry walks the cause chain and would retry 57014 forever as an operator intervention.
+        throw isStatementTimeout(e) ? new DBOSQueryTimeoutError(timeoutMs) : e;
+      }
+    } finally {
+      client.release();
+    }
   }
   getSerializer(): DBOSSerializer {
     return this.serializer;
@@ -1581,7 +1629,7 @@ export class SystemDatabase {
       params.push(offset);
       query += ` OFFSET $${params.length}`;
     }
-    const { rows } = await this.pool.query<operation_outputs>(query, params);
+    const { rows } = await this.#observabilityQuery((client) => client.query<operation_outputs>(query, params));
     return rows;
   }
 
@@ -3359,8 +3407,7 @@ export class SystemDatabase {
   // ==================== Observability: Workflow Communications ====================
 
   async getAllEvents(workflowID: string): Promise<Record<string, unknown>> {
-    const client = await this.#connect();
-    try {
+    return await this.#observabilityQuery(async (client) => {
       const result = await client.query<{ key: string; value: string; serialization: string | null }>(
         `SELECT key, value, serialization FROM "${this.schemaName}".workflow_events
          WHERE workflow_uuid = $1`,
@@ -3371,16 +3418,13 @@ export class SystemDatabase {
         events[row.key] = await safeParse(this.serializer, row.value, row.serialization);
       }
       return events;
-    } finally {
-      client.release();
-    }
+    });
   }
 
   async getAllNotifications(
     workflowID: string,
   ): Promise<{ topic: string | null; message: unknown; createdAtEpochMs: number; consumed: boolean }[]> {
-    const client = await this.#connect();
-    try {
+    return await this.#observabilityQuery(async (client) => {
       const result = await client.query<{
         topic: string;
         message: string;
@@ -3402,14 +3446,11 @@ export class SystemDatabase {
           consumed: row.consumed,
         })),
       );
-    } finally {
-      client.release();
-    }
+    });
   }
 
   async getAllStreamEntries(workflowID: string): Promise<Record<string, unknown[]>> {
-    const client = await this.#connect();
-    try {
+    return await this.#observabilityQuery(async (client) => {
       const result = await client.query<{ key: string; value: string; serialization: string | null }>(
         `SELECT key, value, serialization FROM "${this.schemaName}".streams
          WHERE workflow_uuid = $1
@@ -3433,9 +3474,7 @@ export class SystemDatabase {
         (streams[row.key] ??= []).push(value);
       }
       return streams;
-    } finally {
-      client.release();
-    }
+    });
   }
 
   // ==================== Queues ====================
@@ -4067,7 +4106,10 @@ export class SystemDatabase {
       ${offsetClause}
     `;
 
-    const result = await this.pool.query<workflow_status>(query, params);
+    // An ID-keyed read is bounded by its ID list, so it takes no cap: a status lookup must not fail its own caller.
+    const result = idKeyed
+      ? await this.pool.query<workflow_status>(query, params)
+      : await this.#observabilityQuery((client) => client.query<workflow_status>(query, params));
     return result.rows.map(mapWorkflowStatus);
   }
 
@@ -4236,7 +4278,7 @@ export class SystemDatabase {
       GROUP BY ${groupByClause}
     `;
 
-    const result = await this.pool.query<Record<string, unknown>>(query, params);
+    const result = await this.#observabilityQuery((client) => client.query<Record<string, unknown>>(query, params));
 
     const toIntOrNull = (v: unknown): number | null => (v === null || v === undefined ? null : Number(v));
 
@@ -4363,7 +4405,7 @@ export class SystemDatabase {
       GROUP BY ${groupByClause}
     `;
 
-    const result = await this.pool.query<Record<string, unknown>>(query, params);
+    const result = await this.#observabilityQuery((client) => client.query<Record<string, unknown>>(query, params));
 
     const toIntOrNull = (v: unknown): number | null => (v === null || v === undefined ? null : Number(v));
 
@@ -4539,47 +4581,49 @@ export class SystemDatabase {
     const startEpochMs = new Date(startTime).getTime();
     const endEpochMs = new Date(endTime).getTime();
 
-    const metrics: MetricData[] = [];
+    return await this.#observabilityQuery(async (client) => {
+      const metrics: MetricData[] = [];
 
-    // Query workflow metrics
-    const workflowParams: unknown[] = [startEpochMs, endEpochMs];
-    const workflowScope = this.#observabilityFilter('application_name', applicationName, workflowParams);
-    const workflowResult = await this.pool.query<{ name: string; count: string }>(
-      `SELECT name, COUNT(workflow_uuid) as count
-       FROM "${this.schemaName}".workflow_status
-       WHERE created_at >= $1 AND created_at < $2 AND ${workflowScope}
-       GROUP BY name`,
-      workflowParams,
-    );
+      // Query workflow metrics
+      const workflowParams: unknown[] = [startEpochMs, endEpochMs];
+      const workflowScope = this.#observabilityFilter('application_name', applicationName, workflowParams);
+      const workflowResult = await client.query<{ name: string; count: string }>(
+        `SELECT name, COUNT(workflow_uuid) as count
+         FROM "${this.schemaName}".workflow_status
+         WHERE created_at >= $1 AND created_at < $2 AND ${workflowScope}
+         GROUP BY name`,
+        workflowParams,
+      );
 
-    for (const row of workflowResult.rows) {
-      metrics.push({
-        metricType: 'workflow_count',
-        metricName: row.name,
-        value: Number(row.count),
-      });
-    }
+      for (const row of workflowResult.rows) {
+        metrics.push({
+          metricType: 'workflow_count',
+          metricName: row.name,
+          value: Number(row.count),
+        });
+      }
 
-    // Query step metrics
-    const stepParams: unknown[] = [startEpochMs, endEpochMs];
-    const stepScope = this.#observabilityFilter('application_name', applicationName, stepParams);
-    const stepResult = await this.pool.query<{ function_name: string; count: string }>(
-      `SELECT function_name, COUNT(*) as count
-       FROM "${this.schemaName}".operation_outputs
-       WHERE completed_at_epoch_ms >= $1 AND completed_at_epoch_ms < $2 AND ${stepScope}
-       GROUP BY function_name`,
-      stepParams,
-    );
+      // Query step metrics
+      const stepParams: unknown[] = [startEpochMs, endEpochMs];
+      const stepScope = this.#observabilityFilter('application_name', applicationName, stepParams);
+      const stepResult = await client.query<{ function_name: string; count: string }>(
+        `SELECT function_name, COUNT(*) as count
+         FROM "${this.schemaName}".operation_outputs
+         WHERE completed_at_epoch_ms >= $1 AND completed_at_epoch_ms < $2 AND ${stepScope}
+         GROUP BY function_name`,
+        stepParams,
+      );
 
-    for (const row of stepResult.rows) {
-      metrics.push({
-        metricType: 'step_count',
-        metricName: row.function_name,
-        value: Number(row.count),
-      });
-    }
+      for (const row of stepResult.rows) {
+        metrics.push({
+          metricType: 'step_count',
+          metricName: row.function_name,
+          value: Number(row.count),
+        });
+      }
 
-    return metrics;
+      return metrics;
+    });
   }
 
   // ==================== Scheduling ====================
@@ -4905,12 +4949,14 @@ export class SystemDatabase {
   async listApplicationVersions(): Promise<VersionInfo[]> {
     const params: unknown[] = [];
     const scope = this.#appNameFilter('application_name', this.appName, params);
-    const { rows } = await this.pool.query<application_versions>(
-      `SELECT version_id, version_name, version_timestamp, created_at, application_name
-       FROM "${this.schemaName}".application_versions
-       WHERE ${scope}
-       ORDER BY version_timestamp DESC`,
-      params,
+    const { rows } = await this.#observabilityQuery((client) =>
+      client.query<application_versions>(
+        `SELECT version_id, version_name, version_timestamp, created_at, application_name
+         FROM "${this.schemaName}".application_versions
+         WHERE ${scope}
+         ORDER BY version_timestamp DESC`,
+        params,
+      ),
     );
     return rows.map(mapVersionInfo);
   }

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -110,10 +110,15 @@ export const DEFAULT_NOTIFICATION_COALESCE_MS = 10;
 // An introspection query scanning a huge table for minutes holds back xmin, stalling autovacuum database-wide.
 export const DEFAULT_OBSERVABILITY_QUERY_TIMEOUT_MS = 30_000;
 
-/** Reject NaN/inf: the timeout is rendered into a `SET LOCAL statement_timeout`. */
+// PostgreSQL's statement_timeout is an int32 count of milliseconds; anything larger is rejected.
+const MAX_STATEMENT_TIMEOUT_MS = 2_147_483_647;
+
+/** The timeout is rendered into a `SET LOCAL statement_timeout`, which takes only an in-range integer. */
 export function validateObservabilityQueryTimeoutMs(value: number | undefined): void {
-  if (value !== undefined && !Number.isFinite(value)) {
-    throw new Error(`observabilityQueryTimeoutMs must be a finite number, got ${value}`);
+  if (value !== undefined && (!Number.isFinite(value) || value > MAX_STATEMENT_TIMEOUT_MS)) {
+    throw new Error(
+      `observabilityQueryTimeoutMs must be a finite number no greater than ${MAX_STATEMENT_TIMEOUT_MS}, got ${value}`,
+    );
   }
 }
 
@@ -1007,15 +1012,23 @@ export class SystemDatabase {
     return borrowClient(this.pool, this.#onClientError);
   }
 
-  /** Cap an introspection read with a statement timeout, so one scanning a huge table cannot hold a snapshot for minutes and stall autovacuum database-wide. */
-  async #observabilityQuery<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
+  /**
+   * Cap an introspection read with a statement timeout, so one scanning a huge table cannot hold a
+   * snapshot for minutes and stall autovacuum database-wide. Soft-private so tests can assert the cap
+   * from inside the transaction.
+   *
+   * `fn` must only run queries: node-postgres leaves the unnamed portal, and the snapshot registered
+   * with it, alive until commit, so anything else it awaits extends the very hold this bounds.
+   */
+  private async observabilityQuery<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
     const timeoutMs = this.observabilityQueryTimeoutMs;
     const client = await this.#connect();
     try {
       if (timeoutMs === undefined) {
         return await fn(client);
       }
-      await client.query('BEGIN');
+      // Never inherit default_transaction_isolation: a repeatable-read snapshot would outlive its statement.
+      await client.query('BEGIN ISOLATION LEVEL READ COMMITTED READ ONLY');
       try {
         // SET LOCAL, so the cap dies with its transaction instead of riding the pooled connection into unrelated queries.
         await client.query(`SET LOCAL statement_timeout = ${timeoutMs}`);
@@ -1629,7 +1642,7 @@ export class SystemDatabase {
       params.push(offset);
       query += ` OFFSET $${params.length}`;
     }
-    const { rows } = await this.#observabilityQuery((client) => client.query<operation_outputs>(query, params));
+    const { rows } = await this.observabilityQuery((client) => client.query<operation_outputs>(query, params));
     return rows;
   }
 
@@ -3407,25 +3420,25 @@ export class SystemDatabase {
   // ==================== Observability: Workflow Communications ====================
 
   async getAllEvents(workflowID: string): Promise<Record<string, unknown>> {
-    return await this.#observabilityQuery(async (client) => {
-      const result = await client.query<{ key: string; value: string; serialization: string | null }>(
+    const { rows } = await this.observabilityQuery((client) =>
+      client.query<{ key: string; value: string; serialization: string | null }>(
         `SELECT key, value, serialization FROM "${this.schemaName}".workflow_events
          WHERE workflow_uuid = $1`,
         [workflowID],
-      );
-      const events: Record<string, unknown> = {};
-      for (const row of result.rows) {
-        events[row.key] = await safeParse(this.serializer, row.value, row.serialization);
-      }
-      return events;
-    });
+      ),
+    );
+    const events: Record<string, unknown> = {};
+    for (const row of rows) {
+      events[row.key] = await safeParse(this.serializer, row.value, row.serialization);
+    }
+    return events;
   }
 
   async getAllNotifications(
     workflowID: string,
   ): Promise<{ topic: string | null; message: unknown; createdAtEpochMs: number; consumed: boolean }[]> {
-    return await this.#observabilityQuery(async (client) => {
-      const result = await client.query<{
+    const { rows } = await this.observabilityQuery((client) =>
+      client.query<{
         topic: string;
         message: string;
         serialization: string | null;
@@ -3437,44 +3450,44 @@ export class SystemDatabase {
          WHERE destination_uuid = $1
          ORDER BY created_at_epoch_ms`,
         [workflowID],
-      );
-      return await Promise.all(
-        result.rows.map(async (row) => ({
-          topic: row.topic === this.nullTopic ? null : row.topic,
-          message: await safeParse(this.serializer, row.message, row.serialization),
-          createdAtEpochMs: Number(row.created_at_epoch_ms),
-          consumed: row.consumed,
-        })),
-      );
-    });
+      ),
+    );
+    return await Promise.all(
+      rows.map(async (row) => ({
+        topic: row.topic === this.nullTopic ? null : row.topic,
+        message: await safeParse(this.serializer, row.message, row.serialization),
+        createdAtEpochMs: Number(row.created_at_epoch_ms),
+        consumed: row.consumed,
+      })),
+    );
   }
 
   async getAllStreamEntries(workflowID: string): Promise<Record<string, unknown[]>> {
-    return await this.#observabilityQuery(async (client) => {
-      const result = await client.query<{ key: string; value: string; serialization: string | null }>(
+    const { rows } = await this.observabilityQuery((client) =>
+      client.query<{ key: string; value: string; serialization: string | null }>(
         `SELECT key, value, serialization FROM "${this.schemaName}".streams
          WHERE workflow_uuid = $1
          ORDER BY key, "offset"`,
         [workflowID],
-      );
-      const streams: Record<string, unknown[]> = {};
-      const closed = new Set<string>();
-      for (const row of result.rows) {
-        if (closed.has(row.key)) {
-          continue;
-        }
-        // safeParse yields the raw string for the legacy unserialized marker, which does not parse.
-        const value = await safeParse(this.serializer, row.value, row.serialization);
-        if (isStreamClosedSentinel(value)) {
-          // End the stream where readStream does, so the two never disagree.
-          closed.add(row.key);
-          streams[row.key] ??= [];
-          continue;
-        }
-        (streams[row.key] ??= []).push(value);
+      ),
+    );
+    const streams: Record<string, unknown[]> = {};
+    const closed = new Set<string>();
+    for (const row of rows) {
+      if (closed.has(row.key)) {
+        continue;
       }
-      return streams;
-    });
+      // safeParse yields the raw string for the legacy unserialized marker, which does not parse.
+      const value = await safeParse(this.serializer, row.value, row.serialization);
+      if (isStreamClosedSentinel(value)) {
+        // End the stream where readStream does, so the two never disagree.
+        closed.add(row.key);
+        streams[row.key] ??= [];
+        continue;
+      }
+      (streams[row.key] ??= []).push(value);
+    }
+    return streams;
   }
 
   // ==================== Queues ====================
@@ -4109,7 +4122,7 @@ export class SystemDatabase {
     // An ID-keyed read is bounded by its ID list, so it takes no cap: a status lookup must not fail its own caller.
     const result = idKeyed
       ? await this.pool.query<workflow_status>(query, params)
-      : await this.#observabilityQuery((client) => client.query<workflow_status>(query, params));
+      : await this.observabilityQuery((client) => client.query<workflow_status>(query, params));
     return result.rows.map(mapWorkflowStatus);
   }
 
@@ -4278,7 +4291,7 @@ export class SystemDatabase {
       GROUP BY ${groupByClause}
     `;
 
-    const result = await this.#observabilityQuery((client) => client.query<Record<string, unknown>>(query, params));
+    const result = await this.observabilityQuery((client) => client.query<Record<string, unknown>>(query, params));
 
     const toIntOrNull = (v: unknown): number | null => (v === null || v === undefined ? null : Number(v));
 
@@ -4405,7 +4418,7 @@ export class SystemDatabase {
       GROUP BY ${groupByClause}
     `;
 
-    const result = await this.#observabilityQuery((client) => client.query<Record<string, unknown>>(query, params));
+    const result = await this.observabilityQuery((client) => client.query<Record<string, unknown>>(query, params));
 
     const toIntOrNull = (v: unknown): number | null => (v === null || v === undefined ? null : Number(v));
 
@@ -4581,49 +4594,44 @@ export class SystemDatabase {
     const startEpochMs = new Date(startTime).getTime();
     const endEpochMs = new Date(endTime).getTime();
 
-    return await this.#observabilityQuery(async (client) => {
-      const metrics: MetricData[] = [];
+    const workflowParams: unknown[] = [startEpochMs, endEpochMs];
+    const workflowScope = this.#observabilityFilter('application_name', applicationName, workflowParams);
+    const stepParams: unknown[] = [startEpochMs, endEpochMs];
+    const stepScope = this.#observabilityFilter('application_name', applicationName, stepParams);
 
-      // Query workflow metrics
-      const workflowParams: unknown[] = [startEpochMs, endEpochMs];
-      const workflowScope = this.#observabilityFilter('application_name', applicationName, workflowParams);
-      const workflowResult = await client.query<{ name: string; count: string }>(
+    const [workflowResult, stepResult] = await this.observabilityQuery(async (client) => [
+      await client.query<{ name: string; count: string }>(
         `SELECT name, COUNT(workflow_uuid) as count
          FROM "${this.schemaName}".workflow_status
          WHERE created_at >= $1 AND created_at < $2 AND ${workflowScope}
          GROUP BY name`,
         workflowParams,
-      );
-
-      for (const row of workflowResult.rows) {
-        metrics.push({
-          metricType: 'workflow_count',
-          metricName: row.name,
-          value: Number(row.count),
-        });
-      }
-
-      // Query step metrics
-      const stepParams: unknown[] = [startEpochMs, endEpochMs];
-      const stepScope = this.#observabilityFilter('application_name', applicationName, stepParams);
-      const stepResult = await client.query<{ function_name: string; count: string }>(
+      ),
+      await client.query<{ function_name: string; count: string }>(
         `SELECT function_name, COUNT(*) as count
          FROM "${this.schemaName}".operation_outputs
          WHERE completed_at_epoch_ms >= $1 AND completed_at_epoch_ms < $2 AND ${stepScope}
          GROUP BY function_name`,
         stepParams,
-      );
+      ),
+    ]);
 
-      for (const row of stepResult.rows) {
-        metrics.push({
-          metricType: 'step_count',
-          metricName: row.function_name,
-          value: Number(row.count),
-        });
-      }
-
-      return metrics;
-    });
+    const metrics: MetricData[] = [];
+    for (const row of workflowResult.rows) {
+      metrics.push({
+        metricType: 'workflow_count',
+        metricName: row.name,
+        value: Number(row.count),
+      });
+    }
+    for (const row of stepResult.rows) {
+      metrics.push({
+        metricType: 'step_count',
+        metricName: row.function_name,
+        value: Number(row.count),
+      });
+    }
+    return metrics;
   }
 
   // ==================== Scheduling ====================
@@ -4949,7 +4957,7 @@ export class SystemDatabase {
   async listApplicationVersions(): Promise<VersionInfo[]> {
     const params: unknown[] = [];
     const scope = this.#appNameFilter('application_name', this.appName, params);
-    const { rows } = await this.#observabilityQuery((client) =>
+    const { rows } = await this.observabilityQuery((client) =>
       client.query<application_versions>(
         `SELECT version_id, version_name, version_timestamp, created_at, application_name
          FROM "${this.schemaName}".application_versions

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1027,9 +1027,9 @@ export class SystemDatabase {
       if (timeoutMs === undefined) {
         return await fn(client);
       }
-      // Never inherit default_transaction_isolation: a repeatable-read snapshot would outlive its statement.
-      await client.query('BEGIN ISOLATION LEVEL READ COMMITTED READ ONLY');
       try {
+        // Never inherit default_transaction_isolation: a repeatable-read snapshot would outlive its statement.
+        await client.query('BEGIN ISOLATION LEVEL READ COMMITTED READ ONLY');
         // SET LOCAL, so the cap dies with its transaction instead of riding the pooled connection into unrelated queries.
         await client.query(`SET LOCAL statement_timeout = ${timeoutMs}`);
         const result = await fn(client);

--- a/tests/observability_timeout.test.ts
+++ b/tests/observability_timeout.test.ts
@@ -198,6 +198,24 @@ describe('observability-query-timeout', () => {
     }
   });
 
+  test('a failed BEGIN does not return a poisoned client to the pool', async () => {
+    // A one-connection pool, so the next query is guaranteed the same session.
+    const sysdb = makeSysDb(undefined, 1);
+    try {
+      // Leave the pooled connection inside an aborted transaction, as a caller-supplied pool can.
+      const client = await sysdb.pool.connect();
+      await client.query('BEGIN');
+      await client.query('SELECT * FROM "dbos".no_such_table').catch(() => {});
+      client.release();
+
+      // BEGIN fails with 25P02 on the inherited mess, but must leave the connection reusable.
+      await expect(sysdb.listWorkflows({})).rejects.toThrow();
+      await expect(sysdb.listWorkflows({})).resolves.toBeDefined();
+    } finally {
+      await sysdb.destroy();
+    }
+  });
+
   test('deserialization runs after the transaction commits', async () => {
     // node-postgres keeps the portal's snapshot alive until commit, so parsing inside would extend the hold the cap bounds.
     const log: string[] = [];

--- a/tests/observability_timeout.test.ts
+++ b/tests/observability_timeout.test.ts
@@ -1,0 +1,202 @@
+import { Client, PoolClient } from 'pg';
+import { DBOS, DBOSClient, DBOSConfig } from '../src';
+import { translateDbosConfig } from '../src/config';
+import { DBOSExecutor } from '../src/dbos-executor';
+import { DBOSQueryTimeoutError } from '../src/error';
+import { DBOSJSON } from '../src/serialization';
+import { SystemDatabase } from '../src/system_database';
+import { GlobalLogger } from '../src/telemetry/logs';
+import { getClientConfig } from '../src/utils';
+import { generateDBOSTestConfig, setUpDBOSTestSysDb } from './helpers';
+
+describe('observability-query-timeout', () => {
+  let config: DBOSConfig;
+  let systemDatabaseUrl: string;
+
+  beforeAll(async () => {
+    config = generateDBOSTestConfig();
+    systemDatabaseUrl = translateDbosConfig(config).systemDatabaseUrl;
+    await setUpDBOSTestSysDb(config);
+  });
+
+  /** A second handle on the test system database, so a test can pick its own timeout. */
+  function makeSysDb(observabilityQueryTimeoutMs?: number, poolSize: number = 2): SystemDatabase {
+    return new SystemDatabase(
+      systemDatabaseUrl,
+      new GlobalLogger(),
+      DBOSJSON,
+      poolSize,
+      undefined,
+      'dbos',
+      false,
+      undefined,
+      undefined,
+      undefined,
+      observabilityQueryTimeoutMs,
+    );
+  }
+
+  /** Every statement this handle issues, from the connect event on, so nothing predates the listener. */
+  function captureStatements(sysdb: SystemDatabase): string[] {
+    const statements: string[] = [];
+    sysdb.pool.on('connect', (client: PoolClient) => {
+      const query = client.query.bind(client);
+      client.query = ((...args: Parameters<typeof query>) => {
+        const first = args[0];
+        statements.push(typeof first === 'string' ? first : String((first as { text: string }).text));
+        return query(...args);
+      }) as typeof client.query;
+    });
+    return statements;
+  }
+
+  const timeoutStatements = (statements: string[]) => statements.filter((s) => s.includes('statement_timeout'));
+
+  const workflow = DBOS.registerWorkflow(async () => await DBOS.runStep(() => Promise.resolve(1), { name: 's' }), {
+    name: 'observabilityTimeoutWorkflow',
+  });
+
+  test('observability queries carry a statement timeout', async () => {
+    const sysdb = makeSysDb();
+    const statements = captureStatements(sysdb);
+    try {
+      await sysdb.listWorkflows({});
+      expect(timeoutStatements(statements)).toEqual(['SET LOCAL statement_timeout = 30000']);
+    } finally {
+      await sysdb.destroy();
+    }
+  });
+
+  test('every observability query sets the timeout', async () => {
+    const sysdb = makeSysDb();
+    const statements = captureStatements(sysdb);
+    const workflowID = 'no-such-workflow';
+    const start = new Date(Date.now() - 3600_000).toISOString();
+    const end = new Date(Date.now() + 3600_000).toISOString();
+
+    const cases: [string, () => Promise<unknown>][] = [
+      ['listWorkflows', () => sysdb.listWorkflows({})],
+      ['getAllOperationResults', () => sysdb.getAllOperationResults(workflowID)],
+      ['getWorkflowAggregates', () => sysdb.getWorkflowAggregates({ groupByStatus: true, selectCount: true })],
+      ['getStepAggregates', () => sysdb.getStepAggregates({ groupByFunctionName: true, selectCount: true })],
+      ['getMetrics', () => sysdb.getMetrics(start, end)],
+      ['getAllEvents', () => sysdb.getAllEvents(workflowID)],
+      ['getAllNotifications', () => sysdb.getAllNotifications(workflowID)],
+      ['getAllStreamEntries', () => sysdb.getAllStreamEntries(workflowID)],
+      ['listApplicationVersions', () => sysdb.listApplicationVersions()],
+    ];
+
+    try {
+      for (const [name, call] of cases) {
+        statements.length = 0;
+        await call();
+        expect([name, timeoutStatements(statements)]).toEqual([name, ['SET LOCAL statement_timeout = 30000']]);
+      }
+    } finally {
+      await sysdb.destroy();
+    }
+  });
+
+  test('an ID-keyed workflow lookup is not capped', async () => {
+    const sysdb = makeSysDb();
+    const statements = captureStatements(sysdb);
+    try {
+      await sysdb.listWorkflows({ workflowIDs: ['no-such-workflow'] });
+      await sysdb.getWorkflowStatus('no-such-workflow');
+      expect(timeoutStatements(statements)).toEqual([]);
+    } finally {
+      await sysdb.destroy();
+    }
+  });
+
+  test('the statement timeout does not outlive its transaction', async () => {
+    // A one-connection pool, so the next query is guaranteed the same session.
+    const sysdb = makeSysDb(undefined, 1);
+    try {
+      await sysdb.listWorkflows({});
+      const { rows } = await sysdb.pool.query<{ statement_timeout: string }>('SHOW statement_timeout');
+      expect(rows[0].statement_timeout).toBe('0');
+    } finally {
+      await sysdb.destroy();
+    }
+  });
+
+  test('the statement timeout cancels a blocked query', async () => {
+    const sysdb = makeSysDb(300);
+    const blocker = new Client(getClientConfig(systemDatabaseUrl));
+    await blocker.connect();
+    try {
+      await blocker.query('BEGIN');
+      await blocker.query('LOCK TABLE "dbos".workflow_status IN ACCESS EXCLUSIVE MODE');
+      await expect(sysdb.listWorkflows({})).rejects.toThrow(DBOSQueryTimeoutError);
+    } finally {
+      await blocker.query('ROLLBACK');
+      await blocker.end();
+    }
+    try {
+      // The cancelled query leaves its connection usable.
+      await expect(sysdb.listWorkflows({})).resolves.toEqual([]);
+    } finally {
+      await sysdb.destroy();
+    }
+  });
+
+  test('the statement timeout can be disabled', async () => {
+    const sysdb = makeSysDb(0);
+    const statements = captureStatements(sysdb);
+    try {
+      expect(sysdb.observabilityQueryTimeoutMs).toBeUndefined();
+      await sysdb.listWorkflows({});
+      expect(timeoutStatements(statements)).toEqual([]);
+    } finally {
+      await sysdb.destroy();
+    }
+  });
+
+  test('a sub-millisecond statement timeout still caps', async () => {
+    // Rounding down to 0 would hand back no timeout at all, the loosest cap rather than the tightest.
+    const sysdb = makeSysDb(0.4);
+    try {
+      expect(sysdb.observabilityQueryTimeoutMs).toBe(1);
+    } finally {
+      await sysdb.destroy();
+    }
+  });
+
+  test('a non-finite statement timeout is rejected', () => {
+    for (const bad of [NaN, Infinity]) {
+      expect(() => translateDbosConfig({ ...config, observabilityQueryTimeoutMs: bad })).toThrow(
+        'observabilityQueryTimeoutMs',
+      );
+      expect(() => makeSysDb(bad)).toThrow('observabilityQueryTimeoutMs');
+    }
+  });
+
+  test('a configured statement timeout reaches the system database', async () => {
+    DBOS.setConfig({ ...config, observabilityQueryTimeoutMs: 5000 });
+    await DBOS.launch();
+    try {
+      const sysdb = DBOSExecutor.globalInstance!.systemDatabase;
+      expect(sysdb.observabilityQueryTimeoutMs).toBe(5000);
+
+      // The timeout must not disturb a query that finishes inside it.
+      await expect(workflow()).resolves.toBe(1);
+      const workflows = await DBOS.listWorkflows({});
+      expect(workflows.length).toBe(1);
+      await expect(DBOS.listWorkflowSteps(workflows[0].workflowID)).resolves.toHaveLength(1);
+    } finally {
+      await DBOS.shutdown();
+    }
+  });
+
+  test('a client statement timeout reaches the system database', async () => {
+    const client = await DBOSClient.create({ systemDatabaseUrl, observabilityQueryTimeoutMs: 5000 });
+    try {
+      const sysdb = (client as unknown as { systemDatabase: SystemDatabase }).systemDatabase;
+      expect(sysdb.observabilityQueryTimeoutMs).toBe(5000);
+      await expect(client.listWorkflows({})).resolves.toBeDefined();
+    } finally {
+      await client.destroy();
+    }
+  });
+});

--- a/tests/observability_timeout.test.ts
+++ b/tests/observability_timeout.test.ts
@@ -3,7 +3,7 @@ import { DBOS, DBOSClient, DBOSConfig } from '../src';
 import { translateDbosConfig } from '../src/config';
 import { DBOSExecutor } from '../src/dbos-executor';
 import { DBOSQueryTimeoutError } from '../src/error';
-import { DBOSJSON } from '../src/serialization';
+import { DBOSJSON, DBOSSerializer } from '../src/serialization';
 import { SystemDatabase } from '../src/system_database';
 import { GlobalLogger } from '../src/telemetry/logs';
 import { getClientConfig } from '../src/utils';
@@ -20,11 +20,15 @@ describe('observability-query-timeout', () => {
   });
 
   /** A second handle on the test system database, so a test can pick its own timeout. */
-  function makeSysDb(observabilityQueryTimeoutMs?: number, poolSize: number = 2): SystemDatabase {
+  function makeSysDb(
+    observabilityQueryTimeoutMs?: number,
+    poolSize: number = 2,
+    serializer: DBOSSerializer = DBOSJSON,
+  ): SystemDatabase {
     return new SystemDatabase(
       systemDatabaseUrl,
       new GlobalLogger(),
-      DBOSJSON,
+      serializer,
       poolSize,
       undefined,
       'dbos',
@@ -37,8 +41,7 @@ describe('observability-query-timeout', () => {
   }
 
   /** Every statement this handle issues, from the connect event on, so nothing predates the listener. */
-  function captureStatements(sysdb: SystemDatabase): string[] {
-    const statements: string[] = [];
+  function captureStatements(sysdb: SystemDatabase, statements: string[] = []): string[] {
     sysdb.pool.on('connect', (client: PoolClient) => {
       const query = client.query.bind(client);
       client.query = ((...args: Parameters<typeof query>) => {
@@ -51,6 +54,13 @@ describe('observability-query-timeout', () => {
   }
 
   const timeoutStatements = (statements: string[]) => statements.filter((s) => s.includes('statement_timeout'));
+
+  /** The capped transaction, reached the way the repo's other tests reach soft-private internals. */
+  type Capped = { observabilityQuery<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> };
+  const capped = (sysdb: SystemDatabase) => sysdb as unknown as Capped;
+
+  const show = async (client: PoolClient, setting: string) =>
+    (await client.query<Record<string, string>>(`SHOW ${setting}`)).rows[0][setting];
 
   const workflow = DBOS.registerWorkflow(async () => await DBOS.runStep(() => Promise.resolve(1), { name: 's' }), {
     name: 'observabilityTimeoutWorkflow',
@@ -121,23 +131,113 @@ describe('observability-query-timeout', () => {
     }
   });
 
-  test('the statement timeout cancels a blocked query', async () => {
-    const sysdb = makeSysDb(300);
+  /** Hold ACCESS EXCLUSIVE on workflow_status, so any read of it blocks until the cap cancels it. */
+  async function whileWorkflowStatusIsLocked<T>(fn: () => Promise<T>): Promise<T> {
     const blocker = new Client(getClientConfig(systemDatabaseUrl));
+    blocker.on('error', () => {});
     await blocker.connect();
     try {
       await blocker.query('BEGIN');
       await blocker.query('LOCK TABLE "dbos".workflow_status IN ACCESS EXCLUSIVE MODE');
-      await expect(sysdb.listWorkflows({})).rejects.toThrow(DBOSQueryTimeoutError);
+      return await fn();
     } finally {
-      await blocker.query('ROLLBACK');
-      await blocker.end();
+      await blocker.query('ROLLBACK').catch(() => {});
+      await blocker.end().catch(() => {});
     }
+  }
+
+  test('the statement timeout cancels a blocked query', async () => {
+    const sysdb = makeSysDb(300);
     try {
+      const error = await whileWorkflowStatusIsLocked(() => sysdb.listWorkflows({}).catch((e: unknown) => e));
+      expect(error).toBeInstanceOf(DBOSQueryTimeoutError);
+      // No cause: dbRetry unwraps cause chains and would retry the underlying 57014 forever.
+      expect((error as { cause?: unknown }).cause).toBeUndefined();
       // The cancelled query leaves its connection usable.
-      await expect(sysdb.listWorkflows({})).resolves.toEqual([]);
+      await expect(sysdb.listWorkflows({})).resolves.toBeDefined();
     } finally {
       await sysdb.destroy();
+    }
+  });
+
+  test('a timed-out query under @dbRetry rejects instead of retrying forever', async () => {
+    const sysdb = makeSysDb(300);
+    const start = new Date(0).toISOString();
+    const end = new Date(Date.now() + 3_600_000).toISOString();
+    try {
+      const error = await whileWorkflowStatusIsLocked(() => sysdb.getMetrics(start, end).catch((e: unknown) => e));
+      expect(error).toBeInstanceOf(DBOSQueryTimeoutError);
+    } finally {
+      await sysdb.destroy();
+    }
+  });
+
+  test('a capped query runs under the cap, at read committed', async () => {
+    const sysdb = makeSysDb();
+    try {
+      const settings = await capped(sysdb).observabilityQuery(async (client) => ({
+        timeout: await show(client, 'statement_timeout'),
+        isolation: await show(client, 'transaction_isolation'),
+      }));
+      expect(settings).toEqual({ timeout: '30s', isolation: 'read committed' });
+    } finally {
+      await sysdb.destroy();
+    }
+  });
+
+  test('a non-timeout failure inside a capped query propagates unchanged', async () => {
+    const sysdb = makeSysDb();
+    try {
+      const error = await capped(sysdb)
+        .observabilityQuery((client) => client.query('SELECT * FROM "dbos".no_such_table'))
+        .catch((e: unknown) => e);
+      expect(error).not.toBeInstanceOf(DBOSQueryTimeoutError);
+      expect((error as { code?: string }).code).toBe('42P01');
+    } finally {
+      await sysdb.destroy();
+    }
+  });
+
+  test('deserialization runs after the transaction commits', async () => {
+    // node-postgres keeps the portal's snapshot alive until commit, so parsing inside would extend the hold the cap bounds.
+    const log: string[] = [];
+    const recording: DBOSSerializer = {
+      name: () => 'recording',
+      stringify: (value) => DBOSJSON.stringify(value),
+      parse: (text) => {
+        log.push('PARSE');
+        return DBOSJSON.parse(text);
+      },
+    };
+    const workflowID = 'observability-timeout-parse-order';
+    const seed = new Client(getClientConfig(systemDatabaseUrl));
+    await seed.connect();
+    try {
+      await seed.query(
+        `INSERT INTO "dbos".workflow_status
+           (workflow_uuid, status, name, authenticated_roles, created_at, updated_at, recovery_attempts)
+         VALUES ($1, 'SUCCESS', 'parseOrderProbe', '[]', 1, 1, 1) ON CONFLICT DO NOTHING`,
+        [workflowID],
+      );
+      // A null serialization routes the value through the handle's own serializer.
+      await seed.query(
+        `INSERT INTO "dbos".workflow_events (workflow_uuid, key, value, serialization) VALUES ($1, 'k', '1', NULL)
+         ON CONFLICT DO NOTHING`,
+        [workflowID],
+      );
+
+      const sysdb = makeSysDb(undefined, 2, recording);
+      captureStatements(sysdb, log);
+      try {
+        await expect(sysdb.getAllEvents(workflowID)).resolves.toEqual({ k: 1 });
+        expect(log).toContain('PARSE');
+        expect(log.indexOf('COMMIT')).toBeLessThan(log.indexOf('PARSE'));
+      } finally {
+        await sysdb.destroy();
+      }
+    } finally {
+      await seed.query(`DELETE FROM "dbos".workflow_status WHERE workflow_uuid = $1`, [workflowID]).catch(() => {});
+      await seed.end();
     }
   });
 
@@ -172,6 +272,23 @@ describe('observability-query-timeout', () => {
     }
   });
 
+  test('an out-of-range statement timeout is rejected', async () => {
+    for (const bad of [2_147_483_648, 1e21]) {
+      expect(() => translateDbosConfig({ ...config, observabilityQueryTimeoutMs: bad })).toThrow(
+        'observabilityQueryTimeoutMs',
+      );
+      expect(() => makeSysDb(bad)).toThrow('observabilityQueryTimeoutMs');
+    }
+    // The largest value PostgreSQL accepts still is.
+    const sysdb = makeSysDb(2_147_483_647);
+    try {
+      expect(sysdb.observabilityQueryTimeoutMs).toBe(2_147_483_647);
+      await expect(sysdb.listWorkflows({})).resolves.toBeDefined();
+    } finally {
+      await sysdb.destroy();
+    }
+  });
+
   test('a configured statement timeout reaches the system database', async () => {
     DBOS.setConfig({ ...config, observabilityQueryTimeoutMs: 5000 });
     await DBOS.launch();
@@ -181,7 +298,7 @@ describe('observability-query-timeout', () => {
 
       // The timeout must not disturb a query that finishes inside it.
       await expect(workflow()).resolves.toBe(1);
-      const workflows = await DBOS.listWorkflows({});
+      const workflows = await DBOS.listWorkflows({ workflowName: 'observabilityTimeoutWorkflow' });
       expect(workflows.length).toBe(1);
       await expect(DBOS.listWorkflowSteps(workflows[0].workflowID)).resolves.toHaveLength(1);
     } finally {


### PR DESCRIPTION
Apply statement timeouts to all observability queries so a runaway query on a large database doesn't hold resources forever.